### PR TITLE
fix(core): tendermint withdraws on hd accounts

### DIFF
--- a/mm2src/coins/tendermint/tendermint_token.rs
+++ b/mm2src/coins/tendermint/tendermint_token.rs
@@ -571,7 +571,14 @@ impl MmCoin for TendermintToken {
             };
 
             let fee_amount_u64 = platform
-                .calculate_account_fee_amount_as_u64(msg_payload.clone(), timeout_height, memo.clone(), req.fee)
+                .calculate_account_fee_amount_as_u64(
+                    &account_id,
+                    maybe_pk,
+                    msg_payload.clone(),
+                    timeout_height,
+                    memo.clone(),
+                    req.fee,
+                )
                 .await?;
 
             let fee_amount_dec = big_decimal_from_sat_unsigned(fee_amount_u64, platform.decimals());


### PR DESCRIPTION
Fixes a regression (check `mm2_tests::tendermint_tests::test_tendermint_withdraw_hd` test) which started with pubkey-only activation implementation.