### PR TITLE
deps(network): sync with upstream yamux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3433,7 +3433,7 @@ checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 [[package]]
 name = "libp2p"
 version = "0.52.1"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.1#e7c2fd1ef9d20cc4d29768b0a422a0f0ac9df82d"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.2#15dd3a3c32b1d9b393cbb108f479675cacf71b99"
 dependencies = [
  "bytes 1.4.0",
  "futures 0.3.28",
@@ -3465,7 +3465,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.2.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.1#e7c2fd1ef9d20cc4d29768b0a422a0f0ac9df82d"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.2#15dd3a3c32b1d9b393cbb108f479675cacf71b99"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -3476,7 +3476,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.2.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.1#e7c2fd1ef9d20cc4d29768b0a422a0f0ac9df82d"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.2#15dd3a3c32b1d9b393cbb108f479675cacf71b99"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -3487,7 +3487,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.40.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.1#e7c2fd1ef9d20cc4d29768b0a422a0f0ac9df82d"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.2#15dd3a3c32b1d9b393cbb108f479675cacf71b99"
 dependencies = [
  "either",
  "fnv",
@@ -3514,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.40.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.1#e7c2fd1ef9d20cc4d29768b0a422a0f0ac9df82d"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.2#15dd3a3c32b1d9b393cbb108f479675cacf71b99"
 dependencies = [
  "futures 0.3.28",
  "libp2p-core",
@@ -3528,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.43.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.1#e7c2fd1ef9d20cc4d29768b0a422a0f0ac9df82d"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.2#15dd3a3c32b1d9b393cbb108f479675cacf71b99"
 dependencies = [
  "asynchronous-codec",
  "cuckoofilter",
@@ -3548,7 +3548,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.45.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.1#e7c2fd1ef9d20cc4d29768b0a422a0f0ac9df82d"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.2#15dd3a3c32b1d9b393cbb108f479675cacf71b99"
 dependencies = [
  "asynchronous-codec",
  "base64 0.21.2",
@@ -3579,7 +3579,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.43.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.1#e7c2fd1ef9d20cc4d29768b0a422a0f0ac9df82d"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.2#15dd3a3c32b1d9b393cbb108f479675cacf71b99"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -3619,7 +3619,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.44.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.1#e7c2fd1ef9d20cc4d29768b0a422a0f0ac9df82d"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.2#15dd3a3c32b1d9b393cbb108f479675cacf71b99"
 dependencies = [
  "data-encoding",
  "futures 0.3.28",
@@ -3639,7 +3639,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.13.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.1#e7c2fd1ef9d20cc4d29768b0a422a0f0ac9df82d"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.2#15dd3a3c32b1d9b393cbb108f479675cacf71b99"
 dependencies = [
  "instant",
  "libp2p-core",
@@ -3655,7 +3655,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.43.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.1#e7c2fd1ef9d20cc4d29768b0a422a0f0ac9df82d"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.2#15dd3a3c32b1d9b393cbb108f479675cacf71b99"
 dependencies = [
  "bytes 1.4.0",
  "curve25519-dalek 3.2.0",
@@ -3679,7 +3679,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.43.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.1#e7c2fd1ef9d20cc4d29768b0a422a0f0ac9df82d"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.2#15dd3a3c32b1d9b393cbb108f479675cacf71b99"
 dependencies = [
  "either",
  "futures 0.3.28",
@@ -3696,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.25.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.1#e7c2fd1ef9d20cc4d29768b0a422a0f0ac9df82d"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.2#15dd3a3c32b1d9b393cbb108f479675cacf71b99"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -3713,7 +3713,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.43.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.1#e7c2fd1ef9d20cc4d29768b0a422a0f0ac9df82d"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.2#15dd3a3c32b1d9b393cbb108f479675cacf71b99"
 dependencies = [
  "either",
  "fnv",
@@ -3735,7 +3735,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.33.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.1#e7c2fd1ef9d20cc4d29768b0a422a0f0ac9df82d"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.2#15dd3a3c32b1d9b393cbb108f479675cacf71b99"
 dependencies = [
  "heck",
  "proc-macro-warning",
@@ -3747,7 +3747,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.40.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.1#e7c2fd1ef9d20cc4d29768b0a422a0f0ac9df82d"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.2#15dd3a3c32b1d9b393cbb108f479675cacf71b99"
 dependencies = [
  "futures 0.3.28",
  "futures-timer",
@@ -3763,7 +3763,7 @@ dependencies = [
 [[package]]
 name = "libp2p-wasm-ext"
 version = "0.40.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.1#e7c2fd1ef9d20cc4d29768b0a422a0f0ac9df82d"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.2#15dd3a3c32b1d9b393cbb108f479675cacf71b99"
 dependencies = [
  "futures 0.3.28",
  "js-sys",
@@ -3776,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.42.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.1#e7c2fd1ef9d20cc4d29768b0a422a0f0ac9df82d"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.2#15dd3a3c32b1d9b393cbb108f479675cacf71b99"
 dependencies = [
  "either",
  "futures 0.3.28",
@@ -3795,13 +3795,15 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.44.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.1#e7c2fd1ef9d20cc4d29768b0a422a0f0ac9df82d"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.2#15dd3a3c32b1d9b393cbb108f479675cacf71b99"
 dependencies = [
+ "either",
  "futures 0.3.28",
  "libp2p-core",
- "log",
  "thiserror",
- "yamux",
+ "tracing",
+ "yamux 0.12.1",
+ "yamux 0.13.1",
 ]
 
 [[package]]
@@ -4740,7 +4742,7 @@ checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.1#e7c2fd1ef9d20cc4d29768b0a422a0f0ac9df82d"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.2#15dd3a3c32b1d9b393cbb108f479675cacf71b99"
 dependencies = [
  "bytes 1.4.0",
  "futures 0.3.28",
@@ -5627,7 +5629,7 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.2.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.1#e7c2fd1ef9d20cc4d29768b0a422a0f0ac9df82d"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.2#15dd3a3c32b1d9b393cbb108f479675cacf71b99"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.4.0",
@@ -6379,7 +6381,7 @@ checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.1#e7c2fd1ef9d20cc4d29768b0a422a0f0ac9df82d"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.2#15dd3a3c32b1d9b393cbb108f479675cacf71b99"
 dependencies = [
  "futures 0.3.28",
  "pin-project",
@@ -9411,14 +9413,31 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.10.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0608f53c1dc0bad505d03a34bbd49fbf2ad7b51eb036123e896365532745a1"
+checksum = "9ed0164ae619f2dc144909a9f082187ebb5893693d8c0196e8085283ccd4b776"
 dependencies = [
  "futures 0.3.28",
  "log",
  "nohash-hasher",
  "parking_lot 0.12.0",
+ "pin-project",
+ "rand 0.8.4",
+ "static_assertions",
+]
+
+[[package]]
+name = "yamux"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1d0148b89300047e72994bee99ecdabd15a9166a7b70c8b8c37c314dcc9002"
+dependencies = [
+ "futures 0.3.28",
+ "instant",
+ "log",
+ "nohash-hasher",
+ "parking_lot 0.12.0",
+ "pin-project",
  "rand 0.8.4",
  "static_assertions",
 ]

--- a/mm2src/mm2_p2p/Cargo.toml
+++ b/mm2src/mm2_p2p/Cargo.toml
@@ -29,12 +29,12 @@ void = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 instant = "0.1.12"
-libp2p = { git = "https://github.com/KomodoPlatform/rust-libp2p.git", tag = "k-0.52.1", default-features = false, features = ["dns", "identify", "floodsub", "gossipsub", "noise", "ping", "request-response", "secp256k1", "tcp", "tokio", "websocket", "macros", "yamux"] }
+libp2p = { git = "https://github.com/KomodoPlatform/rust-libp2p.git", tag = "k-0.52.2", default-features = false, features = ["dns", "identify", "floodsub", "gossipsub", "noise", "ping", "request-response", "secp256k1", "tcp", "tokio", "websocket", "macros", "yamux"] }
 tokio = { version = "1.20",  default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 instant = { version = "0.1.12", features = ["wasm-bindgen"] }
-libp2p = { git = "https://github.com/KomodoPlatform/rust-libp2p.git", tag = "k-0.52.1", default-features = false, features = ["identify", "floodsub", "noise", "gossipsub", "ping", "request-response", "secp256k1", "wasm-ext", "wasm-ext-websocket", "macros", "yamux"] }
+libp2p = { git = "https://github.com/KomodoPlatform/rust-libp2p.git", tag = "k-0.52.2", default-features = false, features = ["identify", "floodsub", "noise", "gossipsub", "ping", "request-response", "secp256k1", "wasm-ext", "wasm-ext-websocket", "macros", "yamux"] }
 
 [dev-dependencies]
 async-std = "1.6.2"

--- a/mm2src/mm2_p2p/src/behaviours/peers_exchange.rs
+++ b/mm2src/mm2_p2p/src/behaviours/peers_exchange.rs
@@ -49,12 +49,14 @@ impl<'de> Deserialize<'de> for PeerIdSerde {
 #[derive(Debug, Clone)]
 pub enum PeersExchangeProtocol {
     Version1,
+    Version2,
 }
 
 impl AsRef<str> for PeersExchangeProtocol {
     fn as_ref(&self) -> &str {
         match self {
             PeersExchangeProtocol::Version1 => "/peers-exchange/1",
+            PeersExchangeProtocol::Version2 => "/peers-exchange/2",
         }
     }
 }
@@ -205,7 +207,8 @@ impl NetworkBehaviour for PeersExchange {
 #[allow(clippy::new_without_default)]
 impl PeersExchange {
     pub fn new(network_info: NetworkInfo) -> Self {
-        let protocol = iter::once((PeersExchangeProtocol::Version1, ProtocolSupport::Full));
+        // We don't want to support V1 since it was only used in 7777 old layer.
+        let protocol = iter::once((PeersExchangeProtocol::Version2, ProtocolSupport::Full));
         let config = RequestResponseConfig::default();
         let request_response = RequestResponse::new(protocol, config);
         PeersExchange {

--- a/mm2src/mm2_p2p/src/behaviours/request_response.rs
+++ b/mm2src/mm2_p2p/src/behaviours/request_response.rs
@@ -63,12 +63,14 @@ struct PendingRequest {
 #[derive(Debug, Clone)]
 pub enum Protocol {
     Version1,
+    Version2,
 }
 
 impl AsRef<str> for Protocol {
     fn as_ref(&self) -> &str {
         match self {
             Protocol::Version1 => "/request-response/1",
+            Protocol::Version2 => "/request-response/2",
         }
     }
 }
@@ -393,7 +395,8 @@ impl From<libp2p::request_response::Event<PeerRequest, PeerResponse>> for Reques
 /// Build a request-response network behaviour.
 pub fn build_request_response_behaviour() -> RequestResponseBehaviour {
     let config = RequestResponseConfig::default();
-    let protocol = core::iter::once((Protocol::Version1, ProtocolSupport::Full));
+    // We don't want to support V1 since it was only used in 7777 old layer.
+    let protocol = core::iter::once((Protocol::Version2, ProtocolSupport::Full));
     let inner = RequestResponse::new(protocol, config);
 
     let (tx, rx) = mpsc::unbounded();


### PR DESCRIPTION
From https://github.com/KomodoPlatform/rust-libp2p/blob/port-from-old-impl/muxers/yamux/CHANGELOG.md

> yamux v0.13 enables auto-tuning for the Yamux stream receive window. While preserving small buffers on low-latency and/or low-bandwidth connections, this change allows for high-latency and/or high-bandwidth connections to exhaust the available bandwidth on a single stream. Have libp2p-yamux use yamux v0.13 (new version) by default and fall back to yamux v0.12 (old version) when setting any configuration options. Thus default users benefit from the increased performance, while power users with custom configurations maintain the old behavior. libp2p-yamux will switch over to yamux v0.13 entirely with the next breaking release. See https://github.com/libp2p/rust-libp2p/pull/4970.

Additionally, increases the backpressure buffer cap from 25 to 256.

This shouldn't cause any breaking change, but would be nice to release with #1968 and use this version in all seednodes.