### PR TITLE
feat(stats_swaps): add gui version in status db

### DIFF
--- a/mm2src/mm2_main/src/database.rs
+++ b/mm2src/mm2_main/src/database.rs
@@ -109,6 +109,10 @@ async fn migration_10(ctx: &MmArc) -> Vec<(&'static str, Vec<String>)> {
     set_is_finished_for_legacy_swaps_statements(ctx).await
 }
 
+fn migration_11() -> Vec<(&'static str, Vec<String>)> {
+    db_common::sqlite::execute_batch(stats_swaps::ADD_MAKER_TAKER_GUI_AND_VERSION)
+}
+
 async fn statements_for_migration(ctx: &MmArc, current_migration: i64) -> Option<Vec<(&'static str, Vec<String>)>> {
     match current_migration {
         1 => Some(migration_1(ctx).await),
@@ -121,6 +125,7 @@ async fn statements_for_migration(ctx: &MmArc, current_migration: i64) -> Option
         8 => Some(migration_8()),
         9 => Some(migration_9()),
         10 => Some(migration_10(ctx).await),
+        11 => Some(migration_11()),
         _ => None,
     }
 }


### PR DESCRIPTION
This PR aims to store the `gui` and `mm_version` data in the `stats_swaps` table.

Since `gui` and `mm_version` isn't communicated in swap messages, we only store *our* gui and version.
Seed nodes are able to store both maker and taker's gui and version since they get both.

fixes #2047 