### PR TITLE
update dockerfile

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/debian:buster-slim
+FROM docker.io/debian:10
 
 MAINTAINER Onur Özkan <onur@komodoplatform.com>
 
@@ -10,6 +10,7 @@ RUN apt-get install -y 	\
     ca-certificates 	\
     curl             	\
     wget             	\
+    unzip             	\
     gnupg
 
 RUN ln -s /usr/bin/python3 /bin/python
@@ -26,10 +27,10 @@ RUN ./llvm.sh 16
 
 RUN rm ./llvm.sh
 
-RUN ln -s /usr/bin/clang-16 /usr/bin/clang
-
 ENV AR=/usr/bin/llvm-ar-16
 ENV CC=/usr/bin/clang-16
+
+RUN ln -s /usr/bin/clang-16 /usr/bin/clang
 
 RUN mkdir -m 0755 -p /etc/apt/keyrings
 
@@ -47,6 +48,9 @@ RUN apt-get install -y 	  \
 	containerd.io 		  \
 	docker-buildx-plugin
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile minimal --default-toolchain nightly-2022-10-29 -y
+
+RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.20.1/protoc-3.20.1-linux-x86_64.zip
+RUN unzip protoc-3.20.1-linux-x86_64.zip && mv ./include/google /usr/include/google
 
 ENV PATH="/root/.cargo/bin:$PATH"


### PR DESCRIPTION
mm2 build requires `protoc 3.21.x+` to be installed as mentioned at https://github.com/KomodoPlatform/komodo-defi-framework?tab=readme-ov-file#on-host-system, this PR installs that dependency in the builder container.