### PR TITLE
fix(cli): use the updated activation scheme

### DIFF
--- a/mm2src/adex_cli/src/rpc_data.rs
+++ b/mm2src/adex_cli/src/rpc_data.rs
@@ -4,8 +4,7 @@
 //!
 
 use mm2_rpc::data::legacy::{ElectrumProtocol, GasStationPricePolicy, UtxoMergeParams};
-use serde::ser::SerializeSeq;
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "method", rename_all = "lowercase")]
@@ -17,8 +16,8 @@ pub(crate) enum ActivationRequest {
 #[derive(Debug, Deserialize, Serialize)]
 pub(crate) struct EnableRequest {
     coin: String,
-    #[serde(default, serialize_with = "serialize_urls", skip_serializing_if = "Vec::is_empty")]
-    urls: Vec<EnableUrl>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    urls: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     swap_contract_address: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -39,22 +38,6 @@ pub(crate) struct EnableRequest {
     requires_notarization: Option<bool>,
     #[serde(default)]
     contract_supports_watchers: Option<bool>,
-}
-
-fn serialize_urls<S>(urls: &Vec<EnableUrl>, s: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    let mut s_seq = s.serialize_seq(None)?;
-    for url in urls {
-        s_seq.serialize_element(url.url.as_str())?;
-    }
-    s_seq.end()
-}
-
-#[derive(Debug, Deserialize)]
-struct EnableUrl {
-    url: String,
 }
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
Activation scheme was changed and that is why the related data types had to be fit to it

Related changes in [kmd_ntx_stats_docker](https://github.com/smk762/kmd_ntx_stats_docker/commit/ff6429452d8e9bc496f591c0c25286d667baf1b9)