### PR TITLE
chore(network): write network information to stdout

### DIFF
--- a/mm2src/mm2_p2p/src/behaviours/atomicdex.rs
+++ b/mm2src/mm2_p2p/src/behaviours/atomicdex.rs
@@ -600,6 +600,8 @@ fn start_gossipsub(
     let noise_config = noise::Config::new(&local_key).expect("Signing libp2p-noise static DH keypair failed.");
 
     let network_info = node_type.to_network_info();
+    info!("Network information: {:?}", network_info);
+
     let transport = match network_info {
         NetworkInfo::InMemory => build_memory_transport(noise_config),
         NetworkInfo::Distributed { .. } => build_dns_ws_transport(noise_config, node_type.wss_certs()),

--- a/mm2src/mm2_p2p/src/lib.rs
+++ b/mm2src/mm2_p2p/src/lib.rs
@@ -41,7 +41,7 @@ lazy_static! {
     static ref SECP_SIGN: Secp256k1<SignOnly> = Secp256k1::signing_only();
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum NetworkInfo {
     /// The in-memory network.
     InMemory,
@@ -53,7 +53,7 @@ impl NetworkInfo {
     pub fn in_memory(&self) -> bool { matches!(self, NetworkInfo::InMemory) }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct NetworkPorts {
     pub tcp: u16,
     pub wss: u16,


### PR DESCRIPTION
This should be useful as not requiring to find the mm2 ports on the operating system.

cc @smk762 