### PR TITLE
fix(tests): fix regex parsing passphrase from .env file

### DIFF
--- a/docs/DEV_ENVIRONMENT.md
+++ b/docs/DEV_ENVIRONMENT.md
@@ -9,11 +9,11 @@
    [Unix/Linux](https://github.com/KomodoPlatform/komodo/blob/master/zcutil/fetch-params.sh)
 5. Create `.env.client` file with the following content
    ```
-   PASSPHRASE=spice describe gravity federal blast come thank unfair canal monkey style afraid
+   ALICE_PASSPHRASE=spice describe gravity federal blast come thank unfair canal monkey style afraid
    ```
 6. Create `.env.seed` file with the following content
    ```
-   PASSPHRASE=also shoot benefit prefer juice shell elder veteran woman mimic image kidney
+   BOB_PASSPHRASE=also shoot benefit prefer juice shell elder veteran woman mimic image kidney
    ```
 7. MacOS specific: run script (required after each reboot)
    ```shell

--- a/mm2src/coins/eth/eth_tests.rs
+++ b/mm2src/coins/eth/eth_tests.rs
@@ -60,7 +60,7 @@ pub fn jst_distributor() -> EthCoin {
         "urls": ETH_DEV_NODES,
         "swap_contract_address": ETH_DEV_SWAP_CONTRACT,
     });
-    let seed = get_passphrase!(".env.client", "BOB_PASSPHRASE").unwrap();
+    let seed = get_passphrase!(".env.seed", "BOB_PASSPHRASE").unwrap();
     let keypair = key_pair_from_seed(&seed).unwrap();
     let priv_key_policy = PrivKeyBuildPolicy::IguanaPrivKey(keypair.private().secret);
     block_on(eth_coin_from_conf_and_request(

--- a/mm2src/mm2_main/tests/docker_tests/swap_watcher_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/swap_watcher_tests.rs
@@ -1313,7 +1313,7 @@ fn test_watcher_validate_taker_payment_eth() {
     let taker_keypair = taker_coin.derive_htlc_key_pair(&[]);
     let taker_pub = taker_keypair.public();
 
-    let maker_seed = get_passphrase!(".env.client", "BOB_PASSPHRASE").unwrap();
+    let maker_seed = get_passphrase!(".env.seed", "BOB_PASSPHRASE").unwrap();
     let maker_keypair = key_pair_from_seed(&maker_seed).unwrap();
     let maker_pub = maker_keypair.public();
 
@@ -1557,7 +1557,7 @@ fn test_watcher_validate_taker_payment_erc20() {
     let taker_keypair = taker_coin.derive_htlc_key_pair(&[]);
     let taker_pub = taker_keypair.public();
 
-    let maker_seed = get_passphrase!(".env.client", "BOB_PASSPHRASE").unwrap();
+    let maker_seed = get_passphrase!(".env.seed", "BOB_PASSPHRASE").unwrap();
     let maker_keypair = key_pair_from_seed(&maker_seed).unwrap();
     let maker_pub = maker_keypair.public();
 

--- a/mm2src/mm2_main/tests/mm2_tests/best_orders_tests.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/best_orders_tests.rs
@@ -468,7 +468,7 @@ fn test_best_orders_v2_exclude_mine() {
         assert!(status.is_success(), "!setprice: {}", data);
     }
 
-    let alice_passphrase = get_passphrase(&".env.seed", "ALICE_PASSPHRASE").unwrap();
+    let alice_passphrase = get_passphrase(&".env.client", "ALICE_PASSPHRASE").unwrap();
     let mm_alice = MarketMakerIt::start(
         json! ({
             "gui": "nogui",

--- a/mm2src/mm2_main/tests/mm2_tests/eth_tests.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/eth_tests.rs
@@ -78,7 +78,7 @@ async fn enable_eth_with_tokens_without_balance(
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
 fn test_disable_eth_coin_with_token() {
-    let passphrase = get_passphrase(&".env.client", "BOB_PASSPHRASE").unwrap();
+    let passphrase = get_passphrase(&".env.seed", "BOB_PASSPHRASE").unwrap();
     let coins = json!([eth_testnet_conf(), eth_jst_testnet_conf(),]);
     let conf = Mm2TestConf::seednode(&passphrase, &coins);
     let mm = block_on(MarketMakerIt::start_async(conf.conf, conf.rpc_password, None)).unwrap();
@@ -123,7 +123,7 @@ fn test_disable_eth_coin_with_token() {
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
 fn test_disable_eth_coin_with_token_without_balance() {
-    let passphrase = get_passphrase(&".env.client", "BOB_PASSPHRASE").unwrap();
+    let passphrase = get_passphrase(&".env.seed", "BOB_PASSPHRASE").unwrap();
     let coins = json!([eth_testnet_conf(), eth_jst_testnet_conf(),]);
     let conf = Mm2TestConf::seednode(&passphrase, &coins);
     let mm = block_on(MarketMakerIt::start_async(conf.conf, conf.rpc_password, None)).unwrap();

--- a/mm2src/mm2_main/tests/mm2_tests/mm2_tests_inner.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/mm2_tests_inner.rs
@@ -1328,7 +1328,7 @@ fn test_withdraw_legacy() {
     let alice_passphrase = var("ALICE_PASSPHRASE")
         .ok()
         .or(alice_file_passphrase)
-        .expect("No ALICE_PASSPHRASE or .env.client/PASSPHRASE");
+        .expect("No ALICE_PASSPHRASE or .env.client/ALICE_PASSPHRASE");
 
     let coins = json!([
         {"coin":"RICK","asset":"RICK","rpcport":8923,"txversion":4,"overwintered":1,"txfee":1000,"protocol":{"type":"UTXO"}},
@@ -3881,7 +3881,7 @@ fn test_validateaddress() {
     let bob_passphrase = var("BOB_PASSPHRASE")
         .ok()
         .or(bob_file_passphrase)
-        .expect("No BOB_PASSPHRASE or .env.seed/PASSPHRASE");
+        .expect("No BOB_PASSPHRASE or .env.seed/BOB_PASSPHRASE");
 
     let mm = MarketMakerIt::start(
         json!({

--- a/mm2src/mm2_main/tests/mm2_tests/mm2_tests_inner.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/mm2_tests_inner.rs
@@ -2535,7 +2535,7 @@ fn setprice_buy_sell_too_low_volume() {
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
 fn test_fill_or_kill_taker_order_should_not_transform_to_maker() {
-    let bob_passphrase = get_passphrase(&".env.client", "BOB_PASSPHRASE").unwrap();
+    let bob_passphrase = get_passphrase(&".env.seed", "BOB_PASSPHRASE").unwrap();
 
     let coins = json!([rick_conf(), morty_conf(), eth_testnet_conf(), eth_jst_testnet_conf(),]);
 
@@ -2603,7 +2603,7 @@ fn test_fill_or_kill_taker_order_should_not_transform_to_maker() {
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
 fn test_gtc_taker_order_should_transform_to_maker() {
-    let bob_passphrase = get_passphrase(&".env.client", "BOB_PASSPHRASE").unwrap();
+    let bob_passphrase = get_passphrase(&".env.seed", "BOB_PASSPHRASE").unwrap();
 
     let coins = json!([rick_conf(), morty_conf(), eth_testnet_conf(), eth_jst_testnet_conf(),]);
 
@@ -2676,7 +2676,7 @@ fn test_gtc_taker_order_should_transform_to_maker() {
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
 fn test_set_price_must_save_order_to_db() {
-    let bob_passphrase = get_passphrase(&".env.client", "BOB_PASSPHRASE").unwrap();
+    let bob_passphrase = get_passphrase(&".env.seed", "BOB_PASSPHRASE").unwrap();
 
     let coins = json!([rick_conf(), morty_conf(), eth_testnet_conf(), eth_jst_testnet_conf(),]);
 
@@ -2729,7 +2729,7 @@ fn test_set_price_must_save_order_to_db() {
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
 fn test_set_price_response_format() {
-    let bob_passphrase = get_passphrase(&".env.client", "BOB_PASSPHRASE").unwrap();
+    let bob_passphrase = get_passphrase(&".env.seed", "BOB_PASSPHRASE").unwrap();
 
     let coins = json!([rick_conf(), morty_conf(), eth_testnet_conf(), eth_jst_testnet_conf(),]);
 
@@ -4835,7 +4835,7 @@ fn test_tx_history_tbtc_non_segwit() {
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
 fn test_buy_conf_settings() {
-    let bob_passphrase = get_passphrase(&".env.client", "BOB_PASSPHRASE").unwrap();
+    let bob_passphrase = get_passphrase(&".env.seed", "BOB_PASSPHRASE").unwrap();
 
     let coins = json!([rick_conf(), morty_conf(), eth_testnet_conf(),
     {"coin":"JST","name":"jst","protocol":{"type":"ERC20","protocol_data":{"platform":"ETH","contract_address":ETH_DEV_TOKEN_CONTRACT}},"required_confirmations":2},]);
@@ -4908,7 +4908,7 @@ fn test_buy_conf_settings() {
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
 fn test_buy_response_format() {
-    let bob_passphrase = get_passphrase(&".env.client", "BOB_PASSPHRASE").unwrap();
+    let bob_passphrase = get_passphrase(&".env.seed", "BOB_PASSPHRASE").unwrap();
 
     let coins = json!([rick_conf(), morty_conf(), eth_testnet_conf(), eth_jst_testnet_conf(),]);
 
@@ -4958,7 +4958,7 @@ fn test_buy_response_format() {
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
 fn test_sell_response_format() {
-    let bob_passphrase = get_passphrase(&".env.client", "BOB_PASSPHRASE").unwrap();
+    let bob_passphrase = get_passphrase(&".env.seed", "BOB_PASSPHRASE").unwrap();
 
     let coins = json!([rick_conf(), morty_conf(), eth_testnet_conf(), eth_jst_testnet_conf(),]);
 
@@ -5008,7 +5008,7 @@ fn test_sell_response_format() {
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
 fn test_my_orders_response_format() {
-    let bob_passphrase = get_passphrase(&".env.client", "BOB_PASSPHRASE").unwrap();
+    let bob_passphrase = get_passphrase(&".env.seed", "BOB_PASSPHRASE").unwrap();
 
     let coins = json!([rick_conf(), morty_conf(), eth_testnet_conf(), eth_jst_testnet_conf(),]);
 
@@ -5168,7 +5168,7 @@ fn test_my_orders_after_matched() {
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
 fn test_sell_conf_settings() {
-    let bob_passphrase = get_passphrase(&".env.client", "BOB_PASSPHRASE").unwrap();
+    let bob_passphrase = get_passphrase(&".env.seed", "BOB_PASSPHRASE").unwrap();
 
     let coins = json!([rick_conf(), morty_conf(), eth_testnet_conf(),
     {"coin":"JST","name":"jst","protocol":{"type":"ERC20","protocol_data":{"platform":"ETH","contract_address": ETH_DEV_TOKEN_CONTRACT}},"required_confirmations":2},]);
@@ -5241,7 +5241,7 @@ fn test_sell_conf_settings() {
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
 fn test_set_price_conf_settings() {
-    let bob_passphrase = get_passphrase(&".env.client", "BOB_PASSPHRASE").unwrap();
+    let bob_passphrase = get_passphrase(&".env.seed", "BOB_PASSPHRASE").unwrap();
 
     let coins = json!([rick_conf(), morty_conf(), eth_testnet_conf(),
     {"coin":"JST","name":"jst","protocol":{"type":"ERC20","protocol_data":{"platform":"ETH","contract_address": ETH_DEV_TOKEN_CONTRACT}},"required_confirmations":2},]);
@@ -5314,7 +5314,7 @@ fn test_set_price_conf_settings() {
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
 fn test_update_maker_order() {
-    let bob_passphrase = get_passphrase(&".env.client", "BOB_PASSPHRASE").unwrap();
+    let bob_passphrase = get_passphrase(&".env.seed", "BOB_PASSPHRASE").unwrap();
 
     let coins = json! ([
         {"coin":"RICK","asset":"RICK","required_confirmations":0,"txversion":4,"overwintered":1,"protocol":{"type":"UTXO"}},
@@ -5454,7 +5454,7 @@ fn test_update_maker_order() {
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
 fn test_update_maker_order_fail() {
-    let bob_passphrase = get_passphrase(&".env.client", "BOB_PASSPHRASE").unwrap();
+    let bob_passphrase = get_passphrase(&".env.seed", "BOB_PASSPHRASE").unwrap();
 
     let coins = json! ([
         {"coin":"RICK","asset":"RICK","required_confirmations":0,"txversion":4,"overwintered":1,"protocol":{"type":"UTXO"}},
@@ -5987,7 +5987,7 @@ fn test_orderbook_is_mine_orders() {
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
 fn test_sell_min_volume() {
-    let bob_passphrase = get_passphrase(&".env.client", "BOB_PASSPHRASE").unwrap();
+    let bob_passphrase = get_passphrase(&".env.seed", "BOB_PASSPHRASE").unwrap();
 
     let coins = json!([rick_conf(), morty_conf(), eth_testnet_conf(), eth_jst_testnet_conf(),]);
 
@@ -6060,7 +6060,7 @@ fn test_sell_min_volume() {
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
 fn test_sell_min_volume_dust() {
-    let bob_passphrase = get_passphrase(&".env.client", "BOB_PASSPHRASE").unwrap();
+    let bob_passphrase = get_passphrase(&".env.seed", "BOB_PASSPHRASE").unwrap();
 
     let coins = json! ([
         {"coin":"RICK","asset":"RICK","dust":10000000,"required_confirmations":0,"txversion":4,"overwintered":1,"protocol":{"type":"UTXO"}},
@@ -6111,7 +6111,7 @@ fn test_sell_min_volume_dust() {
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
 fn test_setprice_min_volume_dust() {
-    let bob_passphrase = get_passphrase(&".env.client", "BOB_PASSPHRASE").unwrap();
+    let bob_passphrase = get_passphrase(&".env.seed", "BOB_PASSPHRASE").unwrap();
 
     let coins = json! ([
         {"coin":"RICK","asset":"RICK","dust":10000000,"required_confirmations":0,"txversion":4,"overwintered":1,"protocol":{"type":"UTXO"}},
@@ -6159,7 +6159,7 @@ fn test_setprice_min_volume_dust() {
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
 fn test_buy_min_volume() {
-    let bob_passphrase = get_passphrase(&".env.client", "BOB_PASSPHRASE").unwrap();
+    let bob_passphrase = get_passphrase(&".env.seed", "BOB_PASSPHRASE").unwrap();
 
     let coins = json!([rick_conf(), morty_conf(), eth_testnet_conf(), eth_jst_testnet_conf(),]);
 
@@ -6368,7 +6368,7 @@ fn test_orderbook_depth() {
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
 fn test_mm2_db_migration() {
-    let bob_passphrase = get_passphrase(&".env.client", "BOB_PASSPHRASE").unwrap();
+    let bob_passphrase = get_passphrase(&".env.seed", "BOB_PASSPHRASE").unwrap();
 
     let coins = json!([rick_conf(), morty_conf(), eth_testnet_conf(), eth_jst_testnet_conf(),]);
 

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -3016,4 +3016,3 @@ fn test_parse_env_file() {
         )
     );
 }
-

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -1545,8 +1545,7 @@ pub async fn enable_qrc20(
 pub fn from_env_file(env: Vec<u8>) -> (Option<String>, Option<String>) {
     use regex::bytes::Regex;
     let (mut passphrase, mut userpass) = (None, None);
-    for cap in Regex::new(r"^\w+_(PASSPHRASE|USERPASS)=(\w[\w ]+)\n?")
-
+    for cap in Regex::new(r"^\w+_(PASSPHRASE|USERPASS)=(\w+( \w+)+)\s*")
         .unwrap()
         .captures_iter(&env)
     {
@@ -2999,10 +2998,14 @@ fn test_parse_env_file() {
         b"ALICE_PASSPHRASE=spice describe gravity federal blast come thank unfair canal monkey style afraid";
     let env_client_new_line =
         b"ALICE_PASSPHRASE=spice describe gravity federal blast come thank unfair canal monkey style afraid\n";
+    let env_client_space =
+        b"ALICE_PASSPHRASE=spice describe gravity federal blast come thank unfair canal monkey style afraid  ";
 
     let parsed1 = from_env_file(env_client.to_vec());
     let parsed2 = from_env_file(env_client_new_line.to_vec());
+    let parsed3 = from_env_file(env_client_space.to_vec());
     assert_eq!(parsed1, parsed2);
+    assert_eq!(parsed1, parsed3);
     assert_eq!(
         parsed1,
         (

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -1545,7 +1545,7 @@ pub async fn enable_qrc20(
 pub fn from_env_file(env: Vec<u8>) -> (Option<String>, Option<String>) {
     use regex::bytes::Regex;
     let (mut passphrase, mut userpass) = (None, None);
-    for cap in Regex::new(r"(?m)^(PASSPHRASE|USERPASS)=(\w[\w ]+)$")
+    for cap in Regex::new(r"\w+_(PASSPHRASE|USERPASS)=(\w[\w ]+)\n?")
         .unwrap()
         .captures_iter(&env)
     {
@@ -1581,6 +1581,9 @@ macro_rules! get_passphrase {
 }
 
 /// Reads passphrase from file or environment.
+/// Note that if you try to read the passphrase file from the current directory 
+/// the current directory could be different depending on how you run tests 
+/// (it could be either the workspace directory or the module source directory)
 #[cfg(not(target_arch = "wasm32"))]
 pub fn get_passphrase(path: &dyn AsRef<Path>, env: &str) -> Result<String, String> {
     if let (Some(file_passphrase), _file_userpass) = from_env_file(try_s!(slurp(path))) {
@@ -2986,4 +2989,16 @@ pub async fn get_locked_amount(mm: &MarketMakerIt, coin: &str) -> GetLockedAmoun
     println!("get_locked_amount response {}", request.1);
     let response: RpcV2Response<GetLockedAmountResponse> = json::from_str(&request.1).unwrap();
     response.result
+}
+
+#[test]
+#[cfg(not(target_arch = "wasm32"))]
+fn test_parse_env_file() {
+    let env_client = b"ALICE_PASSPHRASE=spice describe gravity federal blast come thank unfair canal monkey style afraid";
+    let env_client_new_line = b"ALICE_PASSPHRASE=spice describe gravity federal blast come thank unfair canal monkey style afraid\n";
+
+    let parsed1 = from_env_file(env_client.to_vec());
+    let parsed2 = from_env_file(env_client_new_line.to_vec());
+    assert_eq!(parsed1, parsed2);
+    assert_eq!(parsed1, (Some(String::from("spice describe gravity federal blast come thank unfair canal monkey style afraid")), None));
 }

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -1545,17 +1545,17 @@ pub async fn enable_qrc20(
 pub fn from_env_file(env: Vec<u8>) -> (Option<String>, Option<String>) {
     use regex::bytes::Regex;
     let (mut passphrase, mut userpass) = (None, None);
-    for cap in Regex::new(r"^(\w+_|.{0})(PASSPHRASE|USERPASS)=(\w[\w ]+)\n?")
+    for cap in Regex::new(r"^\w+_(PASSPHRASE|USERPASS)=(\w[\w ]+)\n?")
 
         .unwrap()
         .captures_iter(&env)
     {
-        match cap.get(2) {
+        match cap.get(1) {
             Some(name) if name.as_bytes() == b"PASSPHRASE" => {
-                passphrase = cap.get(3).map(|v| String::from_utf8(v.as_bytes().into()).unwrap())
+                passphrase = cap.get(2).map(|v| String::from_utf8(v.as_bytes().into()).unwrap())
             },
             Some(name) if name.as_bytes() == b"USERPASS" => {
-                userpass = cap.get(3).map(|v| String::from_utf8(v.as_bytes().into()).unwrap())
+                userpass = cap.get(2).map(|v| String::from_utf8(v.as_bytes().into()).unwrap())
             },
             _ => (),
         }
@@ -2994,7 +2994,7 @@ pub async fn get_locked_amount(mm: &MarketMakerIt, coin: &str) -> GetLockedAmoun
 
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
-fn test_parse_env_file_1() {
+fn test_parse_env_file() {
     let env_client =
         b"ALICE_PASSPHRASE=spice describe gravity federal blast come thank unfair canal monkey style afraid";
     let env_client_new_line =
@@ -3014,24 +3014,3 @@ fn test_parse_env_file_1() {
     );
 }
 
-#[test]
-#[cfg(not(target_arch = "wasm32"))]
-fn test_parse_env_file_2() {
-    let env_client =
-        b"PASSPHRASE=spice describe gravity federal blast come thank unfair canal monkey style afraid";
-    let env_client_new_line =
-        b"PASSPHRASE=spice describe gravity federal blast come thank unfair canal monkey style afraid\n";
-
-    let parsed1 = from_env_file(env_client.to_vec());
-    let parsed2 = from_env_file(env_client_new_line.to_vec());
-    assert_eq!(parsed1, parsed2);
-    assert_eq!(
-        parsed1,
-        (
-            Some(String::from(
-                "spice describe gravity federal blast come thank unfair canal monkey style afraid"
-            )),
-            None
-        )
-    );
-}

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -1581,8 +1581,8 @@ macro_rules! get_passphrase {
 }
 
 /// Reads passphrase from file or environment.
-/// Note that if you try to read the passphrase file from the current directory 
-/// the current directory could be different depending on how you run tests 
+/// Note that if you try to read the passphrase file from the current directory
+/// the current directory could be different depending on how you run tests
 /// (it could be either the workspace directory or the module source directory)
 #[cfg(not(target_arch = "wasm32"))]
 pub fn get_passphrase(path: &dyn AsRef<Path>, env: &str) -> Result<String, String> {
@@ -2994,11 +2994,21 @@ pub async fn get_locked_amount(mm: &MarketMakerIt, coin: &str) -> GetLockedAmoun
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
 fn test_parse_env_file() {
-    let env_client = b"ALICE_PASSPHRASE=spice describe gravity federal blast come thank unfair canal monkey style afraid";
-    let env_client_new_line = b"ALICE_PASSPHRASE=spice describe gravity federal blast come thank unfair canal monkey style afraid\n";
+    let env_client =
+        b"ALICE_PASSPHRASE=spice describe gravity federal blast come thank unfair canal monkey style afraid";
+    let env_client_new_line =
+        b"ALICE_PASSPHRASE=spice describe gravity federal blast come thank unfair canal monkey style afraid\n";
 
     let parsed1 = from_env_file(env_client.to_vec());
     let parsed2 = from_env_file(env_client_new_line.to_vec());
     assert_eq!(parsed1, parsed2);
-    assert_eq!(parsed1, (Some(String::from("spice describe gravity federal blast come thank unfair canal monkey style afraid")), None));
+    assert_eq!(
+        parsed1,
+        (
+            Some(String::from(
+                "spice describe gravity federal blast come thank unfair canal monkey style afraid"
+            )),
+            None
+        )
+    );
 }


### PR DESCRIPTION
Fix regex to parse passphrase from .env file if newline char added