### PR TITLE
fix(tx history): make tx details calls concurrent

### DIFF
--- a/mm2src/coins/utxo/bch.rs
+++ b/mm2src/coins/utxo/bch.rs
@@ -358,7 +358,7 @@ impl BchCoin {
     /// Returns multiple details by tx hash if token transfers also occurred in the transaction
     pub async fn transaction_details_with_token_transfers<T: TxHistoryStorage>(
         &self,
-        params: UtxoTxDetailsParams<'_, T>,
+        params: &'_ UtxoTxDetailsParams<'_, T>,
     ) -> MmResult<Vec<TransactionDetails>, UtxoTxDetailsError> {
         let tx = self.tx_from_storage_or_rpc(params.hash, params.storage).await?;
 
@@ -1350,7 +1350,7 @@ impl UtxoTxHistoryOps for BchCoin {
 
     async fn tx_details_by_hash<Storage>(
         &self,
-        params: UtxoTxDetailsParams<'_, Storage>,
+        params: &'_ UtxoTxDetailsParams<'_, Storage>,
     ) -> MmResult<Vec<TransactionDetails>, UtxoTxDetailsError>
     where
         Storage: TxHistoryStorage,

--- a/mm2src/coins/utxo/qtum.rs
+++ b/mm2src/coins/utxo/qtum.rs
@@ -1242,7 +1242,7 @@ impl UtxoTxHistoryOps for QtumCoin {
 
     async fn tx_details_by_hash<Storage>(
         &self,
-        params: UtxoTxDetailsParams<'_, Storage>,
+        params: &'_ UtxoTxDetailsParams<'_, Storage>,
     ) -> MmResult<Vec<TransactionDetails>, UtxoTxDetailsError>
     where
         Storage: TxHistoryStorage,

--- a/mm2src/coins/utxo/utxo_common/utxo_tx_history_v2_common.rs
+++ b/mm2src/coins/utxo/utxo_common/utxo_tx_history_v2_common.rs
@@ -154,7 +154,7 @@ where
 /// [`UtxoTxHistoryOps::tx_details_by_hash`] implementation.
 pub async fn tx_details_by_hash<Coin, Storage>(
     coin: &Coin,
-    params: UtxoTxDetailsParams<'_, Storage>,
+    params: &'_ UtxoTxDetailsParams<'_, Storage>,
 ) -> MmResult<Vec<TransactionDetails>, UtxoTxDetailsError>
 where
     Coin: UtxoTxHistoryOps + UtxoCommonOps + MarketCoinOps,

--- a/mm2src/coins/utxo/utxo_standard.rs
+++ b/mm2src/coins/utxo/utxo_standard.rs
@@ -1060,7 +1060,7 @@ impl UtxoTxHistoryOps for UtxoStandardCoin {
 
     async fn tx_details_by_hash<Storage>(
         &self,
-        params: UtxoTxDetailsParams<'_, Storage>,
+        params: &'_ UtxoTxDetailsParams<'_, Storage>,
     ) -> MmResult<Vec<TransactionDetails>, UtxoTxDetailsError>
     where
         Storage: TxHistoryStorage,

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -125,7 +125,7 @@ where
         my_addresses: &my_addresses,
     };
 
-    block_on(UtxoTxHistoryOps::tx_details_by_hash(coin, params)).unwrap()
+    block_on(UtxoTxHistoryOps::tx_details_by_hash(coin, &params)).unwrap()
 }
 
 /// Returns `TransactionDetails` of the given `tx_hash` and checks that


### PR DESCRIPTION
To try this, UTXO v2 activation has to be used. e.g.
```json
{
    "userpass": "{{userpass}}",
    "mmrpc": "2.0",
    "method": "task::enable_utxo::init",
    "params": {
        "ticker":"RICK",
        "activation_params": {
            "mode": {
                "rpc":"Electrum",
                "rpc_data": {
                    "servers": [
                        {
                            "url": "electrum1.cipig.net:10017"
                        },
                        {
                            "url": "electrum2.cipig.net:10017"
                        },
                        {
                            "url": "electrum3.cipig.net:10017"
                        }
                    ]
                }
            },
            "tx_history": true
        }
    }
}
```
```json
{
    "userpass": "{{userpass}}",
    "mmrpc": "2.0",
    "method": "task::enable_utxo::status",
    "params": {
        "task_id": 0
    }
}
```

`my_tx_history` v2 also has to be used
```json
{
    "userpass": "{{userpass}}",
    "mmrpc": "2.0",
    "method": "my_tx_history",
    "params": {
        "coin": "RICK",
        "limit": 10000
    }
}
```

TODO:
- [ ] Add parameter to servers list in requests to specify if it's resource limited or not and use a different chunk size (number of concurrent calls) in this case
- [ ] Fix this for other coins and check if `my_tx_history` needs to be implemented for other coins as well.