### PR TITLE
fix(eth): change etomic swap id computation

### DIFF
--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -668,6 +668,15 @@ impl EthCoinImpl {
         keccak256(&input).to_vec()
     }
 
+    /// The old function to compute the etomic swap id. This is used temporarily inbetween two releases 
+    /// for a transition to the new swap id computation, and will be removed afterwards 
+    fn etomic_swap_id_old(&self, time_lock: u32, secret_hash: &[u8]) -> Vec<u8> {
+        let mut input = vec![];
+        input.extend_from_slice(&time_lock.to_le_bytes());
+        input.extend_from_slice(secret_hash);
+        sha256(&input).to_vec()
+    }
+
     /// Gets `SenderRefunded` events from etomic swap smart contract since `from_block`
     fn refund_events(
         &self,

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -662,14 +662,14 @@ impl EthCoinImpl {
     /// The id used to differentiate payments on Etomic swap smart contract
     fn etomic_swap_id(&self, time_lock: u32, secret_hash: &[u8], sender: H160) -> Vec<u8> {
         let mut input = vec![];
-        input.extend_from_slice(secret_hash);
         input.extend_from_slice(&u64::from(time_lock).to_be_bytes());
+        input.extend_from_slice(secret_hash);
         input.extend_from_slice(sender.as_bytes());
         keccak256(&input).to_vec()
     }
 
-    /// The old function to compute the etomic swap id. This is used temporarily inbetween two releases 
-    /// for a transition to the new swap id computation, and will be removed afterwards 
+    /// The old function to compute the etomic swap id. This is used temporarily inbetween two releases
+    /// for a transition to the new swap id computation, and will be removed afterwards
     fn etomic_swap_id_old(&self, time_lock: u32, secret_hash: &[u8]) -> Vec<u8> {
         let mut input = vec![];
         input.extend_from_slice(&time_lock.to_le_bytes());

--- a/mm2src/coins/eth/eth_tests.rs
+++ b/mm2src/coins/eth/eth_tests.rs
@@ -271,7 +271,7 @@ fn send_and_refund_erc20_payment() {
     log!("{:?}", payment);
     block_on(Timer::sleep(5.));
 
-    let swap_id = coin.etomic_swap_id(time_lock, secret_hash);
+    let swap_id = coin.etomic_swap_id(time_lock, secret_hash, coin.my_address);
     let status = block_on(
         coin.payment_status(
             Address::from_str(ETH_DEV_SWAP_CONTRACT).unwrap(),
@@ -365,7 +365,7 @@ fn send_and_refund_eth_payment() {
     log!("{:?}", payment);
     block_on(Timer::sleep(5.));
 
-    let swap_id = coin.etomic_swap_id(time_lock, secret_hash);
+    let swap_id = coin.etomic_swap_id(time_lock, secret_hash, coin.my_address);
     let status = block_on(
         coin.payment_status(
             Address::from_str(ETH_DEV_SWAP_CONTRACT).unwrap(),


### PR DESCRIPTION
Fixes [#49](https://github.com/KomodoPlatform/adex_bugtracking/issues/49#issue-1726120627)

The [swap contract](https://github.com/caglaryucekaya/etomic-swap/blob/ethereum-swap-watchers/contracts/EtomicSwap.sol) is changed such that instead of accepting the hashed swap id as a parameter, it now computes the hash itself and includes the message sender in the hash. This way, it is not possible anymore for two different addresses to make payments using the same swap id. The `etomic_swap_id` function in mm2 is also changed to mimic the solidity behavior and match the hash value computed in the contract. Note that the change in this PR will not have any effect other than computing the etomic swap id in a different way until the new contract is deployed.