### PR TITLE
fix(wasm): websocket url validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4660,6 +4660,7 @@ dependencies = [
  "tokio-rustls",
  "tonic",
  "tower-service",
+ "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4660,7 +4660,6 @@ dependencies = [
  "tokio-rustls",
  "tonic",
  "tower-service",
- "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",

--- a/mm2src/mm2_net/Cargo.toml
+++ b/mm2src/mm2_net/Cargo.toml
@@ -43,6 +43,7 @@ js-sys = "0.3.27"
 pin-project = "1.1.2"
 tonic = { version = "0.7", default-features = false, features = ["prost", "codegen"] }
 tower-service = "0.3"
+url = { version = "2.2.2", default-features = false }
 wasm-bindgen = "0.2.86"
 wasm-bindgen-test = { version = "0.3.2" }
 wasm-bindgen-futures = "0.4.21"

--- a/mm2src/mm2_net/Cargo.toml
+++ b/mm2src/mm2_net/Cargo.toml
@@ -43,14 +43,13 @@ js-sys = "0.3.27"
 pin-project = "1.1.2"
 tonic = { version = "0.7", default-features = false, features = ["prost", "codegen"] }
 tower-service = "0.3"
-url = { version = "2.2.2", default-features = false }
 wasm-bindgen = "0.2.86"
 wasm-bindgen-test = { version = "0.3.2" }
 wasm-bindgen-futures = "0.4.21"
 web-sys = { version = "0.3.55", features = ["console", "CloseEvent", "DomException", "ErrorEvent", "IdbDatabase",
     "IdbCursor", "IdbCursorWithValue", "IdbFactory", "IdbIndex", "IdbIndexParameters", "IdbObjectStore",
     "IdbObjectStoreParameters", "IdbOpenDbRequest", "IdbKeyRange", "IdbTransaction", "IdbTransactionMode",
-    "IdbVersionChangeEvent", "MessageEvent", "MessagePort", "ReadableStreamDefaultReader", "ReadableStream", "SharedWorker", "WebSocket"] }
+    "IdbVersionChangeEvent", "MessageEvent", "MessagePort", "ReadableStreamDefaultReader", "ReadableStream", "SharedWorker", "Url", "WebSocket"] }
 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/mm2src/mm2_net/src/wasm/wasm_ws.rs
+++ b/mm2src/mm2_net/src/wasm/wasm_ws.rs
@@ -59,8 +59,8 @@ impl InitWsError {
             };
         };
 
-        match e.dyn_ref::<DomException>().map(DomException::code) {
-            Some(DomException::SYNTAX_ERR) => InitWsError::InvalidUrl {
+        match e.dyn_ref::<DomException>().map(DomException::name) {
+            Some(ref name) if name == "SyntaxError" => InitWsError::InvalidUrl {
                 url: url.to_owned(),
                 reason,
             },


### PR DESCRIPTION
This test kept failing because If you give a partial or incomplete URL to the WebSocket::new constructor, the browser tries to fix it by adding it to the current page's web address. 

For our test case, `Websocket::new("invalid address")` will return this URL `ws://127.0.0.1:52732/invalid%20address` as the webpage is being hosted on my pc using port `52732`.

https://github.com/KomodoPlatform/komodo-defi-framework/blob/f0b21dccacb846510e2eb8f2150b1fd02fffd9dd/mm2src/mm2_net/src/wasm/wasm_ws.rs#L782-L795
