### PR TITLE
deps(zcoin): use librustzcash that uses the same `aes` version as mm2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,16 +644,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-modes"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb03d1bed155d89dce0f845b7899b18a9a163e148fd004e1c28421a783e2d8e"
-dependencies = [
- "block-padding 0.2.1",
- "cipher 0.3.0",
-]
-
-[[package]]
 name = "block-padding"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2160,7 +2150,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.1.0"
-source = "git+https://github.com/KomodoPlatform/librustzcash.git?tag=k-1.4.0#debae777f20f5b5fd263e26877258f7600b52cab"
+source = "git+https://github.com/KomodoPlatform/librustzcash.git?branch=bump-aes-version#5fb4721abace3a31aaa8ad2b6da48073d6f31560"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -2451,12 +2441,12 @@ dependencies = [
 
 [[package]]
 name = "fpe"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd910db5f9ca4dc3116f8c46367825807aa2b942f72565f16b4be0b208a00a9e"
+checksum = "26c4b37de5ae15812a764c958297cfc50f5c010438f60c6ce75d11b802abd404"
 dependencies = [
- "block-modes",
- "cipher 0.3.0",
+ "cbc",
+ "cipher 0.4.4",
  "libm 0.2.7",
  "num-bigint",
  "num-integer",
@@ -9554,7 +9544,7 @@ checksum = "0f9079049688da5871a7558ddacb7f04958862c703e68258594cb7a862b5e33f"
 [[package]]
 name = "zcash_client_backend"
 version = "0.5.0"
-source = "git+https://github.com/KomodoPlatform/librustzcash.git?tag=k-1.4.0#debae777f20f5b5fd263e26877258f7600b52cab"
+source = "git+https://github.com/KomodoPlatform/librustzcash.git?branch=bump-aes-version#5fb4721abace3a31aaa8ad2b6da48073d6f31560"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -9579,7 +9569,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.3.0"
-source = "git+https://github.com/KomodoPlatform/librustzcash.git?tag=k-1.4.0#debae777f20f5b5fd263e26877258f7600b52cab"
+source = "git+https://github.com/KomodoPlatform/librustzcash.git?branch=bump-aes-version#5fb4721abace3a31aaa8ad2b6da48073d6f31560"
 dependencies = [
  "async-trait",
  "bech32",
@@ -9601,7 +9591,7 @@ dependencies = [
 [[package]]
 name = "zcash_extras"
 version = "0.1.0"
-source = "git+https://github.com/KomodoPlatform/librustzcash.git?tag=k-1.4.0#debae777f20f5b5fd263e26877258f7600b52cab"
+source = "git+https://github.com/KomodoPlatform/librustzcash.git?branch=bump-aes-version#5fb4721abace3a31aaa8ad2b6da48073d6f31560"
 dependencies = [
  "async-trait",
  "ff 0.8.0",
@@ -9617,7 +9607,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.0.0"
-source = "git+https://github.com/KomodoPlatform/librustzcash.git?tag=k-1.4.0#debae777f20f5b5fd263e26877258f7600b52cab"
+source = "git+https://github.com/KomodoPlatform/librustzcash.git?branch=bump-aes-version#5fb4721abace3a31aaa8ad2b6da48073d6f31560"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -9631,9 +9621,9 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.5.0"
-source = "git+https://github.com/KomodoPlatform/librustzcash.git?tag=k-1.4.0#debae777f20f5b5fd263e26877258f7600b52cab"
+source = "git+https://github.com/KomodoPlatform/librustzcash.git?branch=bump-aes-version#5fb4721abace3a31aaa8ad2b6da48073d6f31560"
 dependencies = [
- "aes 0.7.5",
+ "aes 0.8.3",
  "bitvec 0.18.5",
  "blake2b_simd",
  "blake2s_simd",
@@ -9661,7 +9651,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.5.0"
-source = "git+https://github.com/KomodoPlatform/librustzcash.git?tag=k-1.4.0#debae777f20f5b5fd263e26877258f7600b52cab"
+source = "git+https://github.com/KomodoPlatform/librustzcash.git?branch=bump-aes-version#5fb4721abace3a31aaa8ad2b6da48073d6f31560"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2150,7 +2150,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.1.0"
-source = "git+https://github.com/KomodoPlatform/librustzcash.git?branch=bump-aes-version#5fb4721abace3a31aaa8ad2b6da48073d6f31560"
+source = "git+https://github.com/KomodoPlatform/librustzcash.git?tag=k-1.4.1#e92443a7bbd1c5e92e00e6deb45b5a33af14cea4"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -9544,7 +9544,7 @@ checksum = "0f9079049688da5871a7558ddacb7f04958862c703e68258594cb7a862b5e33f"
 [[package]]
 name = "zcash_client_backend"
 version = "0.5.0"
-source = "git+https://github.com/KomodoPlatform/librustzcash.git?branch=bump-aes-version#5fb4721abace3a31aaa8ad2b6da48073d6f31560"
+source = "git+https://github.com/KomodoPlatform/librustzcash.git?tag=k-1.4.1#e92443a7bbd1c5e92e00e6deb45b5a33af14cea4"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -9569,7 +9569,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.3.0"
-source = "git+https://github.com/KomodoPlatform/librustzcash.git?branch=bump-aes-version#5fb4721abace3a31aaa8ad2b6da48073d6f31560"
+source = "git+https://github.com/KomodoPlatform/librustzcash.git?tag=k-1.4.1#e92443a7bbd1c5e92e00e6deb45b5a33af14cea4"
 dependencies = [
  "async-trait",
  "bech32",
@@ -9591,7 +9591,7 @@ dependencies = [
 [[package]]
 name = "zcash_extras"
 version = "0.1.0"
-source = "git+https://github.com/KomodoPlatform/librustzcash.git?branch=bump-aes-version#5fb4721abace3a31aaa8ad2b6da48073d6f31560"
+source = "git+https://github.com/KomodoPlatform/librustzcash.git?tag=k-1.4.1#e92443a7bbd1c5e92e00e6deb45b5a33af14cea4"
 dependencies = [
  "async-trait",
  "ff 0.8.0",
@@ -9607,7 +9607,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.0.0"
-source = "git+https://github.com/KomodoPlatform/librustzcash.git?branch=bump-aes-version#5fb4721abace3a31aaa8ad2b6da48073d6f31560"
+source = "git+https://github.com/KomodoPlatform/librustzcash.git?tag=k-1.4.1#e92443a7bbd1c5e92e00e6deb45b5a33af14cea4"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -9621,7 +9621,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.5.0"
-source = "git+https://github.com/KomodoPlatform/librustzcash.git?branch=bump-aes-version#5fb4721abace3a31aaa8ad2b6da48073d6f31560"
+source = "git+https://github.com/KomodoPlatform/librustzcash.git?tag=k-1.4.1#e92443a7bbd1c5e92e00e6deb45b5a33af14cea4"
 dependencies = [
  "aes 0.8.3",
  "bitvec 0.18.5",
@@ -9651,7 +9651,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.5.0"
-source = "git+https://github.com/KomodoPlatform/librustzcash.git?branch=bump-aes-version#5fb4721abace3a31aaa8ad2b6da48073d6f31560"
+source = "git+https://github.com/KomodoPlatform/librustzcash.git?tag=k-1.4.1#e92443a7bbd1c5e92e00e6deb45b5a33af14cea4"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/mm2src/coins/Cargo.toml
+++ b/mm2src/coins/Cargo.toml
@@ -107,9 +107,9 @@ uuid = { version = "1.2.2", features = ["fast-rng", "serde", "v4"] }
 # We don't need the default web3 features at all since we added our own web3 transport using shared HYPER instance.
 web3 = { git = "https://github.com/KomodoPlatform/rust-web3", tag = "v0.19.0", default-features = false }
 zbase32 = "0.1.2"
-zcash_client_backend = { git = "https://github.com/KomodoPlatform/librustzcash.git", branch = "bump-aes-version" }
-zcash_extras = { git = "https://github.com/KomodoPlatform/librustzcash.git", branch = "bump-aes-version" }
-zcash_primitives =  {features = ["transparent-inputs"], git = "https://github.com/KomodoPlatform/librustzcash.git", branch = "bump-aes-version" }
+zcash_client_backend = { git = "https://github.com/KomodoPlatform/librustzcash.git", tag = "k-1.4.1" }
+zcash_extras = { git = "https://github.com/KomodoPlatform/librustzcash.git", tag = "k-1.4.1" }
+zcash_primitives =  {features = ["transparent-inputs"], git = "https://github.com/KomodoPlatform/librustzcash.git", tag = "k-1.4.1" }
 
 [target.'cfg(all(not(target_os = "ios"), not(target_os = "android"), not(target_arch = "wasm32")))'.dependencies]
 bincode = { version = "1.3.3", default-features = false, optional = true }
@@ -137,7 +137,7 @@ wasm-bindgen = "0.2.86"
 wasm-bindgen-futures = { version = "0.4.1" }
 wasm-bindgen-test = { version = "0.3.2" }
 web-sys = { version = "0.3.55", features = ["console", "Headers", "Request", "RequestInit", "RequestMode", "Response", "Window"] }
-zcash_proofs = { git = "https://github.com/KomodoPlatform/librustzcash.git", branch = "bump-aes-version", default-features = false, features = ["local-prover"] }
+zcash_proofs = { git = "https://github.com/KomodoPlatform/librustzcash.git", tag = "k-1.4.1", default-features = false, features = ["local-prover"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dirs = { version = "1" }
@@ -159,8 +159,8 @@ tokio = { version = "1.20" }
 tokio-rustls = { version = "0.23" }
 tonic = { version = "0.7", features = ["tls", "tls-webpki-roots", "compression"] }
 webpki-roots = { version = "0.22" }
-zcash_client_sqlite = { git = "https://github.com/KomodoPlatform/librustzcash.git", branch = "bump-aes-version" }
-zcash_proofs = { git = "https://github.com/KomodoPlatform/librustzcash.git", branch = "bump-aes-version", default-features =false, features = ["local-prover", "multicore"] }
+zcash_client_sqlite = { git = "https://github.com/KomodoPlatform/librustzcash.git", tag = "k-1.4.1" }
+zcash_proofs = { git = "https://github.com/KomodoPlatform/librustzcash.git", tag = "k-1.4.1", default-features = false, features = ["local-prover", "multicore"] }
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/mm2src/coins/Cargo.toml
+++ b/mm2src/coins/Cargo.toml
@@ -107,9 +107,9 @@ uuid = { version = "1.2.2", features = ["fast-rng", "serde", "v4"] }
 # We don't need the default web3 features at all since we added our own web3 transport using shared HYPER instance.
 web3 = { git = "https://github.com/KomodoPlatform/rust-web3", tag = "v0.19.0", default-features = false }
 zbase32 = "0.1.2"
-zcash_client_backend = { git = "https://github.com/KomodoPlatform/librustzcash.git", tag = "k-1.4.0" }
-zcash_extras = { git = "https://github.com/KomodoPlatform/librustzcash.git", tag = "k-1.4.0" }
-zcash_primitives =  {features = ["transparent-inputs"], git = "https://github.com/KomodoPlatform/librustzcash.git", tag = "k-1.4.0" }
+zcash_client_backend = { git = "https://github.com/KomodoPlatform/librustzcash.git", branch = "bump-aes-version" }
+zcash_extras = { git = "https://github.com/KomodoPlatform/librustzcash.git", branch = "bump-aes-version" }
+zcash_primitives =  {features = ["transparent-inputs"], git = "https://github.com/KomodoPlatform/librustzcash.git", branch = "bump-aes-version" }
 
 [target.'cfg(all(not(target_os = "ios"), not(target_os = "android"), not(target_arch = "wasm32")))'.dependencies]
 bincode = { version = "1.3.3", default-features = false, optional = true }
@@ -137,7 +137,7 @@ wasm-bindgen = "0.2.86"
 wasm-bindgen-futures = { version = "0.4.1" }
 wasm-bindgen-test = { version = "0.3.2" }
 web-sys = { version = "0.3.55", features = ["console", "Headers", "Request", "RequestInit", "RequestMode", "Response", "Window"] }
-zcash_proofs = { git = "https://github.com/KomodoPlatform/librustzcash.git", tag = "k-1.4.0", default-features = false, features = ["local-prover"] }
+zcash_proofs = { git = "https://github.com/KomodoPlatform/librustzcash.git", branch = "bump-aes-version", default-features = false, features = ["local-prover"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dirs = { version = "1" }
@@ -159,8 +159,8 @@ tokio = { version = "1.20" }
 tokio-rustls = { version = "0.23" }
 tonic = { version = "0.7", features = ["tls", "tls-webpki-roots", "compression"] }
 webpki-roots = { version = "0.22" }
-zcash_client_sqlite = { git = "https://github.com/KomodoPlatform/librustzcash.git", tag = "k-1.4.0" }
-zcash_proofs = { git = "https://github.com/KomodoPlatform/librustzcash.git", tag = "k-1.4.0", default-features =false, features = ["local-prover", "multicore"] }
+zcash_client_sqlite = { git = "https://github.com/KomodoPlatform/librustzcash.git", branch = "bump-aes-version" }
+zcash_proofs = { git = "https://github.com/KomodoPlatform/librustzcash.git", branch = "bump-aes-version", default-features =false, features = ["local-prover", "multicore"] }
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"


### PR DESCRIPTION
This requires this PR https://github.com/KomodoPlatform/librustzcash/pull/9 to be merged first