### PR TITLE
fix(tests): fix failing tests due to RICK/MORTY

### DIFF
--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -42,7 +42,7 @@ use futures::future::join_all;
 use futures::TryFutureExt;
 use mm2_core::mm_ctx::MmCtxBuilder;
 use mm2_number::bigdecimal::{BigDecimal, Signed};
-use mm2_test_helpers::for_tests::{mm_ctx_with_custom_db, MORTY_ELECTRUM_ADDRS, RICK_ELECTRUM_ADDRS};
+use mm2_test_helpers::for_tests::{mm_ctx_with_custom_db, DOC_ELECTRUM_ADDRS, MORTY_ELECTRUM_ADDRS, RICK_ELECTRUM_ADDRS};
 use mocktopus::mocking::*;
 use rpc::v1::types::H256 as H256Json;
 use serialization::{deserialize, CoinVariant};
@@ -953,7 +953,7 @@ fn test_withdraw_rick_rewards_none() {
 #[test]
 fn test_utxo_lock() {
     // send several transactions concurrently to check that they are not using same inputs
-    let client = electrum_client_for_test(RICK_ELECTRUM_ADDRS);
+    let client = electrum_client_for_test(DOC_ELECTRUM_ADDRS);
     let coin = utxo_coin_for_test(client.into(), None, false);
     let output = TransactionOutput {
         value: 1000000,

--- a/mm2src/mm2_test_helpers/src/electrums.rs
+++ b/mm2src/mm2_test_helpers/src/electrums.rs
@@ -3,18 +3,18 @@ use serde_json::{json, Value as Json};
 #[cfg(target_arch = "wasm32")]
 pub fn rick_electrums() -> Vec<Json> {
     vec![
-        json!({ "url": "electrum1.cipig.net:30017", "protocol": "WSS" }),
-        json!({ "url": "electrum2.cipig.net:30017", "protocol": "WSS" }),
-        json!({ "url": "electrum3.cipig.net:30017", "protocol": "WSS" }),
+        json!({ "url": "electrum1.cipig.net:30020", "protocol": "WSS" }),
+        json!({ "url": "electrum2.cipig.net:30020", "protocol": "WSS" }),
+        json!({ "url": "electrum3.cipig.net:30020", "protocol": "WSS" }),
     ]
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 pub fn rick_electrums() -> Vec<Json> {
     vec![
-        json!({ "url": "electrum1.cipig.net:10017" }),
-        json!({ "url": "electrum2.cipig.net:10017" }),
-        json!({ "url": "electrum3.cipig.net:10017" }),
+        json!({ "url": "electrum1.cipig.net:10020" }),
+        json!({ "url": "electrum2.cipig.net:10020" }),
+        json!({ "url": "electrum3.cipig.net:10020" }),
     ]
 }
 
@@ -22,9 +22,9 @@ pub fn rick_electrums() -> Vec<Json> {
 #[cfg(target_arch = "wasm32")]
 pub fn morty_electrums() -> Vec<Json> {
     vec![
-        json!({ "url": "electrum1.cipig.net:30018", "protocol": "WSS" }),
-        json!({ "url": "electrum2.cipig.net:30018", "protocol": "WSS" }),
-        json!({ "url": "electrum3.cipig.net:30018", "protocol": "WSS" }),
+        json!({ "url": "electrum1.cipig.net:30021", "protocol": "WSS" }),
+        json!({ "url": "electrum2.cipig.net:30021", "protocol": "WSS" }),
+        json!({ "url": "electrum3.cipig.net:30021", "protocol": "WSS" }),
     ]
 }
 
@@ -32,9 +32,9 @@ pub fn morty_electrums() -> Vec<Json> {
 #[cfg(not(target_arch = "wasm32"))]
 pub fn morty_electrums() -> Vec<Json> {
     vec![
-        json!({ "url": "electrum1.cipig.net:10018" }),
-        json!({ "url": "electrum2.cipig.net:10018" }),
-        json!({ "url": "electrum3.cipig.net:10018" }),
+        json!({ "url": "electrum1.cipig.net:10021" }),
+        json!({ "url": "electrum2.cipig.net:10021" }),
+        json!({ "url": "electrum3.cipig.net:10021" }),
     ]
 }
 

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -138,6 +138,12 @@ pub const MORTY_ELECTRUM_ADDRS: &[&str] = &[
     "electrum2.cipig.net:10018",
     "electrum3.cipig.net:10018",
 ];
+pub const DOC: &str = "DOC";
+pub const DOC_ELECTRUM_ADDRS: &[&str] = &[
+    "electrum1.cipig.net:10020",
+    "electrum2.cipig.net:10020",
+    "electrum3.cipig.net:10020",
+];
 pub const ZOMBIE_TICKER: &str = "ZOMBIE";
 pub const ARRR: &str = "ARRR";
 pub const ZOMBIE_ELECTRUMS: &[&str] = &[


### PR DESCRIPTION
This PR fixes failing wasm tests and `test_utxo_lock` by making these tests use the `DOC`/`MARTY` electrums. I will be working on another PR that moves all `RICK`/`MORTY` tests to the new testnets and should rename the coins too (although it's not required to rename them).