### PR TITLE
fix(ibc-test): use latest relayer channel for tendermint test

### DIFF
--- a/mm2src/mm2_main/tests/mm2_tests/tendermint_tests.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/tendermint_tests.rs
@@ -34,7 +34,7 @@ fn test_tendermint_activation_and_balance() {
 
     let result: RpcV2Response<TendermintActivationResult> = json::from_value(activation_result).unwrap();
     assert_eq!(result.result.address, expected_address);
-    let expected_balance: BigDecimal = "8.0959".parse().unwrap();
+    let expected_balance: BigDecimal = "0.575457".parse().unwrap();
     assert_eq!(result.result.balance.unwrap().spendable, expected_balance);
 
     let my_balance = block_on(my_balance(&mm, ATOM_TICKER));

--- a/mm2src/mm2_main/tests/mm2_tests/tendermint_tests.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/tendermint_tests.rs
@@ -179,7 +179,7 @@ fn test_custom_gas_limit_on_tendermint_withdraw() {
 
 #[test]
 fn test_tendermint_ibc_withdraw() {
-    // {rpc_url}/ibc/core/channel/v1/channels?pagination.limit=10000
+    // visit `{rpc_url}/ibc/core/channel/v1/channels?pagination.limit=10000` to see the full list of ibc channels
     const IBC_SOURCE_CHANNEL: &str = "channel-93";
 
     const IBC_TARGET_ADDRESS: &str = "cosmos1r5v5srda7xfth3hn2s26txvrcrntldjumt8mhl";

--- a/mm2src/mm2_main/tests/mm2_tests/tendermint_tests.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/tendermint_tests.rs
@@ -179,7 +179,9 @@ fn test_custom_gas_limit_on_tendermint_withdraw() {
 
 #[test]
 fn test_tendermint_ibc_withdraw() {
-    const IBC_SOURCE_CHANNEL: &str = "channel-81";
+    // {rpc_url}/ibc/core/channel/v1/channels?pagination.limit=10000
+    const IBC_SOURCE_CHANNEL: &str = "channel-93";
+
     const IBC_TARGET_ADDRESS: &str = "cosmos1r5v5srda7xfth3hn2s26txvrcrntldjumt8mhl";
     const MY_ADDRESS: &str = "iaa1e0rx87mdj79zejewuc4jg7ql9ud2286g2us8f2";
 


### PR DESCRIPTION
Fixes `mm2_tests::tendermint_tests::test_tendermint_ibc_withdraw` test which fails as:

```log
thread 'mm2_tests::tendermint_tests::test_tendermint_ibc_withdraw' panicked at 'assertion failed: `(left == right)`
  left: `500`,
 right: `200`: 'ibc_withdraw' failed: {"mmrpc":"2.0","error":"Transport error: Could not read gas_info. Error code: 6 Message: rpc error: code = Unknown desc = failed to execute message; message index: 0: cannot send packet using client (07-tendermint-120) with status Expired: client is not active [cosmos/ibc-go/v5@v5.2.0/modules/core/04-channel/keeper/packet.go:74] With gas wanted: '18446744073709551615' and gas used: '71366' : unknown request","error_path":"tendermint_token.tendermint_coin","error_trace":"tendermint_token:180] tendermint_coin:973]","error_type":"Transport","error_data":"Could not read gas_info. Error code: 6 Message: rpc error: code = Unknown desc = failed to execute message; message index: 0: cannot send packet using client (07-tendermint-120) with status Expired: client is not active [cosmos/ibc-go/v5@v5.2.0/modules/core/04-channel/keeper/packet.go:74] With gas wanted: '18446744073709551615' and gas used: '71366' : unknown request","id":null}', /home/runner/work/komodo-defi-framework/komodo-defi-framework/mm2src/mm2_test_helpers/src/for_tests.rs:2239:5
```