### PR TITLE
feat(nft): move db lock, add tx fee and confirmations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1740,10 +1740,12 @@ name = "db_common"
 version = "0.1.0"
 dependencies = [
  "common",
+ "crossbeam-channel 0.5.1",
  "hex 0.4.3",
  "log",
  "rusqlite",
  "sql-builder",
+ "tokio",
  "uuid 1.2.2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1741,6 +1741,7 @@ version = "0.1.0"
 dependencies = [
  "common",
  "crossbeam-channel 0.5.1",
+ "futures 0.3.28",
  "hex 0.4.3",
  "log",
  "rusqlite",

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -422,7 +422,7 @@ pub struct EthCoinImpl {
     swap_contract_address: Address,
     fallback_swap_contract: Option<Address>,
     contract_supports_watchers: bool,
-    web3: Web3<Web3Transport>,
+    pub(crate) web3: Web3<Web3Transport>,
     /// The separate web3 instances kept to get nonce, will replace the web3 completely soon
     web3_instances: Vec<Web3Instance>,
     decimals: u8,
@@ -4713,7 +4713,7 @@ pub struct EthTxFeeDetails {
 }
 
 impl EthTxFeeDetails {
-    fn new(gas: U256, gas_price: U256, coin: &str) -> NumConversResult<EthTxFeeDetails> {
+    pub(crate) fn new(gas: U256, gas_price: U256, coin: &str) -> NumConversResult<EthTxFeeDetails> {
         let total_fee = gas * gas_price;
         // Fees are always paid in ETH, can use 18 decimals by default
         let total_fee = u256_to_big_decimal(total_fee, ETH_DECIMALS)?;

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -875,7 +875,7 @@ async fn withdraw_impl(coin: EthCoin, req: WithdrawRequest) -> WithdrawResult {
 /// `withdraw_erc1155` function returns details of `ERC-1155` transaction including tx hex,
 /// which should be sent to`send_raw_transaction` RPC to broadcast the transaction.
 pub async fn withdraw_erc1155(ctx: MmArc, withdraw_type: WithdrawErc1155) -> WithdrawNftResult {
-    let coin = lp_coinfind_or_err(&ctx, &withdraw_type.chain.to_ticker()).await?;
+    let coin = lp_coinfind_or_err(&ctx, withdraw_type.chain.to_ticker()).await?;
     let (to_addr, token_addr, eth_coin) =
         get_valid_nft_add_to_withdraw(coin, &withdraw_type.to, &withdraw_type.token_address)?;
     let my_address = eth_coin.my_address()?;
@@ -977,7 +977,7 @@ pub async fn withdraw_erc1155(ctx: MmArc, withdraw_type: WithdrawErc1155) -> Wit
 /// `withdraw_erc721` function returns details of `ERC-721` transaction including tx hex,
 /// which should be sent to`send_raw_transaction` RPC to broadcast the transaction.
 pub async fn withdraw_erc721(ctx: MmArc, withdraw_type: WithdrawErc721) -> WithdrawNftResult {
-    let coin = lp_coinfind_or_err(&ctx, &withdraw_type.chain.to_ticker()).await?;
+    let coin = lp_coinfind_or_err(&ctx, withdraw_type.chain.to_ticker()).await?;
     let (to_addr, token_addr, eth_coin) =
         get_valid_nft_add_to_withdraw(coin, &withdraw_type.to, &withdraw_type.token_address)?;
     let my_address = eth_coin.my_address()?;

--- a/mm2src/coins/my_tx_history_v2.rs
+++ b/mm2src/coins/my_tx_history_v2.rs
@@ -491,7 +491,7 @@ where
                 _ => {},
             };
 
-            let confirmations = if details.block_height == 0 || details.block_height > current_block {
+            let confirmations = if details.block_height > current_block {
                 0
             } else {
                 current_block + 1 - details.block_height

--- a/mm2src/coins/nft.rs
+++ b/mm2src/coins/nft.rs
@@ -76,10 +76,7 @@ pub async fn get_nft_list(ctx: MmArc, req: NftListReq) -> MmResult<NftList, GetN
     let nft_ctx = NftCtx::from_ctx(&ctx).map_to_mm(GetNftInfoError::Internal)?;
     let _lock = nft_ctx.guard.lock().await;
 
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage()?;
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await?;
+    let storage = nft_ctx.lock_db().await?;
     for chain in req.chains.iter() {
         if !NftListStorageOps::is_initialized(&storage, chain).await? {
             NftListStorageOps::init(&storage, chain).await?;
@@ -119,10 +116,7 @@ pub async fn get_nft_metadata(ctx: MmArc, req: NftMetadataReq) -> MmResult<Nft, 
     let nft_ctx = NftCtx::from_ctx(&ctx).map_to_mm(GetNftInfoError::Internal)?;
     let _lock = nft_ctx.guard.lock().await;
 
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage()?;
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await?;
+    let storage = nft_ctx.lock_db().await?;
     if !NftListStorageOps::is_initialized(&storage, &req.chain).await? {
         NftListStorageOps::init(&storage, &req.chain).await?;
     }
@@ -164,10 +158,7 @@ pub async fn get_nft_transfers(ctx: MmArc, req: NftTransfersReq) -> MmResult<Nft
     let nft_ctx = NftCtx::from_ctx(&ctx).map_to_mm(GetNftInfoError::Internal)?;
     let _lock = nft_ctx.guard.lock().await;
 
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage()?;
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await?;
+    let storage = nft_ctx.lock_db().await?;
     for chain in req.chains.iter() {
         if !NftTransferHistoryStorageOps::is_initialized(&storage, chain).await? {
             NftTransferHistoryStorageOps::init(&storage, chain).await?;
@@ -203,10 +194,7 @@ pub async fn update_nft(ctx: MmArc, req: UpdateNftReq) -> MmResult<(), UpdateNft
     let nft_ctx = NftCtx::from_ctx(&ctx).map_to_mm(GetNftInfoError::Internal)?;
     let _lock = nft_ctx.guard.lock().await;
 
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage()?;
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await?;
+    let storage = nft_ctx.lock_db().await?;
     for chain in req.chains.iter() {
         let transfer_history_initialized = NftTransferHistoryStorageOps::is_initialized(&storage, chain).await?;
 
@@ -391,10 +379,7 @@ pub async fn refresh_nft_metadata(ctx: MmArc, req: RefreshMetadataReq) -> MmResu
     let nft_ctx = NftCtx::from_ctx(&ctx).map_to_mm(GetNftInfoError::Internal)?;
     let _lock = nft_ctx.guard.lock().await;
 
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage()?;
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await?;
+    let storage = nft_ctx.lock_db().await?;
     let token_address_str = eth_addr_to_hex(&req.token_address);
     let moralis_meta = match get_moralis_metadata(
         token_address_str.clone(),
@@ -1107,10 +1092,7 @@ pub(crate) async fn find_wallet_nft_amount(
     let nft_ctx = NftCtx::from_ctx(ctx).map_to_mm(GetNftInfoError::Internal)?;
     let _lock = nft_ctx.guard.lock().await;
 
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage()?;
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await?;
+    let storage = nft_ctx.lock_db().await?;
     if !NftListStorageOps::is_initialized(&storage, chain).await? {
         NftListStorageOps::init(&storage, chain).await?;
     }

--- a/mm2src/coins/nft.rs
+++ b/mm2src/coins/nft.rs
@@ -19,7 +19,7 @@ use crate::nft::nft_errors::{MetaFromUrlError, ProtectFromSpamError, UpdateSpamP
 use crate::nft::nft_structs::{build_nft_with_empty_meta, BuildNftFields, NftCommon, NftCtx, NftTransferCommon,
                               PhishingDomainReq, PhishingDomainRes, RefreshMetadataReq, SpamContractReq,
                               SpamContractRes, TransferMeta, TransferStatus, UriMeta};
-use crate::nft::storage::{NftListStorageOps, NftStorageBuilder, NftTransferHistoryStorageOps};
+use crate::nft::storage::{NftListStorageOps, NftTransferHistoryStorageOps};
 use common::parse_rfc3339_to_timestamp;
 use crypto::StandardHDCoinAddress;
 use ethereum_types::Address;
@@ -76,7 +76,10 @@ pub async fn get_nft_list(ctx: MmArc, req: NftListReq) -> MmResult<NftList, GetN
     let nft_ctx = NftCtx::from_ctx(&ctx).map_to_mm(GetNftInfoError::Internal)?;
     let _lock = nft_ctx.guard.lock().await;
 
-    let storage = NftStorageBuilder::new(&ctx).build()?;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage()?;
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await?;
     for chain in req.chains.iter() {
         if !NftListStorageOps::is_initialized(&storage, chain).await? {
             NftListStorageOps::init(&storage, chain).await?;
@@ -116,7 +119,10 @@ pub async fn get_nft_metadata(ctx: MmArc, req: NftMetadataReq) -> MmResult<Nft, 
     let nft_ctx = NftCtx::from_ctx(&ctx).map_to_mm(GetNftInfoError::Internal)?;
     let _lock = nft_ctx.guard.lock().await;
 
-    let storage = NftStorageBuilder::new(&ctx).build()?;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage()?;
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await?;
     if !NftListStorageOps::is_initialized(&storage, &req.chain).await? {
         NftListStorageOps::init(&storage, &req.chain).await?;
     }
@@ -158,7 +164,10 @@ pub async fn get_nft_transfers(ctx: MmArc, req: NftTransfersReq) -> MmResult<Nft
     let nft_ctx = NftCtx::from_ctx(&ctx).map_to_mm(GetNftInfoError::Internal)?;
     let _lock = nft_ctx.guard.lock().await;
 
-    let storage = NftStorageBuilder::new(&ctx).build()?;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage()?;
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await?;
     for chain in req.chains.iter() {
         if !NftTransferHistoryStorageOps::is_initialized(&storage, chain).await? {
             NftTransferHistoryStorageOps::init(&storage, chain).await?;
@@ -194,7 +203,10 @@ pub async fn update_nft(ctx: MmArc, req: UpdateNftReq) -> MmResult<(), UpdateNft
     let nft_ctx = NftCtx::from_ctx(&ctx).map_to_mm(GetNftInfoError::Internal)?;
     let _lock = nft_ctx.guard.lock().await;
 
-    let storage = NftStorageBuilder::new(&ctx).build()?;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage()?;
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await?;
     for chain in req.chains.iter() {
         let transfer_history_initialized = NftTransferHistoryStorageOps::is_initialized(&storage, chain).await?;
 
@@ -379,7 +391,10 @@ pub async fn refresh_nft_metadata(ctx: MmArc, req: RefreshMetadataReq) -> MmResu
     let nft_ctx = NftCtx::from_ctx(&ctx).map_to_mm(GetNftInfoError::Internal)?;
     let _lock = nft_ctx.guard.lock().await;
 
-    let storage = NftStorageBuilder::new(&ctx).build()?;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage()?;
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await?;
     let token_address_str = eth_addr_to_hex(&req.token_address);
     let moralis_meta = match get_moralis_metadata(
         token_address_str.clone(),
@@ -1089,10 +1104,13 @@ pub(crate) async fn find_wallet_nft_amount(
     token_address: String,
     token_id: BigDecimal,
 ) -> MmResult<BigDecimal, GetNftInfoError> {
-    let nft_ctx = NftCtx::from_ctx(ctx).map_err(GetNftInfoError::Internal)?;
+    let nft_ctx = NftCtx::from_ctx(ctx).map_to_mm(GetNftInfoError::Internal)?;
     let _lock = nft_ctx.guard.lock().await;
 
-    let storage = NftStorageBuilder::new(ctx).build()?;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage()?;
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await?;
     if !NftListStorageOps::is_initialized(&storage, chain).await? {
         NftListStorageOps::init(&storage, chain).await?;
     }

--- a/mm2src/coins/nft/nft_errors.rs
+++ b/mm2src/coins/nft/nft_errors.rs
@@ -102,7 +102,7 @@ impl From<ProtectFromSpamError> for GetNftInfoError {
 }
 
 impl From<LockDBError> for GetNftInfoError {
-    fn from(e: LockDBError) -> Self { GetNftInfoError::DbError(format!("{:?}", e)) }
+    fn from(e: LockDBError) -> Self { GetNftInfoError::DbError(e.to_string()) }
 }
 
 impl From<TransferConfirmationsError> for GetNftInfoError {
@@ -225,7 +225,7 @@ impl From<ProtectFromSpamError> for UpdateNftError {
 }
 
 impl From<LockDBError> for UpdateNftError {
-    fn from(e: LockDBError) -> Self { UpdateNftError::DbError(format!("{:?}", e)) }
+    fn from(e: LockDBError) -> Self { UpdateNftError::DbError(e.to_string()) }
 }
 
 impl From<CoinFindError> for UpdateNftError {
@@ -331,7 +331,7 @@ impl From<GetInfoFromUriError> for MetaFromUrlError {
     fn from(e: GetInfoFromUriError) -> Self { MetaFromUrlError::GetInfoFromUriError(e) }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Display)]
 pub enum LockDBError {
     #[cfg(target_arch = "wasm32")]
     WasmNftCacheError(WasmNftCacheError),

--- a/mm2src/coins/nft/nft_structs.rs
+++ b/mm2src/coins/nft/nft_structs.rs
@@ -19,6 +19,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use url::Url;
 
+use crate::eth::EthTxFeeDetails;
 use crate::nft::nft_errors::{LockDBError, ParseChainTypeError};
 use crate::nft::storage::{NftListStorageOps, NftTransferHistoryStorageOps};
 
@@ -542,6 +543,7 @@ pub struct NftTransferHistory {
     pub(crate) status: TransferStatus,
     #[serde(default)]
     pub(crate) possible_phishing: bool,
+    pub(crate) fee_details: Option<EthTxFeeDetails>,
 }
 
 /// Represents an NFT transfer structure specifically for deserialization from Moralis's JSON response.

--- a/mm2src/coins/nft/nft_structs.rs
+++ b/mm2src/coins/nft/nft_structs.rs
@@ -290,7 +290,7 @@ pub struct Nft {
     #[serde(flatten)]
     pub(crate) common: NftCommon,
     pub(crate) chain: Chain,
-    #[serde(serialize_with = "serialize_token_id")]
+    #[serde(serialize_with = "serialize_token_id", deserialize_with = "deserialize_token_id")]
     pub(crate) token_id: BigUint,
     pub(crate) block_number_minted: Option<u64>,
     pub(crate) block_number: u64,
@@ -531,7 +531,7 @@ pub struct NftTransferHistory {
     #[serde(flatten)]
     pub(crate) common: NftTransferCommon,
     pub(crate) chain: Chain,
-    #[serde(serialize_with = "serialize_token_id")]
+    #[serde(serialize_with = "serialize_token_id", deserialize_with = "deserialize_token_id")]
     pub(crate) token_id: BigUint,
     pub(crate) block_number: u64,
     pub(crate) block_timestamp: u64,

--- a/mm2src/coins/nft/nft_structs.rs
+++ b/mm2src/coins/nft/nft_structs.rs
@@ -544,6 +544,7 @@ pub struct NftTransferHistory {
     #[serde(default)]
     pub(crate) possible_phishing: bool,
     pub(crate) fee_details: Option<EthTxFeeDetails>,
+    pub(crate) confirmations: u64,
 }
 
 /// Represents an NFT transfer structure specifically for deserialization from Moralis's JSON response.

--- a/mm2src/coins/nft/nft_structs.rs
+++ b/mm2src/coins/nft/nft_structs.rs
@@ -635,7 +635,6 @@ impl From<Nft> for TransferMeta {
 /// This struct provides an interface for interacting with the underlying data structures
 /// required for NFT operations, including guarding against concurrent accesses and
 /// dealing with platform-specific storage mechanisms.
-#[allow(dead_code)]
 pub(crate) struct NftCtx {
     /// An asynchronous mutex to guard against concurrent NFT operations, ensuring data consistency.
     pub(crate) guard: Arc<AsyncMutex<()>>,

--- a/mm2src/coins/nft/nft_structs.rs
+++ b/mm2src/coins/nft/nft_structs.rs
@@ -688,12 +688,11 @@ impl NftCtx {
     pub(crate) async fn lock_db(
         &self,
     ) -> MmResult<impl NftListStorageOps + NftTransferHistoryStorageOps + '_, LockDBError> {
-        let locked_db = self
-            .nft_cache_db
+        self.nft_cache_db
             .get_or_initialize()
             .await
-            .mm_err(WasmNftCacheError::from)?;
-        Ok(locked_db)
+            .mm_err(WasmNftCacheError::from)
+            .mm_err(LockDBError::from)
     }
 }
 

--- a/mm2src/coins/nft/nft_structs.rs
+++ b/mm2src/coins/nft/nft_structs.rs
@@ -116,17 +116,17 @@ pub enum Chain {
 }
 
 pub(crate) trait ConvertChain {
-    fn to_ticker(&self) -> String;
+    fn to_ticker(&self) -> &'static str;
 }
 
 impl ConvertChain for Chain {
-    fn to_ticker(&self) -> String {
+    fn to_ticker(&self) -> &'static str {
         match self {
-            Chain::Avalanche => "AVAX".to_owned(),
-            Chain::Bsc => "BNB".to_owned(),
-            Chain::Eth => "ETH".to_owned(),
-            Chain::Fantom => "FTM".to_owned(),
-            Chain::Polygon => "MATIC".to_owned(),
+            Chain::Avalanche => "AVAX",
+            Chain::Bsc => "BNB",
+            Chain::Eth => "ETH",
+            Chain::Fantom => "FTM",
+            Chain::Polygon => "MATIC",
         }
     }
 }

--- a/mm2src/coins/nft/nft_tests.rs
+++ b/mm2src/coins/nft/nft_tests.rs
@@ -2,8 +2,7 @@ use crate::eth::eth_addr_to_hex;
 use crate::nft::nft_structs::{Chain, NftFromMoralis, NftListFilters, NftTransferHistoryFilters,
                               NftTransferHistoryFromMoralis, PhishingDomainReq, PhishingDomainRes, SpamContractReq,
                               SpamContractRes, TransferMeta, UriMeta};
-use crate::nft::storage::db_test_helpers::{init_nft_history_storage, init_nft_list_storage, nft, nft_list,
-                                           nft_transfer_history};
+use crate::nft::storage::db_test_helpers::{get_nft_ctx, nft, nft_list, nft_transfer_history};
 use crate::nft::storage::{NftListStorageOps, NftTransferHistoryStorageOps, RemoveNftResult};
 use crate::nft::{check_moralis_ipfs_bafy, get_domain_from_url, process_metadata_for_spam_link,
                  process_text_for_spam_link};
@@ -158,7 +157,12 @@ cross_test!(test_camo, {
 
 cross_test!(test_add_get_nfts, {
     let chain = Chain::Bsc;
-    let storage = init_nft_list_storage(&chain).await;
+    let nft_ctx = get_nft_ctx(&chain).await;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage().unwrap();
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await.unwrap();
+    NftListStorageOps::init(&storage, &chain).await.unwrap();
     let nft_list = nft_list();
     storage.add_nfts_to_list(chain, nft_list, 28056726).await.unwrap();
 
@@ -173,7 +177,12 @@ cross_test!(test_add_get_nfts, {
 
 cross_test!(test_last_nft_block, {
     let chain = Chain::Bsc;
-    let storage = init_nft_list_storage(&chain).await;
+    let nft_ctx = get_nft_ctx(&chain).await;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage().unwrap();
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await.unwrap();
+    NftListStorageOps::init(&storage, &chain).await.unwrap();
     let nft_list = nft_list();
     storage.add_nfts_to_list(chain, nft_list, 28056726).await.unwrap();
 
@@ -186,7 +195,12 @@ cross_test!(test_last_nft_block, {
 
 cross_test!(test_nft_list, {
     let chain = Chain::Bsc;
-    let storage = init_nft_list_storage(&chain).await;
+    let nft_ctx = get_nft_ctx(&chain).await;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage().unwrap();
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await.unwrap();
+    NftListStorageOps::init(&storage, &chain).await.unwrap();
     let nft_list = nft_list();
     storage.add_nfts_to_list(chain, nft_list, 28056726).await.unwrap();
 
@@ -203,7 +217,12 @@ cross_test!(test_nft_list, {
 
 cross_test!(test_remove_nft, {
     let chain = Chain::Bsc;
-    let storage = init_nft_list_storage(&chain).await;
+    let nft_ctx = get_nft_ctx(&chain).await;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage().unwrap();
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await.unwrap();
+    NftListStorageOps::init(&storage, &chain).await.unwrap();
     let nft_list = nft_list();
     storage.add_nfts_to_list(chain, nft_list, 28056726).await.unwrap();
 
@@ -226,7 +245,12 @@ cross_test!(test_remove_nft, {
 
 cross_test!(test_nft_amount, {
     let chain = Chain::Bsc;
-    let storage = init_nft_list_storage(&chain).await;
+    let nft_ctx = get_nft_ctx(&chain).await;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage().unwrap();
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await.unwrap();
+    NftListStorageOps::init(&storage, &chain).await.unwrap();
     let mut nft = nft();
     storage
         .add_nfts_to_list(chain, vec![nft.clone()], 25919780)
@@ -266,7 +290,12 @@ cross_test!(test_nft_amount, {
 
 cross_test!(test_refresh_metadata, {
     let chain = Chain::Bsc;
-    let storage = init_nft_list_storage(&chain).await;
+    let nft_ctx = get_nft_ctx(&chain).await;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage().unwrap();
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await.unwrap();
+    NftListStorageOps::init(&storage, &chain).await.unwrap();
     let new_symbol = "NEW_SYMBOL";
     let mut nft = nft();
     storage
@@ -284,7 +313,12 @@ cross_test!(test_refresh_metadata, {
 
 cross_test!(test_update_nft_spam_by_token_address, {
     let chain = Chain::Bsc;
-    let storage = init_nft_list_storage(&chain).await;
+    let nft_ctx = get_nft_ctx(&chain).await;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage().unwrap();
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await.unwrap();
+    NftListStorageOps::init(&storage, &chain).await.unwrap();
     let nft_list = nft_list();
     storage.add_nfts_to_list(chain, nft_list, 28056726).await.unwrap();
 
@@ -303,7 +337,12 @@ cross_test!(test_update_nft_spam_by_token_address, {
 
 cross_test!(test_exclude_nft_spam, {
     let chain = Chain::Bsc;
-    let storage = init_nft_list_storage(&chain).await;
+    let nft_ctx = get_nft_ctx(&chain).await;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage().unwrap();
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await.unwrap();
+    NftListStorageOps::init(&storage, &chain).await.unwrap();
     let nft_list = nft_list();
     storage.add_nfts_to_list(chain, nft_list, 28056726).await.unwrap();
 
@@ -320,7 +359,12 @@ cross_test!(test_exclude_nft_spam, {
 
 cross_test!(test_get_animation_external_domains, {
     let chain = Chain::Bsc;
-    let storage = init_nft_list_storage(&chain).await;
+    let nft_ctx = get_nft_ctx(&chain).await;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage().unwrap();
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await.unwrap();
+    NftListStorageOps::init(&storage, &chain).await.unwrap();
     let nft_list = nft_list();
     storage.add_nfts_to_list(chain, nft_list, 28056726).await.unwrap();
 
@@ -332,7 +376,12 @@ cross_test!(test_get_animation_external_domains, {
 
 cross_test!(test_update_nft_phishing_by_domain, {
     let chain = Chain::Bsc;
-    let storage = init_nft_list_storage(&chain).await;
+    let nft_ctx = get_nft_ctx(&chain).await;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage().unwrap();
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await.unwrap();
+    NftListStorageOps::init(&storage, &chain).await.unwrap();
     let nft_list = nft_list();
     storage.add_nfts_to_list(chain, nft_list, 28056726).await.unwrap();
 
@@ -358,7 +407,12 @@ cross_test!(test_update_nft_phishing_by_domain, {
 
 cross_test!(test_exclude_nft_phishing_spam, {
     let chain = Chain::Bsc;
-    let storage = init_nft_list_storage(&chain).await;
+    let nft_ctx = get_nft_ctx(&chain).await;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage().unwrap();
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await.unwrap();
+    NftListStorageOps::init(&storage, &chain).await.unwrap();
     let nft_list = nft_list();
     storage.add_nfts_to_list(chain, nft_list, 28056726).await.unwrap();
 
@@ -380,7 +434,12 @@ cross_test!(test_exclude_nft_phishing_spam, {
 
 cross_test!(test_add_get_transfers, {
     let chain = Chain::Bsc;
-    let storage = init_nft_history_storage(&chain).await;
+    let nft_ctx = get_nft_ctx(&chain).await;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage().unwrap();
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await.unwrap();
+    NftTransferHistoryStorageOps::init(&storage, &chain).await.unwrap();
     let transfers = nft_transfer_history();
     storage.add_transfers_to_history(chain, transfers).await.unwrap();
 
@@ -405,7 +464,12 @@ cross_test!(test_add_get_transfers, {
 
 cross_test!(test_last_transfer_block, {
     let chain = Chain::Bsc;
-    let storage = init_nft_history_storage(&chain).await;
+    let nft_ctx = get_nft_ctx(&chain).await;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage().unwrap();
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await.unwrap();
+    NftTransferHistoryStorageOps::init(&storage, &chain).await.unwrap();
     let transfers = nft_transfer_history();
     storage.add_transfers_to_history(chain, transfers).await.unwrap();
 
@@ -418,7 +482,12 @@ cross_test!(test_last_transfer_block, {
 
 cross_test!(test_transfer_history, {
     let chain = Chain::Bsc;
-    let storage = init_nft_history_storage(&chain).await;
+    let nft_ctx = get_nft_ctx(&chain).await;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage().unwrap();
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await.unwrap();
+    NftTransferHistoryStorageOps::init(&storage, &chain).await.unwrap();
     let transfers = nft_transfer_history();
     storage.add_transfers_to_history(chain, transfers).await.unwrap();
 
@@ -435,7 +504,12 @@ cross_test!(test_transfer_history, {
 
 cross_test!(test_transfer_history_filters, {
     let chain = Chain::Bsc;
-    let storage = init_nft_history_storage(&chain).await;
+    let nft_ctx = get_nft_ctx(&chain).await;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage().unwrap();
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await.unwrap();
+    NftTransferHistoryStorageOps::init(&storage, &chain).await.unwrap();
     let transfers = nft_transfer_history();
     storage.add_transfers_to_history(chain, transfers).await.unwrap();
 
@@ -495,7 +569,12 @@ cross_test!(test_transfer_history_filters, {
 
 cross_test!(test_get_update_transfer_meta, {
     let chain = Chain::Bsc;
-    let storage = init_nft_history_storage(&chain).await;
+    let nft_ctx = get_nft_ctx(&chain).await;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage().unwrap();
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await.unwrap();
+    NftTransferHistoryStorageOps::init(&storage, &chain).await.unwrap();
     let transfers = nft_transfer_history();
     storage.add_transfers_to_history(chain, transfers).await.unwrap();
 
@@ -528,7 +607,12 @@ cross_test!(test_get_update_transfer_meta, {
 
 cross_test!(test_update_transfer_spam_by_token_address, {
     let chain = Chain::Bsc;
-    let storage = init_nft_history_storage(&chain).await;
+    let nft_ctx = get_nft_ctx(&chain).await;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage().unwrap();
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await.unwrap();
+    NftTransferHistoryStorageOps::init(&storage, &chain).await.unwrap();
     let transfers = nft_transfer_history();
     storage.add_transfers_to_history(chain, transfers).await.unwrap();
 
@@ -547,7 +631,12 @@ cross_test!(test_update_transfer_spam_by_token_address, {
 
 cross_test!(test_get_token_addresses, {
     let chain = Chain::Bsc;
-    let storage = init_nft_history_storage(&chain).await;
+    let nft_ctx = get_nft_ctx(&chain).await;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage().unwrap();
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await.unwrap();
+    NftTransferHistoryStorageOps::init(&storage, &chain).await.unwrap();
     let transfers = nft_transfer_history();
     storage.add_transfers_to_history(chain, transfers).await.unwrap();
 
@@ -557,7 +646,12 @@ cross_test!(test_get_token_addresses, {
 
 cross_test!(test_exclude_transfer_spam, {
     let chain = Chain::Bsc;
-    let storage = init_nft_history_storage(&chain).await;
+    let nft_ctx = get_nft_ctx(&chain).await;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage().unwrap();
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await.unwrap();
+    NftTransferHistoryStorageOps::init(&storage, &chain).await.unwrap();
     let transfers = nft_transfer_history();
     storage.add_transfers_to_history(chain, transfers).await.unwrap();
 
@@ -578,7 +672,12 @@ cross_test!(test_exclude_transfer_spam, {
 
 cross_test!(test_get_domains, {
     let chain = Chain::Bsc;
-    let storage = init_nft_history_storage(&chain).await;
+    let nft_ctx = get_nft_ctx(&chain).await;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage().unwrap();
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await.unwrap();
+    NftTransferHistoryStorageOps::init(&storage, &chain).await.unwrap();
     let transfers = nft_transfer_history();
     storage.add_transfers_to_history(chain, transfers).await.unwrap();
 
@@ -590,7 +689,12 @@ cross_test!(test_get_domains, {
 
 cross_test!(test_update_transfer_phishing_by_domain, {
     let chain = Chain::Bsc;
-    let storage = init_nft_history_storage(&chain).await;
+    let nft_ctx = get_nft_ctx(&chain).await;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage().unwrap();
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await.unwrap();
+    NftTransferHistoryStorageOps::init(&storage, &chain).await.unwrap();
     let transfers = nft_transfer_history();
     storage.add_transfers_to_history(chain, transfers).await.unwrap();
 
@@ -616,7 +720,12 @@ cross_test!(test_update_transfer_phishing_by_domain, {
 
 cross_test!(test_exclude_transfer_phishing_spam, {
     let chain = Chain::Bsc;
-    let storage = init_nft_history_storage(&chain).await;
+    let nft_ctx = get_nft_ctx(&chain).await;
+    #[cfg(not(target_arch = "wasm32"))]
+    let storage = nft_ctx.get_storage().unwrap();
+    #[cfg(target_arch = "wasm32")]
+    let storage = nft_ctx.get_storage().await.unwrap();
+    NftTransferHistoryStorageOps::init(&storage, &chain).await.unwrap();
     let transfers = nft_transfer_history();
     storage.add_transfers_to_history(chain, transfers).await.unwrap();
 

--- a/mm2src/coins/nft/nft_tests.rs
+++ b/mm2src/coins/nft/nft_tests.rs
@@ -158,10 +158,7 @@ cross_test!(test_camo, {
 cross_test!(test_add_get_nfts, {
     let chain = Chain::Bsc;
     let nft_ctx = get_nft_ctx(&chain).await;
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage().unwrap();
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await.unwrap();
+    let storage = nft_ctx.lock_db().await.unwrap();
     NftListStorageOps::init(&storage, &chain).await.unwrap();
     let nft_list = nft_list();
     storage.add_nfts_to_list(chain, nft_list, 28056726).await.unwrap();
@@ -178,10 +175,7 @@ cross_test!(test_add_get_nfts, {
 cross_test!(test_last_nft_block, {
     let chain = Chain::Bsc;
     let nft_ctx = get_nft_ctx(&chain).await;
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage().unwrap();
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await.unwrap();
+    let storage = nft_ctx.lock_db().await.unwrap();
     NftListStorageOps::init(&storage, &chain).await.unwrap();
     let nft_list = nft_list();
     storage.add_nfts_to_list(chain, nft_list, 28056726).await.unwrap();
@@ -196,10 +190,7 @@ cross_test!(test_last_nft_block, {
 cross_test!(test_nft_list, {
     let chain = Chain::Bsc;
     let nft_ctx = get_nft_ctx(&chain).await;
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage().unwrap();
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await.unwrap();
+    let storage = nft_ctx.lock_db().await.unwrap();
     NftListStorageOps::init(&storage, &chain).await.unwrap();
     let nft_list = nft_list();
     storage.add_nfts_to_list(chain, nft_list, 28056726).await.unwrap();
@@ -218,10 +209,7 @@ cross_test!(test_nft_list, {
 cross_test!(test_remove_nft, {
     let chain = Chain::Bsc;
     let nft_ctx = get_nft_ctx(&chain).await;
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage().unwrap();
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await.unwrap();
+    let storage = nft_ctx.lock_db().await.unwrap();
     NftListStorageOps::init(&storage, &chain).await.unwrap();
     let nft_list = nft_list();
     storage.add_nfts_to_list(chain, nft_list, 28056726).await.unwrap();
@@ -246,10 +234,7 @@ cross_test!(test_remove_nft, {
 cross_test!(test_nft_amount, {
     let chain = Chain::Bsc;
     let nft_ctx = get_nft_ctx(&chain).await;
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage().unwrap();
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await.unwrap();
+    let storage = nft_ctx.lock_db().await.unwrap();
     NftListStorageOps::init(&storage, &chain).await.unwrap();
     let mut nft = nft();
     storage
@@ -291,10 +276,7 @@ cross_test!(test_nft_amount, {
 cross_test!(test_refresh_metadata, {
     let chain = Chain::Bsc;
     let nft_ctx = get_nft_ctx(&chain).await;
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage().unwrap();
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await.unwrap();
+    let storage = nft_ctx.lock_db().await.unwrap();
     NftListStorageOps::init(&storage, &chain).await.unwrap();
     let new_symbol = "NEW_SYMBOL";
     let mut nft = nft();
@@ -314,10 +296,7 @@ cross_test!(test_refresh_metadata, {
 cross_test!(test_update_nft_spam_by_token_address, {
     let chain = Chain::Bsc;
     let nft_ctx = get_nft_ctx(&chain).await;
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage().unwrap();
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await.unwrap();
+    let storage = nft_ctx.lock_db().await.unwrap();
     NftListStorageOps::init(&storage, &chain).await.unwrap();
     let nft_list = nft_list();
     storage.add_nfts_to_list(chain, nft_list, 28056726).await.unwrap();
@@ -338,10 +317,7 @@ cross_test!(test_update_nft_spam_by_token_address, {
 cross_test!(test_exclude_nft_spam, {
     let chain = Chain::Bsc;
     let nft_ctx = get_nft_ctx(&chain).await;
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage().unwrap();
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await.unwrap();
+    let storage = nft_ctx.lock_db().await.unwrap();
     NftListStorageOps::init(&storage, &chain).await.unwrap();
     let nft_list = nft_list();
     storage.add_nfts_to_list(chain, nft_list, 28056726).await.unwrap();
@@ -360,10 +336,7 @@ cross_test!(test_exclude_nft_spam, {
 cross_test!(test_get_animation_external_domains, {
     let chain = Chain::Bsc;
     let nft_ctx = get_nft_ctx(&chain).await;
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage().unwrap();
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await.unwrap();
+    let storage = nft_ctx.lock_db().await.unwrap();
     NftListStorageOps::init(&storage, &chain).await.unwrap();
     let nft_list = nft_list();
     storage.add_nfts_to_list(chain, nft_list, 28056726).await.unwrap();
@@ -377,10 +350,7 @@ cross_test!(test_get_animation_external_domains, {
 cross_test!(test_update_nft_phishing_by_domain, {
     let chain = Chain::Bsc;
     let nft_ctx = get_nft_ctx(&chain).await;
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage().unwrap();
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await.unwrap();
+    let storage = nft_ctx.lock_db().await.unwrap();
     NftListStorageOps::init(&storage, &chain).await.unwrap();
     let nft_list = nft_list();
     storage.add_nfts_to_list(chain, nft_list, 28056726).await.unwrap();
@@ -408,10 +378,7 @@ cross_test!(test_update_nft_phishing_by_domain, {
 cross_test!(test_exclude_nft_phishing_spam, {
     let chain = Chain::Bsc;
     let nft_ctx = get_nft_ctx(&chain).await;
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage().unwrap();
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await.unwrap();
+    let storage = nft_ctx.lock_db().await.unwrap();
     NftListStorageOps::init(&storage, &chain).await.unwrap();
     let nft_list = nft_list();
     storage.add_nfts_to_list(chain, nft_list, 28056726).await.unwrap();
@@ -435,10 +402,7 @@ cross_test!(test_exclude_nft_phishing_spam, {
 cross_test!(test_add_get_transfers, {
     let chain = Chain::Bsc;
     let nft_ctx = get_nft_ctx(&chain).await;
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage().unwrap();
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await.unwrap();
+    let storage = nft_ctx.lock_db().await.unwrap();
     NftTransferHistoryStorageOps::init(&storage, &chain).await.unwrap();
     let transfers = nft_transfer_history();
     storage.add_transfers_to_history(chain, transfers).await.unwrap();
@@ -465,10 +429,7 @@ cross_test!(test_add_get_transfers, {
 cross_test!(test_last_transfer_block, {
     let chain = Chain::Bsc;
     let nft_ctx = get_nft_ctx(&chain).await;
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage().unwrap();
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await.unwrap();
+    let storage = nft_ctx.lock_db().await.unwrap();
     NftTransferHistoryStorageOps::init(&storage, &chain).await.unwrap();
     let transfers = nft_transfer_history();
     storage.add_transfers_to_history(chain, transfers).await.unwrap();
@@ -483,10 +444,7 @@ cross_test!(test_last_transfer_block, {
 cross_test!(test_transfer_history, {
     let chain = Chain::Bsc;
     let nft_ctx = get_nft_ctx(&chain).await;
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage().unwrap();
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await.unwrap();
+    let storage = nft_ctx.lock_db().await.unwrap();
     NftTransferHistoryStorageOps::init(&storage, &chain).await.unwrap();
     let transfers = nft_transfer_history();
     storage.add_transfers_to_history(chain, transfers).await.unwrap();
@@ -505,10 +463,7 @@ cross_test!(test_transfer_history, {
 cross_test!(test_transfer_history_filters, {
     let chain = Chain::Bsc;
     let nft_ctx = get_nft_ctx(&chain).await;
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage().unwrap();
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await.unwrap();
+    let storage = nft_ctx.lock_db().await.unwrap();
     NftTransferHistoryStorageOps::init(&storage, &chain).await.unwrap();
     let transfers = nft_transfer_history();
     storage.add_transfers_to_history(chain, transfers).await.unwrap();
@@ -570,10 +525,7 @@ cross_test!(test_transfer_history_filters, {
 cross_test!(test_get_update_transfer_meta, {
     let chain = Chain::Bsc;
     let nft_ctx = get_nft_ctx(&chain).await;
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage().unwrap();
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await.unwrap();
+    let storage = nft_ctx.lock_db().await.unwrap();
     NftTransferHistoryStorageOps::init(&storage, &chain).await.unwrap();
     let transfers = nft_transfer_history();
     storage.add_transfers_to_history(chain, transfers).await.unwrap();
@@ -608,10 +560,7 @@ cross_test!(test_get_update_transfer_meta, {
 cross_test!(test_update_transfer_spam_by_token_address, {
     let chain = Chain::Bsc;
     let nft_ctx = get_nft_ctx(&chain).await;
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage().unwrap();
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await.unwrap();
+    let storage = nft_ctx.lock_db().await.unwrap();
     NftTransferHistoryStorageOps::init(&storage, &chain).await.unwrap();
     let transfers = nft_transfer_history();
     storage.add_transfers_to_history(chain, transfers).await.unwrap();
@@ -632,10 +581,7 @@ cross_test!(test_update_transfer_spam_by_token_address, {
 cross_test!(test_get_token_addresses, {
     let chain = Chain::Bsc;
     let nft_ctx = get_nft_ctx(&chain).await;
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage().unwrap();
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await.unwrap();
+    let storage = nft_ctx.lock_db().await.unwrap();
     NftTransferHistoryStorageOps::init(&storage, &chain).await.unwrap();
     let transfers = nft_transfer_history();
     storage.add_transfers_to_history(chain, transfers).await.unwrap();
@@ -647,10 +593,7 @@ cross_test!(test_get_token_addresses, {
 cross_test!(test_exclude_transfer_spam, {
     let chain = Chain::Bsc;
     let nft_ctx = get_nft_ctx(&chain).await;
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage().unwrap();
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await.unwrap();
+    let storage = nft_ctx.lock_db().await.unwrap();
     NftTransferHistoryStorageOps::init(&storage, &chain).await.unwrap();
     let transfers = nft_transfer_history();
     storage.add_transfers_to_history(chain, transfers).await.unwrap();
@@ -673,10 +616,7 @@ cross_test!(test_exclude_transfer_spam, {
 cross_test!(test_get_domains, {
     let chain = Chain::Bsc;
     let nft_ctx = get_nft_ctx(&chain).await;
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage().unwrap();
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await.unwrap();
+    let storage = nft_ctx.lock_db().await.unwrap();
     NftTransferHistoryStorageOps::init(&storage, &chain).await.unwrap();
     let transfers = nft_transfer_history();
     storage.add_transfers_to_history(chain, transfers).await.unwrap();
@@ -690,10 +630,7 @@ cross_test!(test_get_domains, {
 cross_test!(test_update_transfer_phishing_by_domain, {
     let chain = Chain::Bsc;
     let nft_ctx = get_nft_ctx(&chain).await;
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage().unwrap();
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await.unwrap();
+    let storage = nft_ctx.lock_db().await.unwrap();
     NftTransferHistoryStorageOps::init(&storage, &chain).await.unwrap();
     let transfers = nft_transfer_history();
     storage.add_transfers_to_history(chain, transfers).await.unwrap();
@@ -721,10 +658,7 @@ cross_test!(test_update_transfer_phishing_by_domain, {
 cross_test!(test_exclude_transfer_phishing_spam, {
     let chain = Chain::Bsc;
     let nft_ctx = get_nft_ctx(&chain).await;
-    #[cfg(not(target_arch = "wasm32"))]
-    let storage = nft_ctx.get_storage().unwrap();
-    #[cfg(target_arch = "wasm32")]
-    let storage = nft_ctx.get_storage().await.unwrap();
+    let storage = nft_ctx.lock_db().await.unwrap();
     NftTransferHistoryStorageOps::init(&storage, &chain).await.unwrap();
     let transfers = nft_transfer_history();
     storage.add_transfers_to_history(chain, transfers).await.unwrap();

--- a/mm2src/coins/nft/nft_tests.rs
+++ b/mm2src/coins/nft/nft_tests.rs
@@ -9,7 +9,7 @@ use crate::nft::{check_moralis_ipfs_bafy, get_domain_from_url, process_metadata_
 use common::cross_test;
 use ethereum_types::Address;
 use mm2_net::transport::send_post_request_to_uri;
-use mm2_number::BigDecimal;
+use mm2_number::{BigDecimal, BigUint};
 use std::num::NonZeroUsize;
 use std::str::FromStr;
 
@@ -163,7 +163,7 @@ cross_test!(test_add_get_nfts, {
     let nft_list = nft_list();
     storage.add_nfts_to_list(chain, nft_list, 28056726).await.unwrap();
 
-    let token_id = BigDecimal::from_str(TOKEN_ID).unwrap();
+    let token_id = BigUint::from_str(TOKEN_ID).unwrap();
     let nft = storage
         .get_nft(&chain, TOKEN_ADD.to_string(), token_id)
         .await
@@ -214,7 +214,7 @@ cross_test!(test_remove_nft, {
     let nft_list = nft_list();
     storage.add_nfts_to_list(chain, nft_list, 28056726).await.unwrap();
 
-    let token_id = BigDecimal::from_str(TOKEN_ID).unwrap();
+    let token_id = BigUint::from_str(TOKEN_ID).unwrap();
     let remove_rslt = storage
         .remove_nft_from_list(&chain, TOKEN_ADD.to_string(), token_id, 28056800)
         .await
@@ -245,11 +245,7 @@ cross_test!(test_nft_amount, {
     nft.common.amount -= BigDecimal::from(1);
     storage.update_nft_amount(&chain, nft.clone(), 25919800).await.unwrap();
     let amount = storage
-        .get_nft_amount(
-            &chain,
-            eth_addr_to_hex(&nft.common.token_address),
-            nft.common.token_id.clone(),
-        )
+        .get_nft_amount(&chain, eth_addr_to_hex(&nft.common.token_address), nft.token_id.clone())
         .await
         .unwrap()
         .unwrap();
@@ -264,7 +260,7 @@ cross_test!(test_nft_amount, {
         .await
         .unwrap();
     let amount = storage
-        .get_nft_amount(&chain, eth_addr_to_hex(&nft.common.token_address), nft.common.token_id)
+        .get_nft_amount(&chain, eth_addr_to_hex(&nft.common.token_address), nft.token_id)
         .await
         .unwrap()
         .unwrap();
@@ -287,7 +283,7 @@ cross_test!(test_refresh_metadata, {
     nft.common.symbol = Some(new_symbol.to_string());
     drop_mutability!(nft);
     let token_add = eth_addr_to_hex(&nft.common.token_address);
-    let token_id = nft.common.token_id.clone();
+    let token_id = nft.token_id.clone();
     storage.refresh_nft_metadata(&chain, nft).await.unwrap();
     let nft_upd = storage.get_nft(&chain, token_add, token_id).await.unwrap().unwrap();
     assert_eq!(new_symbol.to_string(), nft_upd.common.symbol.unwrap());
@@ -407,7 +403,7 @@ cross_test!(test_add_get_transfers, {
     let transfers = nft_transfer_history();
     storage.add_transfers_to_history(chain, transfers).await.unwrap();
 
-    let token_id = BigDecimal::from_str(TOKEN_ID).unwrap();
+    let token_id = BigUint::from_str(TOKEN_ID).unwrap();
     let transfer1 = storage
         .get_transfers_by_token_addr_id(chain, TOKEN_ADD.to_string(), token_id)
         .await

--- a/mm2src/coins/nft/storage/db_test_helpers.rs
+++ b/mm2src/coins/nft/storage/db_test_helpers.rs
@@ -247,6 +247,7 @@ pub(crate) fn nft_transfer_history() -> Vec<NftTransferHistory> {
         token_name: None,
         status: TransferStatus::Receive,
         possible_phishing: false,
+        fee_details: None,
     };
 
     let transfer1 = NftTransferHistory {
@@ -278,6 +279,7 @@ pub(crate) fn nft_transfer_history() -> Vec<NftTransferHistory> {
         token_name: None,
         status: TransferStatus::Receive,
         possible_phishing: false,
+        fee_details: None,
     };
 
     // Same as transfer1 but with different log_index, meaning that transfer1 and transfer2 are part of one batch/multi token transaction
@@ -310,6 +312,7 @@ pub(crate) fn nft_transfer_history() -> Vec<NftTransferHistory> {
         token_name: None,
         status: TransferStatus::Receive,
         possible_phishing: false,
+        fee_details: None,
     };
 
     let transfer3 = NftTransferHistory {
@@ -341,6 +344,7 @@ pub(crate) fn nft_transfer_history() -> Vec<NftTransferHistory> {
         token_name: Some("Nebula Nodes".to_string()),
         status: TransferStatus::Receive,
         possible_phishing: false,
+        fee_details: None,
     };
     vec![transfer, transfer1, transfer2, transfer3]
 }

--- a/mm2src/coins/nft/storage/db_test_helpers.rs
+++ b/mm2src/coins/nft/storage/db_test_helpers.rs
@@ -1,6 +1,5 @@
 use crate::nft::nft_structs::{Chain, ContractType, Nft, NftCommon, NftCtx, NftTransferCommon, NftTransferHistory,
                               TransferStatus, UriMeta};
-// use crate::nft::storage::{NftListStorageOps, NftTransferHistoryStorageOps};
 use ethereum_types::Address;
 use mm2_number::BigDecimal;
 #[cfg(not(target_arch = "wasm32"))]

--- a/mm2src/coins/nft/storage/db_test_helpers.rs
+++ b/mm2src/coins/nft/storage/db_test_helpers.rs
@@ -248,6 +248,7 @@ pub(crate) fn nft_transfer_history() -> Vec<NftTransferHistory> {
         status: TransferStatus::Receive,
         possible_phishing: false,
         fee_details: None,
+        confirmations: 0,
     };
 
     let transfer1 = NftTransferHistory {
@@ -280,6 +281,7 @@ pub(crate) fn nft_transfer_history() -> Vec<NftTransferHistory> {
         status: TransferStatus::Receive,
         possible_phishing: false,
         fee_details: None,
+        confirmations: 0,
     };
 
     // Same as transfer1 but with different log_index, meaning that transfer1 and transfer2 are part of one batch/multi token transaction
@@ -313,6 +315,7 @@ pub(crate) fn nft_transfer_history() -> Vec<NftTransferHistory> {
         status: TransferStatus::Receive,
         possible_phishing: false,
         fee_details: None,
+        confirmations: 0,
     };
 
     let transfer3 = NftTransferHistory {
@@ -345,6 +348,7 @@ pub(crate) fn nft_transfer_history() -> Vec<NftTransferHistory> {
         status: TransferStatus::Receive,
         possible_phishing: false,
         fee_details: None,
+        confirmations: 0,
     };
     vec![transfer, transfer1, transfer2, transfer3]
 }

--- a/mm2src/coins/nft/storage/db_test_helpers.rs
+++ b/mm2src/coins/nft/storage/db_test_helpers.rs
@@ -1,7 +1,7 @@
 use crate::nft::nft_structs::{Chain, ContractType, Nft, NftCommon, NftCtx, NftTransferCommon, NftTransferHistory,
                               TransferStatus, UriMeta};
 use ethereum_types::Address;
-use mm2_number::BigDecimal;
+use mm2_number::{BigDecimal, BigUint};
 #[cfg(not(target_arch = "wasm32"))]
 use mm2_test_helpers::for_tests::mm_ctx_with_custom_async_db;
 #[cfg(target_arch = "wasm32")]
@@ -13,7 +13,6 @@ pub(crate) fn nft() -> Nft {
     Nft {
         common: NftCommon {
             token_address: Address::from_str("0x5c7d6712dfaf0cb079d48981781c8705e8417ca0").unwrap(),
-            token_id: Default::default(),
             amount: BigDecimal::from_str("2").unwrap(),
             owner_of: Address::from_str("0xf622a6c52c94b500542e2ae6bcad24c53bc5b6a2").unwrap(),
             token_hash: Some("b34ddf294013d20a6d70691027625839".to_string()),
@@ -31,6 +30,7 @@ pub(crate) fn nft() -> Nft {
             possible_spam: true,
         },
         chain: Chain::Bsc,
+        token_id: Default::default(),
         block_number_minted: Some(25465916),
         block_number: 25919780,
         contract_type: ContractType::Erc1155,
@@ -55,7 +55,6 @@ pub(crate) fn nft_list() -> Vec<Nft> {
     let nft = Nft {
         common: NftCommon {
             token_address: Address::from_str("0x5c7d6712dfaf0cb079d48981781c8705e8417ca0").unwrap(),
-            token_id: Default::default(),
             amount: BigDecimal::from_str("2").unwrap(),
             owner_of: Address::from_str("0xf622a6c52c94b500542e2ae6bcad24c53bc5b6a2").unwrap(),
             token_hash: Some("b34ddf294013d20a6d70691027625839".to_string()),
@@ -70,6 +69,7 @@ pub(crate) fn nft_list() -> Vec<Nft> {
             possible_spam: false,
         },
         chain: Chain::Bsc,
+        token_id: Default::default(),
         block_number_minted: Some(25465916),
         block_number: 25919780,
         contract_type: ContractType::Erc1155,
@@ -92,7 +92,6 @@ pub(crate) fn nft_list() -> Vec<Nft> {
     let nft1 = Nft {
         common: NftCommon {
             token_address: Address::from_str("0xfd913a305d70a60aac4faac70c739563738e1f81").unwrap(),
-            token_id: BigDecimal::from_str("214300047252").unwrap(),
             amount: BigDecimal::from_str("1").unwrap(),
             owner_of: Address::from_str("0xf622a6c52c94b500542e2ae6bcad24c53bc5b6a2").unwrap(),
             token_hash: Some("c5d1cfd75a0535b0ec750c0156e6ddfe".to_string()),
@@ -110,6 +109,7 @@ pub(crate) fn nft_list() -> Vec<Nft> {
             possible_spam: true,
         },
         chain: Chain::Bsc,
+        token_id: BigUint::from_str("214300047252").unwrap(),
         block_number_minted: Some(25721963),
         block_number: 28056726,
         contract_type: ContractType::Erc721,
@@ -134,7 +134,6 @@ pub(crate) fn nft_list() -> Vec<Nft> {
     let nft2 = Nft {
         common: NftCommon {
             token_address: Address::from_str("0xfd913a305d70a60aac4faac70c739563738e1f81").unwrap(),
-            token_id: BigDecimal::from_str("214300047253").unwrap(),
             amount: BigDecimal::from_str("1").unwrap(),
             owner_of: Address::from_str("0xf622a6c52c94b500542e2ae6bcad24c53bc5b6a2").unwrap(),
             token_hash: Some("c5d1cfd75a0535b0ec750c0156e6ddfe".to_string()),
@@ -152,6 +151,7 @@ pub(crate) fn nft_list() -> Vec<Nft> {
             possible_spam: false,
         },
         chain: Chain::Bsc,
+        token_id: BigUint::from_str("214300047253").unwrap(),
         block_number_minted: Some(25721963),
         block_number: 28056726,
         contract_type: ContractType::Erc721,
@@ -176,7 +176,6 @@ pub(crate) fn nft_list() -> Vec<Nft> {
     let nft3 = Nft {
         common: NftCommon {
             token_address: Address::from_str("0xfd913a305d70a60aac4faac70c739563738e1f81").unwrap(),
-            token_id: BigDecimal::from_str("214300044414").unwrap(),
             amount: BigDecimal::from_str("1").unwrap(),
             owner_of: Address::from_str("0xf622a6c52c94b500542e2ae6bcad24c53bc5b6a2").unwrap(),
             token_hash: Some("125f8f4e952e107c257960000b4b250e".to_string()),
@@ -194,6 +193,7 @@ pub(crate) fn nft_list() -> Vec<Nft> {
             possible_spam: false,
         },
         chain: Chain::Bsc,
+        token_id: BigUint::from_str("214300044414").unwrap(),
         block_number_minted: Some(25810308),
         block_number: 28056721,
         contract_type: ContractType::Erc721,
@@ -227,7 +227,6 @@ pub(crate) fn nft_transfer_history() -> Vec<NftTransferHistory> {
             value: Default::default(),
             transaction_type: Some("Single".to_string()),
             token_address: Address::from_str("0x5c7d6712dfaf0cb079d48981781c8705e8417ca0").unwrap(),
-            token_id: Default::default(),
             from_address: Address::from_str("0x4ff0bbc9b64d635a4696d1a38554fb2529c103ff").unwrap(),
             to_address: Address::from_str("0xf622a6c52c94b500542e2ae6bcad24c53bc5b6a2").unwrap(),
             amount: BigDecimal::from_str("1").unwrap(),
@@ -236,6 +235,7 @@ pub(crate) fn nft_transfer_history() -> Vec<NftTransferHistory> {
             possible_spam: false,
         },
         chain: Chain::Bsc,
+        token_id: Default::default(),
         block_number: 25919780,
         block_timestamp: 1677166110,
         contract_type: ContractType::Erc1155,
@@ -260,7 +260,6 @@ pub(crate) fn nft_transfer_history() -> Vec<NftTransferHistory> {
             value: Default::default(),
             transaction_type: Some("Single".to_string()),
             token_address: Address::from_str("0xfd913a305d70a60aac4faac70c739563738e1f81").unwrap(),
-            token_id: BigDecimal::from_str("214300047252").unwrap(),
             from_address: Address::from_str("0x6fad0ec6bb76914b2a2a800686acc22970645820").unwrap(),
             to_address: Address::from_str("0xf622a6c52c94b500542e2ae6bcad24c53bc5b6a2").unwrap(),
             amount: BigDecimal::from_str("1").unwrap(),
@@ -269,6 +268,7 @@ pub(crate) fn nft_transfer_history() -> Vec<NftTransferHistory> {
             possible_spam: true,
         },
         chain: Chain::Bsc,
+        token_id: BigUint::from_str("214300047252").unwrap(),
         block_number: 28056726,
         block_timestamp: 1683627432,
         contract_type: ContractType::Erc721,
@@ -294,7 +294,6 @@ pub(crate) fn nft_transfer_history() -> Vec<NftTransferHistory> {
             value: Default::default(),
             transaction_type: Some("Single".to_string()),
             token_address: Address::from_str("0xfd913a305d70a60aac4faac70c739563738e1f81").unwrap(),
-            token_id: BigDecimal::from_str("214300047253").unwrap(),
             from_address: Address::from_str("0x6fad0ec6bb76914b2a2a800686acc22970645820").unwrap(),
             to_address: Address::from_str("0xf622a6c52c94b500542e2ae6bcad24c53bc5b6a2").unwrap(),
             amount: BigDecimal::from_str("1").unwrap(),
@@ -303,6 +302,7 @@ pub(crate) fn nft_transfer_history() -> Vec<NftTransferHistory> {
             possible_spam: false,
         },
         chain: Chain::Bsc,
+        token_id: BigUint::from_str("214300047253").unwrap(),
         block_number: 28056726,
         block_timestamp: 1683627432,
         contract_type: ContractType::Erc721,
@@ -327,7 +327,6 @@ pub(crate) fn nft_transfer_history() -> Vec<NftTransferHistory> {
             value: Default::default(),
             transaction_type: Some("Single".to_string()),
             token_address: Address::from_str("0xfd913a305d70a60aac4faac70c739563738e1f81").unwrap(),
-            token_id: BigDecimal::from_str("214300044414").unwrap(),
             from_address: Address::from_str("0x6fad0ec6bb76914b2a2a800686acc22970645820").unwrap(),
             to_address: Address::from_str("0xf622a6c52c94b500542e2ae6bcad24c53bc5b6a2").unwrap(),
             amount: BigDecimal::from_str("1").unwrap(),
@@ -336,6 +335,7 @@ pub(crate) fn nft_transfer_history() -> Vec<NftTransferHistory> {
             possible_spam: false,
         },
         chain: Chain::Bsc,
+        token_id: BigUint::from_str("214300044414").unwrap(),
         block_number: 28056721,
         block_timestamp: 1683627417,
         contract_type: ContractType::Erc721,

--- a/mm2src/coins/nft/storage/mod.rs
+++ b/mm2src/coins/nft/storage/mod.rs
@@ -2,9 +2,7 @@ use crate::nft::nft_structs::{Chain, Nft, NftList, NftListFilters, NftTokenAddrI
                               NftTransferHistoryFilters, NftsTransferHistoryList, TransferMeta};
 use crate::WithdrawError;
 use async_trait::async_trait;
-use derive_more::Display;
 use ethereum_types::Address;
-use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::mm_error::MmResult;
 use mm2_err_handle::mm_error::{NotEqual, NotMmError};
 use mm2_number::BigDecimal;
@@ -202,41 +200,6 @@ pub trait NftTransferHistoryStorageOps {
         domain: String,
         possible_phishing: bool,
     ) -> MmResult<(), Self::Error>;
-}
-
-/// Represents potential errors that can occur when creating an NFT storage.
-#[derive(Debug, Deserialize, Display, Serialize)]
-pub enum CreateNftStorageError {
-    Internal(String),
-}
-
-impl From<CreateNftStorageError> for WithdrawError {
-    fn from(e: CreateNftStorageError) -> Self {
-        match e {
-            CreateNftStorageError::Internal(err) => WithdrawError::InternalError(err),
-        }
-    }
-}
-
-/// `NftStorageBuilder` is used to create an instance that implements the [`NftListStorageOps`]
-/// and [`NftTransferHistoryStorageOps`] traits.
-pub struct NftStorageBuilder<'a> {
-    ctx: &'a MmArc,
-}
-
-impl<'a> NftStorageBuilder<'a> {
-    /// Creates a new `NftStorageBuilder` instance with the provided context.
-    #[inline]
-    pub fn new(ctx: &MmArc) -> NftStorageBuilder<'_> { NftStorageBuilder { ctx } }
-
-    /// `build` function is used to build nft storage which implements [`NftListStorageOps`] and [`NftTransferHistoryStorageOps`] traits.
-    #[inline]
-    pub fn build(&self) -> MmResult<impl NftListStorageOps + NftTransferHistoryStorageOps, CreateNftStorageError> {
-        #[cfg(target_arch = "wasm32")]
-        return wasm::wasm_storage::IndexedDbNftStorage::new(self.ctx);
-        #[cfg(not(target_arch = "wasm32"))]
-        sql_storage::SqliteNftStorage::new(self.ctx)
-    }
 }
 
 /// `get_offset_limit` function calculates offset and limit for final result if we use pagination.

--- a/mm2src/coins/nft/storage/mod.rs
+++ b/mm2src/coins/nft/storage/mod.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use ethereum_types::Address;
 use mm2_err_handle::mm_error::MmResult;
 use mm2_err_handle::mm_error::{NotEqual, NotMmError};
-use mm2_number::BigDecimal;
+use mm2_number::{BigDecimal, BigUint};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::num::NonZeroUsize;
@@ -61,14 +61,14 @@ pub trait NftListStorageOps {
         &self,
         chain: &Chain,
         token_address: String,
-        token_id: BigDecimal,
+        token_id: BigUint,
     ) -> MmResult<Option<Nft>, Self::Error>;
 
     async fn remove_nft_from_list(
         &self,
         chain: &Chain,
         token_address: String,
-        token_id: BigDecimal,
+        token_id: BigUint,
         scanned_block: u64,
     ) -> MmResult<RemoveNftResult, Self::Error>;
 
@@ -76,7 +76,7 @@ pub trait NftListStorageOps {
         &self,
         chain: &Chain,
         token_address: String,
-        token_id: BigDecimal,
+        token_id: BigUint,
     ) -> MmResult<Option<String>, Self::Error>;
 
     async fn refresh_nft_metadata(&self, chain: &Chain, nft: Nft) -> MmResult<(), Self::Error>;
@@ -153,7 +153,7 @@ pub trait NftTransferHistoryStorageOps {
         &self,
         chain: Chain,
         token_address: String,
-        token_id: BigDecimal,
+        token_id: BigUint,
     ) -> MmResult<Vec<NftTransferHistory>, Self::Error>;
 
     async fn get_transfer_by_tx_hash_and_log_index(

--- a/mm2src/coins/nft/storage/mod.rs
+++ b/mm2src/coins/nft/storage/mod.rs
@@ -1,3 +1,4 @@
+use crate::eth::EthTxFeeDetails;
 use crate::nft::nft_structs::{Chain, Nft, NftList, NftListFilters, NftTokenAddrId, NftTransferHistory,
                               NftTransferHistoryFilters, NftsTransferHistoryList, TransferMeta};
 use crate::WithdrawError;
@@ -235,4 +236,5 @@ pub(crate) struct TransferDetailsJson {
     pub(crate) operator: Option<String>,
     pub(crate) from_address: Address,
     pub(crate) to_address: Address,
+    pub(crate) fee_details: Option<EthTxFeeDetails>,
 }

--- a/mm2src/coins/nft/storage/sql_storage.rs
+++ b/mm2src/coins/nft/storage/sql_storage.rs
@@ -522,7 +522,8 @@ fn get_transfers_with_empty_meta_builder<'a>(conn: &'a Connection, chain: &'a Ch
         .and_where_is_null("token_uri")
         .and_where_is_null("collection_name")
         .and_where_is_null("image_url")
-        .and_where_is_null("token_name");
+        .and_where_is_null("token_name")
+        .and_where("possible_spam == 0");
     drop_mutability!(sql_builder);
     Ok(sql_builder)
 }

--- a/mm2src/coins/nft/storage/sql_storage.rs
+++ b/mm2src/coins/nft/storage/sql_storage.rs
@@ -25,13 +25,13 @@ use std::str::FromStr;
 
 impl Chain {
     fn nft_list_table_name(&self) -> SqlResult<String> {
-        let name = self.to_ticker() + "_nft_list";
+        let name = self.to_ticker().to_owned() + "_nft_list";
         validate_table_name(&name)?;
         Ok(name)
     }
 
     fn transfer_history_table_name(&self) -> SqlResult<String> {
-        let name = self.to_ticker() + "_nft_transfer_history";
+        let name = self.to_ticker().to_owned() + "_nft_transfer_history";
         validate_table_name(&name)?;
         Ok(name)
     }
@@ -643,7 +643,7 @@ impl NftListStorageOps for AsyncMutexGuard<'_, AsyncConnection> {
                 ];
                 sql_transaction.execute(&insert_nft_in_list_sql(&chain)?, params)?;
             }
-            let scanned_block_params = [chain.to_ticker(), last_scanned_block.to_string()];
+            let scanned_block_params = [chain.to_ticker().to_string(), last_scanned_block.to_string()];
             sql_transaction.execute(&upsert_last_scanned_block_sql()?, scanned_block_params)?;
             sql_transaction.commit()?;
             Ok(())
@@ -679,7 +679,7 @@ impl NftListStorageOps for AsyncMutexGuard<'_, AsyncConnection> {
         let table_name = chain.nft_list_table_name()?;
         let sql = delete_nft_sql(table_name)?;
         let params = [token_address, token_id.to_string()];
-        let scanned_block_params = [chain.to_ticker(), scanned_block.to_string()];
+        let scanned_block_params = [chain.to_ticker().to_string(), scanned_block.to_string()];
         self.call(move |conn| {
             let sql_transaction = conn.transaction()?;
             let rows_num = sql_transaction.execute(&sql, params)?;
@@ -785,7 +785,7 @@ impl NftListStorageOps for AsyncMutexGuard<'_, AsyncConnection> {
             "UPDATE {} SET amount = ?1 WHERE token_address = ?2 AND token_id = ?3;",
             table_name
         );
-        let scanned_block_params = [chain.to_ticker(), scanned_block.to_string()];
+        let scanned_block_params = [chain.to_ticker().to_string(), scanned_block.to_string()];
         self.call(move |conn| {
             let sql_transaction = conn.transaction()?;
             let params = [
@@ -808,7 +808,7 @@ impl NftListStorageOps for AsyncMutexGuard<'_, AsyncConnection> {
             "UPDATE {} SET amount = ?1, block_number = ?2 WHERE token_address = ?3 AND token_id = ?4;",
             table_name
         );
-        let scanned_block_params = [chain.to_ticker(), nft.block_number.to_string()];
+        let scanned_block_params = [chain.to_ticker().to_string(), nft.block_number.to_string()];
         self.call(move |conn| {
             let sql_transaction = conn.transaction()?;
             let params = [

--- a/mm2src/coins/nft/storage/sql_storage.rs
+++ b/mm2src/coins/nft/storage/sql_storage.rs
@@ -365,6 +365,7 @@ fn transfer_history_from_row(row: &Row<'_>) -> Result<NftTransferHistory, SqlErr
         status,
         possible_phishing: possible_phishing != 0,
         fee_details: details.fee_details,
+        confirmations: 0,
     };
 
     Ok(transfer_history)

--- a/mm2src/coins/nft/storage/sql_storage.rs
+++ b/mm2src/coins/nft/storage/sql_storage.rs
@@ -364,6 +364,7 @@ fn transfer_history_from_row(row: &Row<'_>) -> Result<NftTransferHistory, SqlErr
         token_name,
         status,
         possible_phishing: possible_phishing != 0,
+        fee_details: details.fee_details,
     };
 
     Ok(transfer_history)
@@ -976,6 +977,7 @@ impl NftTransferHistoryStorageOps for AsyncMutexGuard<'_, AsyncConnection> {
                     operator: transfer.common.operator,
                     from_address: transfer.common.from_address,
                     to_address: transfer.common.from_address,
+                    fee_details: transfer.fee_details,
                 };
                 let transfer_json = json::to_string(&details_json).expect("serialization should not fail");
                 let params = [

--- a/mm2src/coins/nft/storage/wasm/mod.rs
+++ b/mm2src/coins/nft/storage/wasm/mod.rs
@@ -1,7 +1,6 @@
 use crate::nft::storage::NftStorageError;
 use mm2_db::indexed_db::{DbTransactionError, InitDbError};
 use mm2_err_handle::prelude::*;
-use mm2_number::bigdecimal::ParseBigDecimalError;
 
 pub(crate) mod nft_idb;
 pub(crate) mod wasm_storage;
@@ -20,7 +19,6 @@ pub enum WasmNftCacheError {
     NotSupported(String),
     InternalError(String),
     GetLastNftBlockError(String),
-    ParseBigDecimalError(ParseBigDecimalError),
 }
 
 impl From<InitDbError> for WasmNftCacheError {

--- a/mm2src/coins/nft/storage/wasm/wasm_storage.rs
+++ b/mm2src/coins/nft/storage/wasm/wasm_storage.rs
@@ -609,6 +609,7 @@ impl NftTransferHistoryStorageOps for NftCacheIDBLocked<'_> {
                 && item.collection_name.is_none()
                 && item.image_url.is_none()
                 && item.token_name.is_none()
+                && !item.possible_spam
             {
                 res.insert(NftTokenAddrId {
                     token_address: item.token_address,

--- a/mm2src/coins/nft/storage/wasm/wasm_storage.rs
+++ b/mm2src/coins/nft/storage/wasm/wasm_storage.rs
@@ -46,12 +46,13 @@ where
     let mut filtered_nfts = Vec::new();
     for nft_table in nfts {
         let nft = nft_details_from_item(nft_table)?;
-        if let Some(filters) = &filters {
-            if filters.passes_spam_filter(&nft) && filters.passes_phishing_filter(&nft) {
-                filtered_nfts.push(nft);
-            }
-        } else {
-            filtered_nfts.push(nft);
+        match filters {
+            Some(filters) => {
+                if filters.passes_spam_filter(&nft) && filters.passes_phishing_filter(&nft) {
+                    filtered_nfts.push(nft);
+                }
+            },
+            None => filtered_nfts.push(nft),
         }
     }
     Ok(filtered_nfts)
@@ -83,16 +84,17 @@ where
     let mut filtered_transfers = Vec::new();
     for transfers_table in transfers {
         let transfer = transfer_details_from_item(transfers_table)?;
-        if let Some(filters) = &filters {
-            if filters.is_status_match(&transfer)
-                && filters.is_date_match(&transfer)
-                && filters.passes_spam_filter(&transfer)
-                && filters.passes_phishing_filter(&transfer)
-            {
-                filtered_transfers.push(transfer);
-            }
-        } else {
-            filtered_transfers.push(transfer);
+        match filters {
+            Some(filters) => {
+                if filters.is_status_match(&transfer)
+                    && filters.is_date_match(&transfer)
+                    && filters.passes_spam_filter(&transfer)
+                    && filters.passes_phishing_filter(&transfer)
+                {
+                    filtered_transfers.push(transfer);
+                }
+            },
+            None => filtered_transfers.push(transfer),
         }
     }
     Ok(filtered_transfers)

--- a/mm2src/db_common/Cargo.toml
+++ b/mm2src/db_common/Cargo.toml
@@ -13,8 +13,8 @@ log = "0.4.17"
 uuid = { version = "1.2.2", features = ["fast-rng", "serde", "v4"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+crossbeam-channel = "0.5.1"
+futures = "0.3.1"
 rusqlite = { version = "0.28", features = ["bundled"] }
 sql-builder = "3.1.1"
 tokio = { version = "1.20", default-features = false, features = ["macros"] }
-crossbeam-channel = "0.5.1"
-futures = "0.3.1"

--- a/mm2src/db_common/Cargo.toml
+++ b/mm2src/db_common/Cargo.toml
@@ -15,5 +15,5 @@ uuid = { version = "1.2.2", features = ["fast-rng", "serde", "v4"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rusqlite = { version = "0.28", features = ["bundled"] }
 sql-builder = "3.1.1"
-tokio = { version = "1.20", features = ["sync"] }
+tokio = { version = "1.20", features = ["macros", "sync"] }
 crossbeam-channel = "0.5.1"

--- a/mm2src/db_common/Cargo.toml
+++ b/mm2src/db_common/Cargo.toml
@@ -17,4 +17,4 @@ rusqlite = { version = "0.28", features = ["bundled"] }
 sql-builder = "3.1.1"
 tokio = { version = "1.20", default-features = false, features = ["macros"] }
 crossbeam-channel = "0.5.1"
-futures = { version = "0.3.1", package = "futures" }
+futures = "0.3.1"

--- a/mm2src/db_common/Cargo.toml
+++ b/mm2src/db_common/Cargo.toml
@@ -15,3 +15,5 @@ uuid = { version = "1.2.2", features = ["fast-rng", "serde", "v4"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rusqlite = { version = "0.28", features = ["bundled"] }
 sql-builder = "3.1.1"
+tokio = { version = "1.20", features = ["sync"] }
+crossbeam-channel = "0.5.1"

--- a/mm2src/db_common/Cargo.toml
+++ b/mm2src/db_common/Cargo.toml
@@ -15,5 +15,6 @@ uuid = { version = "1.2.2", features = ["fast-rng", "serde", "v4"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rusqlite = { version = "0.28", features = ["bundled"] }
 sql-builder = "3.1.1"
-tokio = { version = "1.20", features = ["macros", "sync"] }
+tokio = { version = "1.20", default-features = false, features = ["macros"] }
 crossbeam-channel = "0.5.1"
+futures = { version = "0.3.1", package = "futures" }

--- a/mm2src/db_common/src/async_conn_tests.rs
+++ b/mm2src/db_common/src/async_conn_tests.rs
@@ -1,0 +1,252 @@
+use crate::async_sql_conn::{AsyncConnError, AsyncConnection, Result as AsyncConnResult};
+use rusqlite::{ffi, ErrorCode};
+use std::fmt::Display;
+
+#[tokio::test]
+async fn open_in_memory_test() -> AsyncConnResult<()> {
+    let conn = AsyncConnection::open_in_memory().await;
+    assert!(conn.is_ok());
+    Ok(())
+}
+
+#[tokio::test]
+async fn call_success_test() -> AsyncConnResult<()> {
+    let conn = AsyncConnection::open_in_memory().await?;
+
+    let result = conn
+        .call(|conn| {
+            conn.execute(
+                "CREATE TABLE person(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL);",
+                [],
+            )
+            .map_err(|e| e.into())
+        })
+        .await;
+
+    assert_eq!(0, result.unwrap());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn call_unwrap_success_test() -> AsyncConnResult<()> {
+    let conn = AsyncConnection::open_in_memory().await?;
+
+    let result = conn
+        .call_unwrap(|conn| {
+            conn.execute(
+                "CREATE TABLE person(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL);",
+                [],
+            )
+            .unwrap()
+        })
+        .await;
+
+    assert_eq!(0, result);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn call_failure_test() -> AsyncConnResult<()> {
+    let conn = AsyncConnection::open_in_memory().await?;
+
+    let result = conn
+        .call(|conn| conn.execute("Invalid sql", []).map_err(|e| e.into()))
+        .await;
+
+    assert!(match result.unwrap_err() {
+        AsyncConnError::Rusqlite(e) => {
+            e == rusqlite::Error::SqlInputError {
+                error: ffi::Error {
+                    code: ErrorCode::Unknown,
+                    extended_code: 1,
+                },
+                msg: "near \"Invalid\": syntax error".to_string(),
+                sql: "Invalid sql".to_string(),
+                offset: 0,
+            }
+        },
+        _ => false,
+    });
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn close_success_test() -> AsyncConnResult<()> {
+    let conn = AsyncConnection::open_in_memory().await?;
+
+    assert!(conn.close().await.is_ok());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn double_close_test() -> AsyncConnResult<()> {
+    let conn = AsyncConnection::open_in_memory().await?;
+
+    let conn2 = conn.clone();
+
+    assert!(conn.close().await.is_ok());
+    assert!(conn2.close().await.is_ok());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn close_call_test() -> AsyncConnResult<()> {
+    let conn = AsyncConnection::open_in_memory().await?;
+
+    let conn2 = conn.clone();
+
+    assert!(conn.close().await.is_ok());
+
+    let result = conn2
+        .call(|conn| conn.execute("SELECT 1;", []).map_err(|e| e.into()))
+        .await;
+
+    assert!(matches!(result.unwrap_err(), AsyncConnError::ConnectionClosed));
+
+    Ok(())
+}
+
+#[tokio::test]
+#[should_panic]
+async fn close_call_unwrap_test() {
+    let conn = AsyncConnection::open_in_memory().await.unwrap();
+
+    let conn2 = conn.clone();
+
+    assert!(conn.close().await.is_ok());
+
+    conn2.call_unwrap(|conn| conn.execute("SELECT 1;", [])).await.unwrap();
+}
+
+#[tokio::test]
+async fn close_failure_test() -> AsyncConnResult<()> {
+    let conn = AsyncConnection::open_in_memory().await?;
+
+    conn.call(|conn| {
+        conn.execute(
+            "CREATE TABLE person(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL);",
+            [],
+        )
+        .map_err(|e| e.into())
+    })
+    .await?;
+
+    conn.call(|conn| {
+        // Leak a prepared statement to make the database uncloseable
+        // See https://www.sqlite.org/c3ref/close.html for details regarding this behaviour
+        let stmt = Box::new(conn.prepare("INSERT INTO person VALUES (1, ?1);").unwrap());
+        Box::leak(stmt);
+        Ok(())
+    })
+    .await?;
+
+    assert!(match conn.close().await.unwrap_err() {
+        AsyncConnError::Close((_, e)) => {
+            e == rusqlite::Error::SqliteFailure(
+                ffi::Error {
+                    code: ErrorCode::DatabaseBusy,
+                    extended_code: 5,
+                },
+                Some("unable to close due to unfinalized statements or unfinished backups".to_string()),
+            )
+        },
+        _ => false,
+    });
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn debug_format_test() -> AsyncConnResult<()> {
+    let conn = AsyncConnection::open_in_memory().await?;
+
+    assert_eq!("AsyncConnection".to_string(), format!("{conn:?}"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_error_display() -> AsyncConnResult<()> {
+    let conn = AsyncConnection::open_in_memory().await?;
+
+    let error = AsyncConnError::Close((conn, rusqlite::Error::InvalidQuery));
+    assert_eq!(
+        "Close((AsyncConnection, \"Query is not read-only\"))",
+        format!("{error}")
+    );
+
+    let error = AsyncConnError::ConnectionClosed;
+    assert_eq!("ConnectionClosed", format!("{error}"));
+
+    let error = AsyncConnError::Rusqlite(rusqlite::Error::InvalidQuery);
+    assert_eq!("Rusqlite(\"Query is not read-only\")", format!("{error}"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_error_source() -> AsyncConnResult<()> {
+    let conn = AsyncConnection::open_in_memory().await?;
+
+    let error = AsyncConnError::Close((conn, rusqlite::Error::InvalidQuery));
+    assert_eq!(
+        std::error::Error::source(&error)
+            .and_then(|e| e.downcast_ref::<rusqlite::Error>())
+            .unwrap(),
+        &rusqlite::Error::InvalidQuery,
+    );
+
+    let error = AsyncConnError::ConnectionClosed;
+    assert_eq!(
+        std::error::Error::source(&error).and_then(|e| e.downcast_ref::<rusqlite::Error>()),
+        None,
+    );
+
+    let error = AsyncConnError::Rusqlite(rusqlite::Error::InvalidQuery);
+    assert_eq!(
+        std::error::Error::source(&error)
+            .and_then(|e| e.downcast_ref::<rusqlite::Error>())
+            .unwrap(),
+        &rusqlite::Error::InvalidQuery,
+    );
+
+    Ok(())
+}
+
+fn failable_func(_: &rusqlite::Connection) -> std::result::Result<(), MyError> { Err(MyError::MySpecificError) }
+
+#[tokio::test]
+async fn test_ergonomic_errors() -> AsyncConnResult<()> {
+    let conn = AsyncConnection::open_in_memory().await?;
+
+    let res = conn
+        .call(|conn| failable_func(conn).map_err(|e| AsyncConnError::Other(Box::new(e))))
+        .await
+        .unwrap_err();
+
+    let err = std::error::Error::source(&res)
+        .and_then(|e| e.downcast_ref::<MyError>())
+        .unwrap();
+
+    assert!(matches!(err, MyError::MySpecificError));
+
+    Ok(())
+}
+
+#[derive(Debug)]
+enum MyError {
+    MySpecificError,
+}
+
+impl Display for MyError {
+    fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { Ok(()) }
+}
+
+impl std::error::Error for MyError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+}

--- a/mm2src/db_common/src/async_conn_tests.rs
+++ b/mm2src/db_common/src/async_conn_tests.rs
@@ -1,6 +1,7 @@
 use crate::async_sql_conn::{AsyncConnError, AsyncConnection, InternalError, Result as AsyncConnResult};
 use rusqlite::{ffi, ErrorCode};
 use std::fmt::Display;
+
 #[tokio::test]
 async fn open_in_memory_test() -> AsyncConnResult<()> {
     let conn = AsyncConnection::open_in_memory().await;
@@ -74,7 +75,7 @@ async fn call_failure_test() -> AsyncConnResult<()> {
 
 #[tokio::test]
 async fn close_success_test() -> AsyncConnResult<()> {
-    let conn = AsyncConnection::open_in_memory().await?;
+    let mut conn = AsyncConnection::open_in_memory().await?;
 
     assert!(conn.close().await.is_ok());
 
@@ -83,9 +84,9 @@ async fn close_success_test() -> AsyncConnResult<()> {
 
 #[tokio::test]
 async fn double_close_test() -> AsyncConnResult<()> {
-    let conn = AsyncConnection::open_in_memory().await?;
+    let mut conn = AsyncConnection::open_in_memory().await?;
 
-    let conn2 = conn.clone();
+    let mut conn2 = conn.clone();
 
     assert!(conn.close().await.is_ok());
     assert!(conn2.close().await.is_ok());
@@ -95,7 +96,7 @@ async fn double_close_test() -> AsyncConnResult<()> {
 
 #[tokio::test]
 async fn close_call_test() -> AsyncConnResult<()> {
-    let conn = AsyncConnection::open_in_memory().await?;
+    let mut conn = AsyncConnection::open_in_memory().await?;
 
     let conn2 = conn.clone();
 
@@ -113,7 +114,7 @@ async fn close_call_test() -> AsyncConnResult<()> {
 #[tokio::test]
 #[should_panic]
 async fn close_call_unwrap_test() {
-    let conn = AsyncConnection::open_in_memory().await.unwrap();
+    let mut conn = AsyncConnection::open_in_memory().await.unwrap();
 
     let conn2 = conn.clone();
 
@@ -124,7 +125,7 @@ async fn close_call_unwrap_test() {
 
 #[tokio::test]
 async fn close_failure_test() -> AsyncConnResult<()> {
-    let conn = AsyncConnection::open_in_memory().await?;
+    let mut conn = AsyncConnection::open_in_memory().await?;
 
     conn.call(|conn| {
         conn.execute(

--- a/mm2src/db_common/src/async_sql_conn.rs
+++ b/mm2src/db_common/src/async_sql_conn.rs
@@ -213,7 +213,7 @@ impl AsyncConnection {
     /// # Failure
     ///
     /// Will return `Err` if the underlying SQLite close call fails.
-    pub async fn close(self) -> Result<()> {
+    pub async fn close(&mut self) -> Result<()> {
         let (sender, receiver) = oneshot::channel::<std::result::Result<(), SqlError>>();
 
         if let Err(crossbeam_channel::SendError(_)) = self.sender.send(Message::Close(sender)) {
@@ -230,7 +230,7 @@ impl AsyncConnection {
             return Ok(());
         }
 
-        result.unwrap().map_err(|e| AsyncConnError::Close((self, e)))
+        result.unwrap().map_err(|e| AsyncConnError::Close((self.clone(), e)))
     }
 }
 

--- a/mm2src/db_common/src/async_sql_conn.rs
+++ b/mm2src/db_common/src/async_sql_conn.rs
@@ -1,10 +1,10 @@
 use crate::sqlite::rusqlite::Error as SqlError;
 use crossbeam_channel::Sender;
+use futures::channel::oneshot::{self};
 use rusqlite::OpenFlags;
 use std::fmt::{self, Debug, Display};
 use std::path::Path;
 use std::thread;
-use tokio::sync::oneshot::{self};
 
 /// Represents the errors specific for AsyncConnection.
 #[derive(Debug)]
@@ -143,8 +143,7 @@ impl AsyncConnection {
         start(move || rusqlite::Connection::open_in_memory_with_flags_and_vfs(flags, &vfs)).await
     }
 
-    /// Call a function in background thread and get the result
-    /// asynchronously.
+    /// Call a function in background thread and get the result asynchronously.
     ///
     /// # Failure
     ///
@@ -166,8 +165,7 @@ impl AsyncConnection {
         receiver.await.map_err(|_| AsyncConnError::ConnectionClosed)?
     }
 
-    /// Call a function in background thread and get the result
-    /// asynchronously.
+    /// Call a function in background thread and get the result asynchronously.
     ///
     /// This method can cause a `panic` if the underlying database connection is closed.
     /// it is a more user-friendly alternative to the [`AsyncConnection::call`] method.

--- a/mm2src/db_common/src/async_sql_conn.rs
+++ b/mm2src/db_common/src/async_sql_conn.rs
@@ -6,21 +6,18 @@ use std::path::Path;
 use std::thread;
 use tokio::sync::oneshot::{self};
 
-/// Represents the errors specific for this library.
+/// Represents the errors specific for AsyncConnection.
 #[derive(Debug)]
 pub enum AsyncConnError {
     /// The connection to the SQLite has been closed and cannot be queried any more.
     ConnectionClosed,
-
-    /// An error occured while closing the SQLite connection.
+    /// An error occurred while closing the SQLite connection.
     /// This `Error` variant contains the [`AsyncConnection`], which can be used to retry the close operation
-    /// and the underlying [`SqlError`] that made it impossile to close the database.
+    /// and the underlying [`SqlError`] that made it impossible to close the database.
     Close((AsyncConnection, SqlError)),
-
-    /// A `Rusqlite` error occured.
+    /// A `Rusqlite` error occurred.
     Rusqlite(SqlError),
-
-    /// An application-specific error occured.
+    /// An application-specific error occurred.
     Other(Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 

--- a/mm2src/db_common/src/async_sql_conn.rs
+++ b/mm2src/db_common/src/async_sql_conn.rs
@@ -1,0 +1,298 @@
+use crate::sqlite::rusqlite::Error as SqlError;
+use crossbeam_channel::Sender;
+use rusqlite::OpenFlags;
+use std::fmt::{self, Debug, Display};
+use std::path::Path;
+use std::thread;
+use tokio::sync::oneshot::{self};
+
+const BUG_TEXT: &str = "bug in tokio-rusqlite, please report";
+
+/// Represents the errors specific for this library.
+#[derive(Debug)]
+pub enum AsyncConnError {
+    /// The connection to the SQLite has been closed and cannot be queried any more.
+    ConnectionClosed,
+
+    /// An error occured while closing the SQLite connection.
+    /// This `Error` variant contains the [`AsyncConnection`], which can be used to retry the close operation
+    /// and the underlying [`SqlError`] that made it impossile to close the database.
+    Close((AsyncConnection, SqlError)),
+
+    /// A `Rusqlite` error occured.
+    Rusqlite(SqlError),
+
+    /// An application-specific error occured.
+    Other(Box<dyn std::error::Error + Send + Sync + 'static>),
+}
+
+impl Display for AsyncConnError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AsyncConnError::ConnectionClosed => write!(f, "ConnectionClosed"),
+            AsyncConnError::Close((_, e)) => write!(f, "Close((AsyncConnection, \"{e}\"))"),
+            AsyncConnError::Rusqlite(e) => write!(f, "Rusqlite(\"{e}\")"),
+            AsyncConnError::Other(ref e) => write!(f, "Other(\"{e}\")"),
+        }
+    }
+}
+
+impl std::error::Error for AsyncConnError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            AsyncConnError::ConnectionClosed => None,
+            AsyncConnError::Close((_, e)) => Some(e),
+            AsyncConnError::Rusqlite(e) => Some(e),
+            AsyncConnError::Other(ref e) => Some(&**e),
+        }
+    }
+}
+
+impl From<SqlError> for AsyncConnError {
+    fn from(value: SqlError) -> Self { AsyncConnError::Rusqlite(value) }
+}
+
+/// The result returned on method calls in this crate.
+pub type Result<T> = std::result::Result<T, AsyncConnError>;
+
+type CallFn = Box<dyn FnOnce(&mut rusqlite::Connection) + Send + 'static>;
+
+enum Message {
+    Execute(CallFn),
+    Close(oneshot::Sender<std::result::Result<(), SqlError>>),
+}
+
+/// A handle to call functions in background thread.
+#[derive(Clone)]
+pub struct AsyncConnection {
+    sender: Sender<Message>,
+}
+
+impl AsyncConnection {
+    /// Open a new connection to a SQLite database.
+    ///
+    /// `AsyncConnection::open(path)` is equivalent to
+    /// `AsyncConnection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_WRITE |
+    /// OpenFlags::SQLITE_OPEN_CREATE)`.
+    ///
+    /// # Failure
+    ///
+    /// Will return `Err` if `path` cannot be converted to a C-compatible
+    /// string or if the underlying SQLite open call fails.
+    pub async fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let path = path.as_ref().to_owned();
+        start(move || rusqlite::Connection::open(path))
+            .await
+            .map_err(AsyncConnError::Rusqlite)
+    }
+
+    /// Open a new AsyncConnection to an in-memory SQLite database.
+    ///
+    /// # Failure
+    ///
+    /// Will return `Err` if the underlying SQLite open call fails.
+    pub async fn open_in_memory() -> Result<Self> {
+        start(rusqlite::Connection::open_in_memory)
+            .await
+            .map_err(AsyncConnError::Rusqlite)
+    }
+
+    /// Open a new AsyncConnection to a SQLite database.
+    ///
+    /// [Database Connection](http://www.sqlite.org/c3ref/open.html) for a
+    /// description of valid flag combinations.
+    ///
+    /// # Failure
+    ///
+    /// Will return `Err` if `path` cannot be converted to a C-compatible
+    /// string or if the underlying SQLite open call fails.
+    pub async fn open_with_flags<P: AsRef<Path>>(path: P, flags: OpenFlags) -> Result<Self> {
+        let path = path.as_ref().to_owned();
+        start(move || rusqlite::Connection::open_with_flags(path, flags))
+            .await
+            .map_err(AsyncConnError::Rusqlite)
+    }
+
+    /// Open a new AsyncConnection to a SQLite database using the specific flags
+    /// and vfs name.
+    ///
+    /// [Database Connection](http://www.sqlite.org/c3ref/open.html) for a
+    /// description of valid flag combinations.
+    ///
+    /// # Failure
+    ///
+    /// Will return `Err` if either `path` or `vfs` cannot be converted to a
+    /// C-compatible string or if the underlying SQLite open call fails.
+    pub async fn open_with_flags_and_vfs<P: AsRef<Path>>(path: P, flags: OpenFlags, vfs: &str) -> Result<Self> {
+        let path = path.as_ref().to_owned();
+        let vfs = vfs.to_owned();
+        start(move || rusqlite::Connection::open_with_flags_and_vfs(path, flags, &vfs))
+            .await
+            .map_err(AsyncConnError::Rusqlite)
+    }
+
+    /// Open a new AsyncConnection to an in-memory SQLite database.
+    ///
+    /// [Database Connection](http://www.sqlite.org/c3ref/open.html) for a
+    /// description of valid flag combinations.
+    ///
+    /// # Failure
+    ///
+    /// Will return `Err` if the underlying SQLite open call fails.
+    pub async fn open_in_memory_with_flags(flags: OpenFlags) -> Result<Self> {
+        start(move || rusqlite::Connection::open_in_memory_with_flags(flags))
+            .await
+            .map_err(AsyncConnError::Rusqlite)
+    }
+
+    /// Open a new connection to an in-memory SQLite database using the
+    /// specific flags and vfs name.
+    ///
+    /// [Database Connection](http://www.sqlite.org/c3ref/open.html) for a
+    /// description of valid flag combinations.
+    ///
+    /// # Failure
+    ///
+    /// Will return `Err` if `vfs` cannot be converted to a C-compatible
+    /// string or if the underlying SQLite open call fails.
+    pub async fn open_in_memory_with_flags_and_vfs(flags: OpenFlags, vfs: &str) -> Result<Self> {
+        let vfs = vfs.to_owned();
+        start(move || rusqlite::Connection::open_in_memory_with_flags_and_vfs(flags, &vfs))
+            .await
+            .map_err(AsyncConnError::Rusqlite)
+    }
+
+    /// Call a function in background thread and get the result
+    /// asynchronously.
+    ///
+    /// # Failure
+    ///
+    /// Will return `Err` if the database connection has been closed.
+    pub async fn call<F, R>(&self, function: F) -> Result<R>
+    where
+        F: FnOnce(&mut rusqlite::Connection) -> Result<R> + 'static + Send,
+        R: Send + 'static,
+    {
+        let (sender, receiver) = oneshot::channel::<Result<R>>();
+
+        self.sender
+            .send(Message::Execute(Box::new(move |conn| {
+                let value = function(conn);
+                let _ = sender.send(value);
+            })))
+            .map_err(|_| AsyncConnError::ConnectionClosed)?;
+
+        receiver.await.map_err(|_| AsyncConnError::ConnectionClosed)?
+    }
+
+    /// Call a function in background thread and get the result
+    /// asynchronously.
+    ///
+    /// This method can cause a `panic` if the underlying database connection is closed.
+    /// it is a more user-friendly alternative to the [`AsyncConnection::call`] method.
+    /// It should be safe if the connection is never explicitly closed (using the [`AsyncConnection::close`] call).
+    ///
+    /// Calling this on a closed connection will cause a `panic`.
+    pub async fn call_unwrap<F, R>(&self, function: F) -> R
+    where
+        F: FnOnce(&mut rusqlite::Connection) -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        let (sender, receiver) = oneshot::channel::<R>();
+
+        self.sender
+            .send(Message::Execute(Box::new(move |conn| {
+                let value = function(conn);
+                let _ = sender.send(value);
+            })))
+            .expect("database connection should be open");
+
+        receiver.await.expect(BUG_TEXT)
+    }
+
+    /// Close the database AsyncConnection.
+    ///
+    /// This is functionally equivalent to the `Drop` implementation for
+    /// `AsyncConnection`. It consumes the `AsyncConnection`, but on error returns it
+    /// to the caller for retry purposes.
+    ///
+    /// If successful, any following `close` operations performed
+    /// on `AsyncConnection` copies will succeed immediately.
+    ///
+    /// On the other hand, any calls to [`AsyncConnection::call`] will return a [`AsyncConnError::ConnectionClosed`],
+    /// and any calls to [`AsyncConnection::call_unwrap`] will cause a `panic`.
+    ///
+    /// # Failure
+    ///
+    /// Will return `Err` if the underlying SQLite close call fails.
+    pub async fn close(self) -> Result<()> {
+        let (sender, receiver) = oneshot::channel::<std::result::Result<(), SqlError>>();
+
+        if let Err(crossbeam_channel::SendError(_)) = self.sender.send(Message::Close(sender)) {
+            // If the channel is closed on the other side, it means the connection closed successfully
+            // This is a safeguard against calling close on a `Copy` of the connection
+            return Ok(());
+        }
+
+        let result = receiver.await;
+
+        if result.is_err() {
+            // If we get a RecvError at this point, it also means the channel closed in the meantime
+            // we can assume the connection is closed
+            return Ok(());
+        }
+
+        result.unwrap().map_err(|e| AsyncConnError::Close((self, e)))
+    }
+}
+
+impl Debug for AsyncConnection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { f.debug_struct("Connection").finish() }
+}
+
+async fn start<F>(open: F) -> rusqlite::Result<AsyncConnection>
+where
+    F: FnOnce() -> rusqlite::Result<rusqlite::Connection> + Send + 'static,
+{
+    let (sender, receiver) = crossbeam_channel::unbounded::<Message>();
+    let (result_sender, result_receiver) = oneshot::channel();
+
+    thread::spawn(move || {
+        let mut conn = match open() {
+            Ok(c) => c,
+            Err(e) => {
+                let _ = result_sender.send(Err(e));
+                return;
+            },
+        };
+
+        if let Err(_e) = result_sender.send(Ok(())) {
+            return;
+        }
+
+        while let Ok(message) = receiver.recv() {
+            match message {
+                Message::Execute(f) => f(&mut conn),
+                Message::Close(s) => {
+                    let result = conn.close();
+
+                    match result {
+                        Ok(v) => {
+                            s.send(Ok(v)).expect(BUG_TEXT);
+                            break;
+                        },
+                        Err((c, e)) => {
+                            conn = c;
+                            s.send(Err(e)).expect(BUG_TEXT);
+                        },
+                    }
+                },
+            }
+        }
+    });
+
+    result_receiver
+        .await
+        .expect(BUG_TEXT)
+        .map(|_| AsyncConnection { sender })
+}

--- a/mm2src/db_common/src/lib.rs
+++ b/mm2src/db_common/src/lib.rs
@@ -1,3 +1,6 @@
+#[allow(dead_code)]
+#[cfg(not(target_arch = "wasm32"))]
+pub mod async_sql_conn;
 #[cfg(not(target_arch = "wasm32"))] mod sql_condition;
 #[cfg(not(target_arch = "wasm32"))] mod sql_constraint;
 #[cfg(not(target_arch = "wasm32"))] mod sql_create;

--- a/mm2src/db_common/src/lib.rs
+++ b/mm2src/db_common/src/lib.rs
@@ -1,6 +1,6 @@
-#[allow(dead_code)]
-#[cfg(not(target_arch = "wasm32"))]
-pub mod async_sql_conn;
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod async_conn_tests;
+#[cfg(not(target_arch = "wasm32"))] pub mod async_sql_conn;
 #[cfg(not(target_arch = "wasm32"))] mod sql_condition;
 #[cfg(not(target_arch = "wasm32"))] mod sql_constraint;
 #[cfg(not(target_arch = "wasm32"))] mod sql_create;

--- a/mm2src/mm2_core/src/mm_ctx.rs
+++ b/mm2src/mm2_core/src/mm_ctx.rs
@@ -26,7 +26,9 @@ cfg_wasm32! {
 }
 
 cfg_native! {
+    use db_common::async_sql_conn::AsyncConnection;
     use db_common::sqlite::rusqlite::Connection;
+    use futures::lock::Mutex as AsyncMutex;
     use futures_rustls::webpki::DNSNameRef;
     use mm2_metrics::prometheus;
     use mm2_metrics::MmMetricsError;
@@ -34,8 +36,6 @@ cfg_native! {
     use std::path::{Path, PathBuf};
     use std::str::FromStr;
     use std::sync::MutexGuard;
-    use db_common::async_sql_conn::AsyncConnection;
-    use futures::lock::Mutex as AsyncMutex;
 }
 
 /// Default interval to export and record metrics to log.
@@ -131,6 +131,7 @@ pub struct MmCtx {
     pub db_namespace: DbNamespaceId,
     /// The context belonging to the `nft` mod: `NftCtx`.
     pub nft_ctx: Mutex<Option<Arc<dyn Any + 'static + Send + Sync>>>,
+    /// asynchronous handle for rusqlite connection.
     #[cfg(not(target_arch = "wasm32"))]
     pub async_sqlite_connection: Constructible<Arc<AsyncMutex<AsyncConnection>>>,
 }

--- a/mm2src/mm2_core/src/mm_ctx.rs
+++ b/mm2src/mm2_core/src/mm_ctx.rs
@@ -112,8 +112,10 @@ pub struct MmCtx {
     /// The RPC sender forwarding requests to writing part of underlying stream.
     #[cfg(target_arch = "wasm32")]
     pub wasm_rpc: Constructible<WasmRpcSender>,
+    /// Deprecated, please use `async_sqlite_connection` for new implementations.
     #[cfg(not(target_arch = "wasm32"))]
     pub sqlite_connection: Constructible<Arc<Mutex<Connection>>>,
+    /// Deprecated, please use `async_sqlite_connection` for new implementations.
     #[cfg(not(target_arch = "wasm32"))]
     pub shared_sqlite_conn: Constructible<Arc<Mutex<Connection>>>,
     pub mm_version: String,

--- a/mm2src/mm2_core/src/mm_ctx.rs
+++ b/mm2src/mm2_core/src/mm_ctx.rs
@@ -318,10 +318,7 @@ impl MmCtx {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn init_sqlite_connection(&self) -> Result<(), String> {
         let sqlite_file_path = self.dbdir().join("MM2.db");
-        log::debug!(
-            "Trying to open SQLite database file {}",
-            try_s!(sqlite_file_path.canonicalize()).display()
-        );
+        log_sqlite_file_open_attempt(&sqlite_file_path);
         let connection = try_s!(Connection::open(sqlite_file_path));
         try_s!(self.sqlite_connection.pin(Arc::new(Mutex::new(connection))));
         Ok(())
@@ -330,10 +327,7 @@ impl MmCtx {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn init_shared_sqlite_conn(&self) -> Result<(), String> {
         let sqlite_file_path = self.shared_dbdir().join("MM2-shared.db");
-        log::debug!(
-            "Trying to open SQLite database file {}",
-            try_s!(sqlite_file_path.canonicalize()).display()
-        );
+        log_sqlite_file_open_attempt(&sqlite_file_path);
         let connection = try_s!(Connection::open(sqlite_file_path));
         try_s!(self.shared_sqlite_conn.pin(Arc::new(Mutex::new(connection))));
         Ok(())
@@ -342,10 +336,7 @@ impl MmCtx {
     #[cfg(not(target_arch = "wasm32"))]
     pub async fn init_async_sqlite_connection(&self) -> Result<(), String> {
         let sqlite_file_path = self.dbdir().join("KOMODEFI.db");
-        log::debug!(
-            "Trying to open SQLite database file {}",
-            try_s!(sqlite_file_path.canonicalize()).display()
-        );
+        log_sqlite_file_open_attempt(&sqlite_file_path);
         let async_conn = try_s!(AsyncConnection::open(sqlite_file_path).await);
         try_s!(self.async_sqlite_connection.pin(Arc::new(AsyncMutex::new(async_conn))));
         Ok(())
@@ -730,5 +721,17 @@ impl MmCtxBuilder {
         }
 
         MmArc::new(ctx)
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn log_sqlite_file_open_attempt(sqlite_file_path: &Path) {
+    match sqlite_file_path.canonicalize() {
+        Ok(absolute_path) => {
+            log::debug!("Trying to open SQLite database file {}", absolute_path.display());
+        },
+        Err(_) => {
+            log::debug!("Trying to open SQLite database file {}", sqlite_file_path.display());
+        },
     }
 }

--- a/mm2src/mm2_core/src/mm_ctx.rs
+++ b/mm2src/mm2_core/src/mm_ctx.rs
@@ -60,7 +60,6 @@ const EXPORT_METRICS_INTERVAL: f64 = 5. * 60.;
 /// Only the pointers (`MmArc`, `MmWeak`) can be moved around.
 ///
 /// Threads only have the non-`mut` access to `MmCtx`, allowing us to directly share certain fields.
-#[allow(dead_code)]
 pub struct MmCtx {
     /// MM command-line configuration.
     pub conf: Json,

--- a/mm2src/mm2_core/src/mm_ctx.rs
+++ b/mm2src/mm2_core/src/mm_ctx.rs
@@ -4,8 +4,6 @@ use common::executor::{abortable_queue::{AbortableQueue, WeakSpawner},
                        graceful_shutdown, AbortSettings, AbortableSystem, SpawnAbortable, SpawnFuture};
 use common::log::{self, LogLevel, LogOnError, LogState};
 use common::{cfg_native, cfg_wasm32, small_rng};
-#[cfg(not(target_arch = "wasm32"))]
-use db_common::async_sql_conn::AsyncConnection;
 use gstuff::{try_s, Constructible, ERR, ERRL};
 use lazy_static::lazy_static;
 use mm2_event_stream::{controller::Controller, Event, EventStreamConfiguration};
@@ -36,6 +34,8 @@ cfg_native! {
     use std::path::{Path, PathBuf};
     use std::str::FromStr;
     use std::sync::MutexGuard;
+    use db_common::async_sql_conn::AsyncConnection;
+    use futures::lock::Mutex as AsyncMutex;
 }
 
 /// Default interval to export and record metrics to log.
@@ -132,7 +132,7 @@ pub struct MmCtx {
     /// The context belonging to the `nft` mod: `NftCtx`.
     pub nft_ctx: Mutex<Option<Arc<dyn Any + 'static + Send + Sync>>>,
     #[cfg(not(target_arch = "wasm32"))]
-    pub async_sqlite_connection: Constructible<Arc<AsyncConnection>>,
+    pub async_sqlite_connection: Constructible<Arc<AsyncMutex<AsyncConnection>>>,
 }
 
 impl MmCtx {
@@ -336,7 +336,7 @@ impl MmCtx {
         let sqlite_file_path = self.dbdir().join("DB_ASYNC.db");
         log::debug!("Trying to open SQLite database file {}", sqlite_file_path.display());
         let async_conn = try_s!(AsyncConnection::open(sqlite_file_path).await);
-        try_s!(self.async_sqlite_connection.pin(Arc::new(async_conn)));
+        try_s!(self.async_sqlite_connection.pin(Arc::new(AsyncMutex::new(async_conn))));
         Ok(())
     }
 

--- a/mm2src/mm2_core/src/mm_ctx.rs
+++ b/mm2src/mm2_core/src/mm_ctx.rs
@@ -318,7 +318,10 @@ impl MmCtx {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn init_sqlite_connection(&self) -> Result<(), String> {
         let sqlite_file_path = self.dbdir().join("MM2.db");
-        log::debug!("Trying to open SQLite database file {}", sqlite_file_path.display());
+        log::debug!(
+            "Trying to open SQLite database file {}",
+            try_s!(sqlite_file_path.canonicalize()).display()
+        );
         let connection = try_s!(Connection::open(sqlite_file_path));
         try_s!(self.sqlite_connection.pin(Arc::new(Mutex::new(connection))));
         Ok(())
@@ -327,7 +330,10 @@ impl MmCtx {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn init_shared_sqlite_conn(&self) -> Result<(), String> {
         let sqlite_file_path = self.shared_dbdir().join("MM2-shared.db");
-        log::debug!("Trying to open SQLite database file {}", sqlite_file_path.display());
+        log::debug!(
+            "Trying to open SQLite database file {}",
+            try_s!(sqlite_file_path.canonicalize()).display()
+        );
         let connection = try_s!(Connection::open(sqlite_file_path));
         try_s!(self.shared_sqlite_conn.pin(Arc::new(Mutex::new(connection))));
         Ok(())
@@ -336,7 +342,10 @@ impl MmCtx {
     #[cfg(not(target_arch = "wasm32"))]
     pub async fn init_async_sqlite_connection(&self) -> Result<(), String> {
         let sqlite_file_path = self.dbdir().join("KOMODEFI.db");
-        log::debug!("Trying to open SQLite database file {}", sqlite_file_path.display());
+        log::debug!(
+            "Trying to open SQLite database file {}",
+            try_s!(sqlite_file_path.canonicalize()).display()
+        );
         let async_conn = try_s!(AsyncConnection::open(sqlite_file_path).await);
         try_s!(self.async_sqlite_connection.pin(Arc::new(AsyncMutex::new(async_conn))));
         Ok(())

--- a/mm2src/mm2_core/src/mm_ctx.rs
+++ b/mm2src/mm2_core/src/mm_ctx.rs
@@ -115,7 +115,7 @@ pub struct MmCtx {
     /// Deprecated, please use `async_sqlite_connection` for new implementations.
     #[cfg(not(target_arch = "wasm32"))]
     pub sqlite_connection: Constructible<Arc<Mutex<Connection>>>,
-    /// Deprecated, please use `async_sqlite_connection` for new implementations.
+    /// Deprecated, please create `shared_async_sqlite_conn` for new implementations and call db `KOMODEFI-shared.db`.
     #[cfg(not(target_arch = "wasm32"))]
     pub shared_sqlite_conn: Constructible<Arc<Mutex<Connection>>>,
     pub mm_version: String,
@@ -335,7 +335,7 @@ impl MmCtx {
 
     #[cfg(not(target_arch = "wasm32"))]
     pub async fn init_async_sqlite_connection(&self) -> Result<(), String> {
-        let sqlite_file_path = self.dbdir().join("DB_ASYNC.db");
+        let sqlite_file_path = self.dbdir().join("KOMODEFI.db");
         log::debug!("Trying to open SQLite database file {}", sqlite_file_path.display());
         let async_conn = try_s!(AsyncConnection::open(sqlite_file_path).await);
         try_s!(self.async_sqlite_connection.pin(Arc::new(AsyncMutex::new(async_conn))));

--- a/mm2src/mm2_main/src/lp_native_dex.rs
+++ b/mm2src/mm2_main/src/lp_native_dex.rs
@@ -423,6 +423,9 @@ pub async fn lp_init_continue(ctx: MmArc) -> MmInitResult<()> {
             .map_to_mm(MmInitError::ErrorSqliteInitializing)?;
         ctx.init_shared_sqlite_conn()
             .map_to_mm(MmInitError::ErrorSqliteInitializing)?;
+        ctx.init_async_sqlite_connection()
+            .await
+            .map_to_mm(MmInitError::ErrorSqliteInitializing)?;
         init_and_migrate_db(&ctx).await?;
         migrate_db(&ctx)?;
     }

--- a/mm2src/mm2_main/src/rpc/lp_commands/lp_commands_legacy.rs
+++ b/mm2src/mm2_main/src/rpc/lp_commands/lp_commands_legacy.rs
@@ -246,12 +246,26 @@ pub async fn my_balance(ctx: MmArc, req: Json) -> Result<Response<Vec<u8>>, Stri
     Ok(try_s!(Response::builder().body(res)))
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+async fn close_async_connection(ctx: &MmArc) {
+    if let Some(async_conn) = ctx.async_sqlite_connection.as_option() {
+        let mut conn = async_conn.lock().await;
+        if let Err(e) = conn.close().await {
+            error!("Error stopping AsyncConnection: {}", e);
+        }
+    }
+}
+
 pub async fn stop(ctx: MmArc) -> Result<Response<Vec<u8>>, String> {
     dispatch_lp_event(ctx.clone(), StopCtxEvent.into()).await;
     // Should delay the shutdown a bit in order not to trip the "stop" RPC call in unit tests.
     // Stopping immediately leads to the "stop" RPC call failing with the "errno 10054" sometimes.
     let fut = async move {
         Timer::sleep(0.05).await;
+
+        #[cfg(not(target_arch = "wasm32"))]
+        close_async_connection(&ctx).await;
+
         if let Err(e) = ctx.stop() {
             error!("Error stopping MmCtx: {}", e);
         }

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -907,6 +907,19 @@ pub fn mm_ctx_with_custom_db() -> MmArc {
     ctx
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+pub async fn mm_ctx_with_custom_async_db() -> MmArc {
+    use db_common::async_sql_conn::AsyncConnection;
+    use std::sync::Arc;
+
+    let ctx = MmCtxBuilder::new().into_mm_arc();
+
+    let connection = AsyncConnection::open_in_memory().await.unwrap();
+    let _ = ctx.async_sqlite_connection.pin(Arc::new(connection));
+
+    ctx
+}
+
 /// Automatically kill a wrapped process.
 pub struct RaiiKill {
     pub handle: Child,

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -910,12 +910,13 @@ pub fn mm_ctx_with_custom_db() -> MmArc {
 #[cfg(not(target_arch = "wasm32"))]
 pub async fn mm_ctx_with_custom_async_db() -> MmArc {
     use db_common::async_sql_conn::AsyncConnection;
+    use futures::lock::Mutex as AsyncMutex;
     use std::sync::Arc;
 
     let ctx = MmCtxBuilder::new().into_mm_arc();
 
     let connection = AsyncConnection::open_in_memory().await.unwrap();
-    let _ = ctx.async_sqlite_connection.pin(Arc::new(connection));
+    let _ = ctx.async_sqlite_connection.pin(Arc::new(AsyncMutex::new(connection)));
 
     ctx
 }


### PR DESCRIPTION
continuation of this [PR](https://github.com/KomodoPlatform/komodo-defi-framework/pull/1959).
solves [comment](https://github.com/KomodoPlatform/komodo-defi-framework/pull/1959#issuecomment-1718782560) and [issue](https://github.com/KomodoPlatform/komodo-defi-framework/issues/1943).

- `nft_cache_db` was added in `NftCtx` for non wasm target.
- [ Changelog of Async sqlite wrapper gist](https://gist.github.com/laruh/6f7fc778d0c53d7f91fb70e27968bff6)
- `AsyncConnection` structure was created in  `mm2src/db_common/src/async_sql_conn.rs`. It can be used as async wrapper for sqlite connection.
- `async_sqlite_connection` field was added in `MmCtx`.

### note:
According to [this](https://github.com/ethereum/go-ethereum/issues/22653#issuecomment-817871794)  `transaction_receipt(hash)` can return `None` for "old" transactions.
`transaction_receipt` should work fine for swaps, as we need info about the recently broadcasted transaction.

# deps added
`mm2src/db_common/Cargo.toml`
tokio = { version = "1.20", default-features = false, features = ["macros"] }
crossbeam-channel = "0.5.1"
futures = "0.3.1"