### PR TITLE
fix(price_endpoints): add cached url

### DIFF
--- a/mm2src/coins/lp_price.rs
+++ b/mm2src/coins/lp_price.rs
@@ -13,7 +13,7 @@ use std::str::Utf8Error;
 const PRICE_ENDPOINTS: [&str; 3] = [
     "https://prices.komodian.info/api/v2/tickers",
     "https://prices.cipig.net:1717/api/v2/tickers",
-    "https://defi-stats.komodo.earth/api/v3/prices/tickers_v2"
+    "https://defi-stats.komodo.earth/api/v3/prices/tickers_v2",
 ];
 
 #[derive(Debug)]

--- a/mm2src/coins/lp_price.rs
+++ b/mm2src/coins/lp_price.rs
@@ -10,9 +10,10 @@ use std::collections::HashMap;
 #[cfg(feature = "run-docker-tests")] use std::str::FromStr;
 use std::str::Utf8Error;
 
-const PRICE_ENDPOINTS: [&str; 2] = [
+const PRICE_ENDPOINTS: [&str; 3] = [
     "https://prices.komodian.info/api/v2/tickers",
     "https://prices.cipig.net:1717/api/v2/tickers",
+    "https://defi-stats.komodo.earth/api/v3/prices/tickers_v2"
 ];
 
 #[derive(Debug)]


### PR DESCRIPTION
The current urls sometimes become rate limited, especially when testing across a few instances of mm2 at the same time.
I've added an additional `PRICE_ENDPOINTS` url which is a cached copy of https://prices.komodian.info/api/v2/tickers, updated every minute. This should sever as a reliable fallback when rate limiting becomes an issue.
