### PR TITLE
chore(containers and docs): update docs and container images

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -22,11 +22,6 @@ RUN \
     wget -O- https://sh.rustup.rs > /tmp/rustup-init.sh &&\
     sh /tmp/rustup-init.sh -y --default-toolchain none &&\
     . /root/.cargo/env &&\
-    rustup set profile minimal &&\
-    rustup install nightly-2020-02-01 &&\
-    rustup default nightly-2020-02-01 &&\
-    # It seems that bindgen won't prettify without it:
-    rustup component add rustfmt-preview &&\
     rm -f /tmp/rustup-init.sh
 
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,55 +1,52 @@
-# Happening in a well-defined setting the Docker builds should be somewhat
-# more reproducible than builds relying on the local workstation environment.
-# Hence we're going to use the Docker build as the reference one.
-# CI and local builds might be considered a second tier build optimizations.
-# 
-# docker build --tag mm2 .
+FROM docker.io/debian:buster-slim
 
-# NB: The version here was picked to match the one tested in our CI. The latest Travis has (as of 2018-11) is Xenial.
-FROM docker.io/ubuntu:xenial
+MAINTAINER Onur Özkan <onur@komodoplatform.com>
 
-RUN \
-    apt-get update &&\
-    apt-get install -y git build-essential libssl-dev wget &&\
-    apt-get install -y cmake &&\
-    # https://github.com/rust-lang/rust-bindgen/blob/master/book/src/requirements.md#debian-based-linuxes
-    apt-get install -y llvm-3.9-dev libclang-3.9-dev clang-3.9 lld &&\
-    # openssl-sys requirements, cf. https://crates.io/crates/openssl-sys
-    apt-get install -y pkg-config libssl-dev &&\
-    apt-get clean
+RUN apt-get update -y
 
-RUN \
-    wget -O- https://sh.rustup.rs > /tmp/rustup-init.sh &&\
-    sh /tmp/rustup-init.sh -y --default-toolchain none &&\
-    . /root/.cargo/env &&\
-    rm -f /tmp/rustup-init.sh
+RUN apt-get install -y 	\
+	build-essential 	\
+	cmake 			 	\
+    ca-certificates 	\
+    curl             	\
+    wget             	\
+    gnupg
 
-ENV PATH="/root/.cargo/bin:${PATH}"
+RUN ln -s /usr/bin/python3 /bin/python
 
-# First 7 characters of the commit ID.
-ENV MM_VERSION="f236ad1"
+RUN apt install -y  			\
+	software-properties-common 	\
+	lsb-release
 
-RUN cd /tmp &&\
-    wget https://api.github.com/repos/KomodoPlatform/atomicDEX-API/tarball/$MM_VERSION &&\
-    tar -xzf $MM_VERSION &&\
-    ls &&\
-    mv KomodoPlatform-atomicDEX-API-$MM_VERSION /mm2 &&\
-    rm $MM_VERSION &&\
-    echo $MM_VERSION > /mm2/MM_VERSION
+RUN curl --output llvm.sh https://apt.llvm.org/llvm.sh
 
-RUN cd /mm2 && cargo fetch
+RUN chmod +x llvm.sh
 
-# This will overwrite the Git version with the local one.
-# Only needed when we're developing or changing something locally.
-#COPY . /mm2
+RUN ./llvm.sh 16
 
-# Build MM1 and MM2.
-# Increased verbosity here allows us to see the MM1 CMake logs.
-RUN cd /mm2 &&\
-    cargo build -vv &&\
-    mv target/debug/mm2 /usr/local/bin/marketmaker-mainnet &&\
-    # We currently need BOB_PASSPHRASE, BOB_USERPASS, ALICE_PASSPHRASE and ALICE_USERPASS for the tests…
-    #cargo test &&\
-    cargo clean
+RUN rm ./llvm.sh
 
-CMD marketmaker-testnet
+RUN ln -s /usr/bin/clang-16 /usr/bin/clang
+
+ENV AR=/usr/bin/llvm-ar-16
+ENV CC=/usr/bin/clang-16
+
+RUN mkdir -m 0755 -p /etc/apt/keyrings
+
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+RUN echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+RUN apt-get update -y
+
+RUN apt-get install -y 	  \
+	docker-ce 			  \
+	docker-ce-cli 		  \
+	containerd.io 		  \
+	docker-buildx-plugin
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+ENV PATH="/root/.cargo/bin:$PATH"

--- a/.docker/Dockerfile.ci-container
+++ b/.docker/Dockerfile.ci-container
@@ -23,7 +23,7 @@ RUN apt install -y  			\
 	lsb-release 				\
 	gnupg
 
