### PR TITLE
feat(app-dir): implement root application dir `.kdf`

### DIFF
--- a/mm2src/common/common.rs
+++ b/mm2src/common/common.rs
@@ -188,6 +188,9 @@ cfg_wasm32! {
     use std::sync::atomic::AtomicUsize;
 }
 
+// Directory used to store configuration and database files within the user's home directory.
+const KOMODO_DEFI_FRAMEWORK_DIR_NAME: &str = ".kdf";
+
 pub const X_GRPC_WEB: &str = "x-grpc-web";
 pub const X_API_KEY: &str = "X-API-Key";
 pub const APPLICATION_JSON: &str = "application/json";
@@ -772,6 +775,38 @@ pub fn writeln(line: &str) {
     use web_sys::console;
     console::log_1(&line.into());
     append_log_tail(line);
+}
+
+/// Returns the path for application directory of kdf(komodo-defi-framework).
+pub fn kdf_app_dir() -> Option<PathBuf> {
+    #[allow(deprecated)]
+    Some(env::home_dir()?.join(KOMODO_DEFI_FRAMEWORK_DIR_NAME))
+}
+
+/// Returns path of the coins file.
+pub fn kdf_coins_file() -> PathBuf { find_kdf_dependency_file("MM_COINS_PATH", "coins") }
+
+/// Returns path of the config file.
+pub fn kdf_config_file() -> PathBuf { find_kdf_dependency_file("MM_CONF_PATH", "MM2.json") }
+
+/// Returns the desired file path for kdf(komodo-defi-framework).
+///
+/// Path priority:
+///  1- From the environment variable.
+///  2- From the current directory where app is called.
+///  3- From the root application directory.
+pub fn find_kdf_dependency_file(env_key: &str, path_leaf: &str) -> PathBuf {
+    match env::var(env_key) {
+        Ok(path) => PathBuf::from(path),
+        Err(_) => {
+            let from_current_dir = PathBuf::from(path_leaf);
+            if from_current_dir.exists() {
+                from_current_dir
+            } else {
+                kdf_app_dir().unwrap_or_default().join(path_leaf)
+            }
+        },
+    }
 }
 
 pub fn small_rng() -> SmallRng { SmallRng::seed_from_u64(now_ms()) }

--- a/mm2src/common/common.rs
+++ b/mm2src/common/common.rs
@@ -817,16 +817,15 @@ pub fn kdf_config_file() -> PathBuf {
 ///  2- From the current directory where app is called.
 ///  3- From the root application directory.
 pub fn find_kdf_dependency_file(value_from_env: Option<String>, path_leaf: &str) -> PathBuf {
-    match value_from_env {
-        Some(path) => PathBuf::from(path),
-        None => {
-            let from_current_dir = PathBuf::from(path_leaf);
-            if from_current_dir.exists() {
-                from_current_dir
-            } else {
-                kdf_app_dir().unwrap_or_default().join(path_leaf)
-            }
-        },
+    if let Some(path) = value_from_env {
+        return PathBuf::from(path);
+    }
+
+    let from_current_dir = PathBuf::from(path_leaf);
+    if from_current_dir.exists() {
+        from_current_dir
+    } else {
+        kdf_app_dir().unwrap_or_default().join(path_leaf)
     }
 }
 

--- a/mm2src/mm2_core/src/mm_ctx.rs
+++ b/mm2src/mm2_core/src/mm_ctx.rs
@@ -406,13 +406,25 @@ impl Drop for MmCtx {
 }
 
 /// Returns the path to the MM database root.
+///
+/// Path priority:
+///  1- From db_root function arg.
+///  2- From the current directory where app is called.
+///  3- From the root application directory.
 #[cfg(not(target_arch = "wasm32"))]
-fn path_to_db_root(db_root: Option<&str>) -> &Path {
-    const DEFAULT_ROOT: &str = "DB";
-
+fn path_to_db_root(db_root: Option<&str>) -> PathBuf {
     match db_root {
-        Some(dbdir) if !dbdir.is_empty() => Path::new(dbdir),
-        _ => Path::new(DEFAULT_ROOT),
+        Some(dbdir) if !dbdir.is_empty() => PathBuf::from(dbdir),
+        _ => {
+            const LEAF: &str = "DB";
+
+            let from_current_dir = PathBuf::from(LEAF);
+            if from_current_dir.exists() {
+                from_current_dir
+            } else {
+                common::kdf_app_dir().unwrap_or_default().join(LEAF)
+            }
+        },
     }
 }
 

--- a/mm2src/mm2_main/src/mm2.rs
+++ b/mm2src/mm2_main/src/mm2.rs
@@ -278,7 +278,7 @@ pub fn mm2_main(version: String, datetime: String) {
 /// Parses and returns the `first_arg` as JSON.
 /// Attempts to load the config from `MM2.json` file if `first_arg` is None
 pub fn get_mm2config(first_arg: Option<&str>) -> Result<Json, String> {
-    let conf_path = env::var("MM_CONF_PATH").unwrap_or_else(|_| "MM2.json".into());
+    let conf_path = common::kdf_config_file();
     let conf_from_file = slurp(&conf_path);
     let conf = match first_arg {
         Some(s) => s,
@@ -286,7 +286,7 @@ pub fn get_mm2config(first_arg: Option<&str>) -> Result<Json, String> {
             if conf_from_file.is_empty() {
                 return ERR!(
                     "Config is not set from command line arg and {} file doesn't exist.",
-                    conf_path
+                    conf_path.display()
                 );
             }
             try_s!(std::str::from_utf8(&conf_from_file))
@@ -302,12 +302,13 @@ pub fn get_mm2config(first_arg: Option<&str>) -> Result<Json, String> {
     };
 
     if conf["coins"].is_null() {
-        let coins_path = env::var("MM_COINS_PATH").unwrap_or_else(|_| "coins".into());
+        let coins_path = common::kdf_coins_file();
+
         let coins_from_file = slurp(&coins_path);
         if coins_from_file.is_empty() {
             return ERR!(
                 "No coins are set in JSON config and '{}' file doesn't exist",
-                coins_path
+                coins_path.display()
             );
         }
         conf["coins"] = match json::from_slice(&coins_from_file) {


### PR DESCRIPTION
Consolidates all the runtime files together under `$HOME/.kdf` by default (so you don't have to set environment variables on the host). This should improve the user experience significantly as this is a standard practice followed by most of the programs on UNIX systems.