### PR TITLE
feat(event streaming): configurable worker path, use SharedWorker

### DIFF
--- a/mm2src/mm2_event_stream/src/lib.rs
+++ b/mm2src/mm2_event_stream/src/lib.rs
@@ -34,6 +34,7 @@ pub struct EventStreamConfiguration {
     pub access_control_allow_origin: String,
     #[serde(default)]
     active_events: HashMap<String, EventConfig>,
+    pub worker_path: Option<String>,
 }
 
 /// Represents the configuration for a specific event within the event stream.
@@ -51,6 +52,7 @@ impl Default for EventStreamConfiguration {
         Self {
             access_control_allow_origin: String::from("*"),
             active_events: Default::default(),
+            worker_path: None,
         }
     }
 }

--- a/mm2src/mm2_event_stream/src/lib.rs
+++ b/mm2src/mm2_event_stream/src/lib.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 #[cfg(target_arch = "wasm32")] use std::path::PathBuf;
 
 #[cfg(target_arch = "wasm32")]
-const DEFAULT_WORKER_PATH: &str = "worker.js";
+const DEFAULT_WORKER_PATH: &str = "event_streaming_worker.js";
 
 /// Multi-purpose/generic event type that can easily be used over the event streaming
 pub struct Event {

--- a/mm2src/mm2_event_stream/src/lib.rs
+++ b/mm2src/mm2_event_stream/src/lib.rs
@@ -40,8 +40,13 @@ pub struct EventStreamConfiguration {
     active_events: HashMap<String, EventConfig>,
     /// The path to the worker script for event streaming.
     #[cfg(target_arch = "wasm32")]
+    #[serde(default = "default_worker_path")]
     pub worker_path: PathBuf,
 }
+
+#[cfg(target_arch = "wasm32")]
+#[inline]
+fn default_worker_path() -> PathBuf { PathBuf::from(DEFAULT_WORKER_PATH) }
 
 /// Represents the configuration for a specific event within the event stream.
 #[derive(Clone, Default, Deserialize)]
@@ -59,7 +64,7 @@ impl Default for EventStreamConfiguration {
             access_control_allow_origin: String::from("*"),
             active_events: Default::default(),
             #[cfg(target_arch = "wasm32")]
-            worker_path: PathBuf::from(DEFAULT_WORKER_PATH),
+            worker_path: default_worker_path(),
         }
     }
 }

--- a/mm2src/mm2_event_stream/src/lib.rs
+++ b/mm2src/mm2_event_stream/src/lib.rs
@@ -38,6 +38,7 @@ pub struct EventStreamConfiguration {
     pub access_control_allow_origin: String,
     #[serde(default)]
     active_events: HashMap<String, EventConfig>,
+    /// The path to the worker script for event streaming.
     #[cfg(target_arch = "wasm32")]
     pub worker_path: PathBuf,
 }

--- a/mm2src/mm2_event_stream/src/lib.rs
+++ b/mm2src/mm2_event_stream/src/lib.rs
@@ -1,5 +1,9 @@
 use serde::Deserialize;
 use std::collections::HashMap;
+#[cfg(target_arch = "wasm32")] use std::path::PathBuf;
+
+#[cfg(target_arch = "wasm32")]
+const DEFAULT_WORKER_PATH: &str = "worker.js";
 
 /// Multi-purpose/generic event type that can easily be used over the event streaming
 pub struct Event {
@@ -34,7 +38,8 @@ pub struct EventStreamConfiguration {
     pub access_control_allow_origin: String,
     #[serde(default)]
     active_events: HashMap<String, EventConfig>,
-    pub worker_path: Option<String>,
+    #[cfg(target_arch = "wasm32")]
+    pub worker_path: PathBuf,
 }
 
 /// Represents the configuration for a specific event within the event stream.
@@ -52,7 +57,8 @@ impl Default for EventStreamConfiguration {
         Self {
             access_control_allow_origin: String::from("*"),
             active_events: Default::default(),
-            worker_path: None,
+            #[cfg(target_arch = "wasm32")]
+            worker_path: PathBuf::from(DEFAULT_WORKER_PATH),
         }
     }
 }

--- a/mm2src/mm2_net/Cargo.toml
+++ b/mm2src/mm2_net/Cargo.toml
@@ -49,7 +49,7 @@ wasm-bindgen-futures = "0.4.21"
 web-sys = { version = "0.3.55", features = ["console", "CloseEvent", "DomException", "ErrorEvent", "IdbDatabase",
     "IdbCursor", "IdbCursorWithValue", "IdbFactory", "IdbIndex", "IdbIndexParameters", "IdbObjectStore",
     "IdbObjectStoreParameters", "IdbOpenDbRequest", "IdbKeyRange", "IdbTransaction", "IdbTransactionMode",
-    "IdbVersionChangeEvent", "MessageEvent", "ReadableStreamDefaultReader", "ReadableStream", "WebSocket", "Worker"] }
+    "IdbVersionChangeEvent", "MessageEvent", "MessagePort", "ReadableStreamDefaultReader", "ReadableStream", "SharedWorker", "WebSocket"] }
 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/mm2src/mm2_net/src/wasm_event_stream.rs