-RUN wget https://apt.llvm.org/llvm.sh
+RUN curl --output llvm.sh https://apt.llvm.org/llvm.sh
 
 RUN chmod +x llvm.sh
 
@@ -53,3 +53,5 @@ RUN apt-get install -y 	  \
 	docker-buildx-plugin
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+ENV PATH="/root/.cargo/bin:$PATH"

--- a/.docker/Dockerfile.ubuntu.ci
+++ b/.docker/Dockerfile.ubuntu.ci
@@ -14,11 +14,6 @@ RUN \
     wget -O- https://sh.rustup.rs > /tmp/rustup-init.sh &&\
     sh /tmp/rustup-init.sh -y --default-toolchain none &&\
     . /root/.cargo/env &&\
-    rustup set profile minimal &&\
-    rustup install nightly-2021-07-18 &&\
-    rustup default nightly-2021-07-18 &&\
-    # It seems that bindgen won't prettify without it:
-    rustup component add rustfmt-preview &&\
     rm -f /tmp/rustup-init.sh &&\
     chmod -R 777 /root
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ For a curated list of Komodo DeFi Framework based projects and resources, check 
 
 ## Building from source
 
+### On Host System:
+
 [Pre-built release binaries](https://developers.komodoplatform.com/basic-docs/atomicdex/atomicdex-setup/get-started-atomicdex.html) are available for OSX, Linux or Windows.
 
 If you want to build from source, the following prerequisites are required:
@@ -86,6 +88,24 @@ If you want to build from source, the following prerequisites are required:
 To build, run `cargo build` (or `cargo build -vv` to get verbose build output).
 
 For more detailed instructions, please refer to the [Installation Guide](https://developers.komodoplatform.com/basic-docs/atomicdex/atomicdex-setup/get-started-atomicdex.html).
+
+### From Container:
+
+If you want to build from source without installing prerequisites to your host system, you can do so by binding the source code inside a container and compiling it there.
+
+Build the image:
+
+```sh
+docker build -t mm2-build-container -f .docker/Dockerfile .
+```
+
+Bind source code into container and compile it:
+
+```sh
+docker run -v "$(pwd)":/app -w /app mm2-build-container cargo build
+```
+
+Just like building it on your host system, you will now have the target directory containing the build files.
 
 ## Building WASM binary
 

--- a/README.md
+++ b/README.md
@@ -82,12 +82,6 @@ If you want to build from source, the following prerequisites are required:
 - (Optional) OSX: run `LIBRARY_PATH=/usr/local/opt/openssl/lib`
 - (Optional) Linux: Install libudev-dev (dpkg) or libudev-devel (rpm) package.
 - [Download](https://github.com/protocolbuffers/protobuf/releases) or [compile](https://github.com/protocolbuffers/protobuf) `protoc 3.21.x+` and add it to your PATH env. It is also available via package managers depending on the OS.
-- Additional Rust Components
-    ```
-    rustup install nightly-2022-10-29
-    rustup default nightly-2022-10-29
-    rustup component add rustfmt-preview
-    ```
 
 To build, run `cargo build` (or `cargo build -vv` to get verbose build output).
 

--- a/docs/RASPBERRY_PI4_CROSS.md
+++ b/docs/RASPBERRY_PI4_CROSS.md
@@ -1,9 +1,4 @@
-1. Install latest nightly toolchain and make it default:
-```
-rustup install nightly
-rustup default nightly
-```
-2. Install cross: `cargo install cross`.
-3. Build the Docker image for cross compilation: `docker build -f .docker/Dockerfile.armv7-unknown-linux-gnueabihf -t mm2-armv7-unknown-linux-gnueabihf .`
-4. Build mm2: `cross build --target armv7-unknown-linux-gnueabihf` or `cross build --target armv7-unknown-linux-gnueabihf --release` for release build.
-5. The binary path will be `target/armv7-unknown-linux-gnueabihf/debug/mm2` or `target/armv7-unknown-linux-gnueabihf/release/mm2` for release build.   
+1. Install cross: `cargo install cross`.
+2. Build the Docker image for cross compilation: `docker build -f .docker/Dockerfile.armv7-unknown-linux-gnueabihf -t mm2-armv7-unknown-linux-gnueabihf .`
+3. Build mm2: `cross build --target armv7-unknown-linux-gnueabihf` or `cross build --target armv7-unknown-linux-gnueabihf --release` for release build.
+4. The binary path will be `target/armv7-unknown-linux-gnueabihf/debug/mm2` or `target/armv7-unknown-linux-gnueabihf/release/mm2` for release build.   


### PR DESCRIPTION
This PR aims:

- to remove unnecessary informations from the documentations.
- to avoid manual toolchain installations in container images (rustup can handle this already with `rust-toolchain.toml`).
- to add new guideline about compiling source from container under `Building from source` topic.