### PR TITLE
chore(network): exclude `168.119.236.249` from the seednode list

### DIFF
--- a/mm2src/mm2_p2p/src/network.rs
+++ b/mm2src/mm2_p2p/src/network.rs
@@ -26,10 +26,11 @@ const ALL_DEFAULT_NETID_SEEDNODES: &[(&str, &str)] = &[
         "12D3KooWHBeCnJdzNk51G4mLnao9cDsjuqiMTEo5wMFXrd25bd1F",
         "168.119.236.243",
     ),
-    (
-        "12D3KooWKxavLCJVrQ5Gk1kd9m6cohctGQBmiKPS9XQFoXEoyGmS",
-        "168.119.236.249",
-    ),
+    // TODO: Uncomment this once re-enabled on the main network.
+    // (
+    //     "12D3KooWKxavLCJVrQ5Gk1kd9m6cohctGQBmiKPS9XQFoXEoyGmS",
+    //     "168.119.236.249",
+    // ),
     (
         "12D3KooW9soGyPfX6kcyh3uVXNHq1y2dPmQNt2veKgdLXkBiCVKq",
         "168.119.236.246",


### PR DESCRIPTION
self-explanatory

blocker for https://github.com/KomodoPlatform/komodo-defi-framework/pull/1968