### PR TITLE
fix(tests): p2p ctx mocking issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4549,7 +4549,6 @@ dependencies = [
  "mm2_event_stream",
  "mm2_p2p",
  "mm2_state_machine",
- "mocktopus",
  "parking_lot 0.12.0",
  "prost",
  "rand 0.7.3",

--- a/mm2src/mm2_main/src/ordermatch_tests.rs
+++ b/mm2src/mm2_main/src/ordermatch_tests.rs
@@ -1662,14 +1662,10 @@ fn pubkey_and_secret_for_test(passphrase: &str) -> (String, [u8; 32]) {
     (pubkey, secret)
 }
 
-fn p2p_context_mock() -> (mpsc::Sender<AdexBehaviourCmd>, mpsc::Receiver<AdexBehaviourCmd>) {
+fn p2p_context_mock(ctx: &MmArc) -> (mpsc::Sender<AdexBehaviourCmd>, mpsc::Receiver<AdexBehaviourCmd>) {
     let (cmd_tx, cmd_rx) = mpsc::channel(10);
-    let cmd_sender = cmd_tx.clone();
-    P2PContext::fetch_from_mm_arc.mock_safe(move |_| {
-        MockResult::Return(Arc::new(P2PContext {
-            cmd_tx: PaMutex::new(cmd_sender.clone()),
-        }))
-    });
+    let p2p_context = P2PContext::new(cmd_tx.clone());
+    p2p_context.store_to_mm_arc(ctx);
     (cmd_tx, cmd_rx)
 }
 
@@ -1775,7 +1771,7 @@ fn test_request_and_fill_orderbook() {
     const ORDERS_NUMBER: usize = 10;
 
     let (ctx, _pubkey, _secret) = make_ctx_for_tests();
-    let (_, mut cmd_rx) = p2p_context_mock();
+    let (_, mut cmd_rx) = p2p_context_mock(&ctx);
 
     let other_pubkeys: Vec<(String, [u8; 32])> = (0..PUBKEYS_NUMBER)
         .map(|idx| {
@@ -1927,9 +1923,10 @@ fn test_process_order_keep_alive_requested_from_peer() {
     let ordermatch_ctx = Arc::new(OrdermatchContext::default());
     let ordermatch_ctx_clone = ordermatch_ctx.clone();
     OrdermatchContext::from_ctx.mock_safe(move |_| MockResult::Return(Ok(ordermatch_ctx_clone.clone())));
-    let (_, mut cmd_rx) = p2p_context_mock();
 
     let (ctx, pubkey, secret) = make_ctx_for_tests();
+    let (_, mut cmd_rx) = p2p_context_mock(&ctx);
+
     let uuid = new_uuid();
     let peer = PeerId::random().to_string();
 
@@ -2048,7 +2045,7 @@ fn test_process_get_order_request() {
 #[test]
 fn test_subscribe_to_ordermatch_topic_not_subscribed() {
     let (ctx, _pubkey, _secret) = make_ctx_for_tests();
-    let (_, mut cmd_rx) = p2p_context_mock();
+    let (_, mut cmd_rx) = p2p_context_mock(&ctx);
 
     spawn(async move {
         match cmd_rx.next().await.unwrap() {
@@ -2092,7 +2089,7 @@ fn test_subscribe_to_ordermatch_topic_not_subscribed() {
 #[test]
 fn test_subscribe_to_ordermatch_topic_subscribed_not_filled() {
     let (ctx, _pubkey, _secret) = make_ctx_for_tests();
-    let (_, mut cmd_rx) = p2p_context_mock();
+    let (_, mut cmd_rx) = p2p_context_mock(&ctx);
 
     {
         let ordermatch_ctx = OrdermatchContext::from_ctx(&ctx).unwrap();
@@ -2144,7 +2141,7 @@ fn test_subscribe_to_ordermatch_topic_subscribed_not_filled() {
 #[test]
 fn test_subscribe_to_ordermatch_topic_subscribed_filled() {
     let (ctx, _pubkey, _secret) = make_ctx_for_tests();
-    let (_, mut cmd_rx) = p2p_context_mock();
+    let (_, mut cmd_rx) = p2p_context_mock(&ctx);
 
     // enough time has passed for the orderbook to be filled
     let subscribed_at = now_ms() / 1000 - ORDERBOOK_REQUESTING_TIMEOUT - 1;
@@ -2174,6 +2171,7 @@ fn test_subscribe_to_ordermatch_topic_subscribed_filled() {
     assert_eq!(actual, expected);
 }
 */
+
 #[test]
 fn test_taker_request_can_match_with_maker_pubkey() {
     let coin = TestCoin::default().into();

--- a/mm2src/mm2_main/src/ordermatch_tests.rs
+++ b/mm2src/mm2_main/src/ordermatch_tests.rs
@@ -1662,7 +1662,7 @@ fn pubkey_and_secret_for_test(passphrase: &str) -> (String, [u8; 32]) {
     (pubkey, secret)
 }
 
-fn p2p_context_mock(ctx: &MmArc) -> (mpsc::Sender<AdexBehaviourCmd>, mpsc::Receiver<AdexBehaviourCmd>) {
+fn init_p2p_context(ctx: &MmArc) -> (mpsc::Sender<AdexBehaviourCmd>, mpsc::Receiver<AdexBehaviourCmd>) {
     let (cmd_tx, cmd_rx) = mpsc::channel(10);
     let p2p_context = P2PContext::new(cmd_tx.clone());
     p2p_context.store_to_mm_arc(ctx);
@@ -1771,7 +1771,7 @@ fn test_request_and_fill_orderbook() {
     const ORDERS_NUMBER: usize = 10;
 
     let (ctx, _pubkey, _secret) = make_ctx_for_tests();
-    let (_, mut cmd_rx) = p2p_context_mock(&ctx);
+    let (_, mut cmd_rx) = init_p2p_context(&ctx);
 
     let other_pubkeys: Vec<(String, [u8; 32])> = (0..PUBKEYS_NUMBER)
         .map(|idx| {
@@ -1925,7 +1925,7 @@ fn test_process_order_keep_alive_requested_from_peer() {
     OrdermatchContext::from_ctx.mock_safe(move |_| MockResult::Return(Ok(ordermatch_ctx_clone.clone())));
 
     let (ctx, pubkey, secret) = make_ctx_for_tests();
-    let (_, mut cmd_rx) = p2p_context_mock(&ctx);
+    let (_, mut cmd_rx) = init_p2p_context(&ctx);
 
     let uuid = new_uuid();
     let peer = PeerId::random().to_string();
@@ -2045,7 +2045,7 @@ fn test_process_get_order_request() {
 #[test]
 fn test_subscribe_to_ordermatch_topic_not_subscribed() {
     let (ctx, _pubkey, _secret) = make_ctx_for_tests();
-    let (_, mut cmd_rx) = p2p_context_mock(&ctx);
+    let (_, mut cmd_rx) = init_p2p_context(&ctx);
 
     spawn(async move {
         match cmd_rx.next().await.unwrap() {
@@ -2089,7 +2089,7 @@ fn test_subscribe_to_ordermatch_topic_not_subscribed() {
 #[test]
 fn test_subscribe_to_ordermatch_topic_subscribed_not_filled() {
     let (ctx, _pubkey, _secret) = make_ctx_for_tests();
-    let (_, mut cmd_rx) = p2p_context_mock(&ctx);
+    let (_, mut cmd_rx) = init_p2p_context(&ctx);
 
     {
         let ordermatch_ctx = OrdermatchContext::from_ctx(&ctx).unwrap();
@@ -2141,7 +2141,7 @@ fn test_subscribe_to_ordermatch_topic_subscribed_not_filled() {
 #[test]
 fn test_subscribe_to_ordermatch_topic_subscribed_filled() {
     let (ctx, _pubkey, _secret) = make_ctx_for_tests();
-    let (_, mut cmd_rx) = p2p_context_mock(&ctx);
+    let (_, mut cmd_rx) = init_p2p_context(&ctx);
 
     // enough time has passed for the orderbook to be filled
     let subscribed_at = now_ms() / 1000 - ORDERBOOK_REQUESTING_TIMEOUT - 1;

--- a/mm2src/mm2_net/Cargo.toml
+++ b/mm2src/mm2_net/Cargo.toml
@@ -43,6 +43,3 @@ gstuff = { version = "0.7", features = ["nightly"] }
 rustls = { version = "0.20", default-features = false }
 tokio = { version = "1.20" }
 tokio-rustls = { version = "0.23", default-features = false }
-
-[dev-dependencies]
-mocktopus = "0.8.0"

--- a/mm2src/mm2_net/src/p2p.rs
+++ b/mm2src/mm2_net/src/p2p.rs
@@ -1,6 +1,5 @@
 use mm2_core::mm_ctx::MmArc;
 use mm2_libp2p::behaviours::atomicdex::AdexCmdTx;
-#[cfg(test)] use mocktopus::macros::*;
 use parking_lot::Mutex;
 use std::sync::Arc;
 
@@ -9,15 +8,6 @@ pub struct P2PContext {
     pub cmd_tx: Mutex<AdexCmdTx>,
 }
 
-// `mockable` violates these
-#[allow(
-    clippy::forget_ref,
-    clippy::forget_copy,
-    clippy::swap_ptr_to_ref,
-    clippy::forget_non_drop,
-    clippy::let_unit_value
-)]
-#[cfg_attr(test, mockable)]
 impl P2PContext {
     pub fn new(cmd_tx: AdexCmdTx) -> Self {
         P2PContext {


### PR DESCRIPTION
For some reason, mocktopus dependency can not mock the p2p context after the p2p stack upgrade. 
This PR fixes that(by not doing it magically).