### PR TITLE
fix(posv): fix missing n_time in posv transactions

### DIFF
--- a/mm2src/coins/utxo.rs
+++ b/mm2src/coins/utxo.rs
@@ -778,7 +778,11 @@ impl UtxoCoinFields {
             None
         };
 
-        let n_time = if self.conf.is_pos { Some(now_sec_u32()) } else { None };
+        let n_time = if self.conf.is_pos || self.conf.is_posv {
+            Some(now_sec_u32())
+        } else {
+            None
+        };
 
         TransactionInputSigner {
             version: self.conf.tx_version,


### PR DESCRIPTION
this is a fix for the Reddcoin withdrawal issue.

electrum was reporting that it could not parse transaction
On investigating, the issue was a missing n_time field in the generated transaction

The fix now correctly considers when n_time is required, and the rawtransaction can be broadcast