+++ b/mm2src/mm2_net/src/wasm_event_stream.rs
@@ -21,7 +21,7 @@ pub async fn handle_worker_stream(ctx: MmArc) {
             .worker_path
             .to_str()
             .expect("worker_path contains invalid UTF-8 characters");
-        let worker = web_sys::Worker::new(worker_path).expect(&format!("Missing {}", worker_path));
+        let worker = web_sys::Worker::new(worker_path).unwrap_or_else(|_| panic!("Missing {}", worker_path));
         let message_js = wasm_bindgen::JsValue::from_str(&data.to_string());
 
         worker.post_message(&message_js)

--- a/mm2src/mm2_net/src/wasm_event_stream.rs
+++ b/mm2src/mm2_net/src/wasm_event_stream.rs
@@ -17,7 +17,8 @@ pub async fn handle_worker_stream(ctx: MmArc) {
             "message": event.message(),
         });
 
-        let worker = web_sys::Worker::new("worker.js").expect("Missing worker.js");
+        let script_url = ctx.conf["worker"].as_str().unwrap_or_else(|| "worker.js");
+        let worker = web_sys::Worker::new(script_url).expect("Missing worker.js");
         let message_js = wasm_bindgen::JsValue::from_str(&data.to_string());
 
         worker.post_message(&message_js)

--- a/mm2src/mm2_net/src/wasm_event_stream.rs
+++ b/mm2src/mm2_net/src/wasm_event_stream.rs
@@ -1,8 +1,6 @@
 use mm2_core::mm_ctx::MmArc;
 use serde_json::json;
 
-const DEFAULT_WORKER_PATH: &str = "worker.js";
-
 /// Handles broadcasted messages from `mm2_event_stream` continuously for WASM.
 pub async fn handle_worker_stream(ctx: MmArc) {
     let config = ctx
@@ -19,7 +17,10 @@ pub async fn handle_worker_stream(ctx: MmArc) {
             "message": event.message(),
         });
 
-        let worker_path = config.worker_path.as_deref().unwrap_or(DEFAULT_WORKER_PATH);
+        let worker_path = config
+            .worker_path
+            .to_str()
+            .expect("worker_path contains invalid UTF-8 characters");
         let worker = web_sys::Worker::new(worker_path).expect(&format!("Missing {}", worker_path));
         let message_js = wasm_bindgen::JsValue::from_str(&data.to_string());
 

--- a/mm2src/mm2_net/src/wasm_event_stream.rs
+++ b/mm2src/mm2_net/src/wasm_event_stream.rs
@@ -20,7 +20,7 @@ pub async fn handle_worker_stream(ctx: MmArc) {
         });
 
         let worker_path = config.worker_path.as_deref().unwrap_or(DEFAULT_WORKER_PATH);
-        let worker = web_sys::Worker::new(worker_path).expect("Missing worker.js");
+        let worker = web_sys::Worker::new(worker_path).expect(&format!("Missing {}", worker_path));
         let message_js = wasm_bindgen::JsValue::from_str(&data.to_string());
 
         worker.post_message(&message_js)

--- a/mm2src/mm2_net/src/wasm_event_stream.rs
+++ b/mm2src/mm2_net/src/wasm_event_stream.rs
@@ -17,7 +17,7 @@ pub async fn handle_worker_stream(ctx: MmArc) {
             "message": event.message(),
         });
 
-        let script_url = ctx.conf["worker"].as_str().unwrap_or_else(|| "worker.js");
+        let script_url = ctx.conf["worker"].as_str().unwrap_or("worker.js");
         let worker = web_sys::Worker::new(script_url).expect("Missing worker.js");
         let message_js = wasm_bindgen::JsValue::from_str(&data.to_string());
 

--- a/mm2src/mm2_net/src/wasm_event_stream.rs
+++ b/mm2src/mm2_net/src/wasm_event_stream.rs
@@ -38,6 +38,6 @@ pub async fn handle_worker_stream(ctx: MmArc) {
         let message_js = wasm_bindgen::JsValue::from_str(&data.to_string());
 
         port.0.post_message(&message_js)
-            .expect("Incompatible browser!\nSee https://developer.mozilla.org/en-US/docs/Web/API/Worker/postMessage#browser_compatibility for details.");
+            .expect("Incompatible browser!\nSee https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/postMessage#browser_compatibility for details.");
     }
 }

--- a/mm2src/mm2_net/src/wasm_event_stream.rs
+++ b/mm2src/mm2_net/src/wasm_event_stream.rs
@@ -1,6 +1,8 @@
 use mm2_core::mm_ctx::MmArc;
 use serde_json::json;
 
+const DEFAULT_WORKER_PATH: &str = "worker.js";
+
 /// Handles broadcasted messages from `mm2_event_stream` continuously for WASM.
 pub async fn handle_worker_stream(ctx: MmArc) {
     let config = ctx
@@ -17,8 +19,8 @@ pub async fn handle_worker_stream(ctx: MmArc) {
             "message": event.message(),
         });
 
-        let script_url = ctx.conf["worker"].as_str().unwrap_or("worker.js");
-        let worker = web_sys::Worker::new(script_url).expect("Missing worker.js");
+        let worker_path = config.worker_path.as_deref().unwrap_or(DEFAULT_WORKER_PATH);
+        let worker = web_sys::Worker::new(worker_path).expect("Missing worker.js");
         let message_js = wasm_bindgen::JsValue::from_str(&data.to_string());
 
         worker.post_message(&message_js)


### PR DESCRIPTION
This PR allows any worker path to be used instead of hardcoded `worker.js` file. The worker path can be specified using `worker_path` in `event_stream_configuration`,  if not specified `worker.js` will be used as default. Example:
```json
"event_stream_configuration": {
    "access_control_allow_origin": "*",
    "active_events": {
      "NETWORK": { "stream_interval_seconds": 1.5 }
    },
    "worker_path": "index.js" // This can be added in wasm only configuration
}