### PR TITLE
feat(ETH): add gas_limit coins param to override default values

### DIFF
--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -233,14 +233,14 @@ pub mod gas_limit {
     /// real values are approx 48,6K by etherscan
     pub const ETH_PAYMENT: u64 = 65_000;
     /// Gas limit for swap payment tx with ERC20 tokens
-    /// real values are 98,9K
-    pub const ERC20_PAYMENT: u64 = 120_000;
+    /// real values are 98,9K for ERC20 and 135K for ERC-1967 proxied ERC20 contracts (use 'gas_limit' override in coins to tune)
+    pub const ERC20_PAYMENT: u64 = 150_000;
     /// Gas limit for swap receiver spend tx with coins
     /// real values are 40,7K
     pub const ETH_RECEIVER_SPEND: u64 = 65_000;
     /// Gas limit for swap receiver spend tx with ERC20 tokens
     /// real values are 72,8K
-    pub const ERC20_RECEIVER_SPEND: u64 = 120_000;
+    pub const ERC20_RECEIVER_SPEND: u64 = 150_000;
     /// Gas limit for swap refund tx with coins
     pub const ETH_SENDER_REFUND: u64 = 100_000;
     /// Gas limit for swap refund tx with with ERC20 tokens

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -6440,6 +6440,7 @@ pub async fn eth_coin_from_conf_and_request(
 
     let platform_fee_estimator_state = FeeEstimatorState::init_fee_estimator(ctx, conf, &coin_type).await?;
     let max_eth_tx_type = get_max_eth_tx_type_conf(ctx, conf, &coin_type).await?;
+    let gas_limit = extract_gas_limit_from_conf(conf)?;
 
     let coin = EthCoinImpl {
         priv_key_policy: key_pair,
@@ -6464,7 +6465,7 @@ pub async fn eth_coin_from_conf_and_request(
         erc20_tokens_infos: Default::default(),
         nfts_infos: Default::default(),
         platform_fee_estimator_state,
-        gas_limit: extract_gas_limit_from_conf(conf)?,
+        gas_limit,
         abortable_system,
     };
 

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -254,7 +254,7 @@ pub mod gas_limit {
 pub struct EthGasLimitOverride {
     /// Gas limit for sending coins override value
     pub eth_send_coins: Option<u64>,
-    /// Gas limit for swap payment tx with ERC20 tokens override value
+    /// Gas limit for sending ERC20 tokens override value
     pub eth_send_erc20: Option<u64>,
     /// Gas limit for swap payment tx with coins override value
     pub eth_payment: Option<u64>,

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -6464,11 +6464,7 @@ pub async fn eth_coin_from_conf_and_request(
         erc20_tokens_infos: Default::default(),
         nfts_infos: Default::default(),
         platform_fee_estimator_state,
-        gas_limit: if conf["gas_limit"].is_null() {
-            Default::default()
-        } else {
-            json::from_value(conf["gas_limit"].clone()).map_err(|e| e.to_string())?
-        },
+        gas_limit: extract_gas_limit_from_conf(conf)?,
         abortable_system,
     };
 
@@ -7099,6 +7095,14 @@ pub fn pubkey_from_extended(extended_pubkey: &Secp256k1ExtendedPublicKey) -> Pub
     let mut pubkey_uncompressed = Public::default();
     pubkey_uncompressed.as_mut().copy_from_slice(&serialized[1..]);
     pubkey_uncompressed
+}
+
+fn extract_gas_limit_from_conf(coin_conf: &Json) -> Result<EthGasLimitOverride, String> {
+    if coin_conf["gas_limit"].is_null() {
+        Ok(Default::default())
+    } else {
+        json::from_value(coin_conf["gas_limit"].clone()).map_err(|e| e.to_string())
+    }
 }
 
 impl Eip1559Ops for EthCoin {

--- a/mm2src/coins/eth/eth_tests.rs
+++ b/mm2src/coins/eth/eth_tests.rs
@@ -1017,8 +1017,10 @@ fn test_gas_limit_conf() {
         _ => panic!("not eth coin"),
     };
     assert!(
-        eth_coin.gas_limit.erc20_payment.unwrap() == 120000
-            && eth_coin.gas_limit.erc20_receiver_spend.unwrap() == 130000
-            && eth_coin.gas_limit.erc20_sender_refund.unwrap() == 110000
+        eth_coin.gas_limit.eth_send_coins == 21_000
+            && eth_coin.gas_limit.erc20_payment == 120000
+            && eth_coin.gas_limit.erc20_receiver_spend == 130000
+            && eth_coin.gas_limit.erc20_sender_refund == 110000
+            && eth_coin.gas_limit.eth_max_trade_gas == 150_000
     );
 }

--- a/mm2src/coins/eth/eth_tests.rs
+++ b/mm2src/coins/eth/eth_tests.rs
@@ -978,3 +978,47 @@ fn test_fee_history() {
     let res = block_on(coin.eth_fee_history(U256::from(1u64), BlockNumber::Latest, &[]));
     assert!(res.is_ok());
 }
+
+#[test]
+#[cfg(not(target_arch = "wasm32"))]
+fn test_gas_limit_conf() {
+    use mm2_test_helpers::for_tests::ETH_SEPOLIA_SWAP_CONTRACT;
+
+    let conf = json!({
+        "coins": [{
+            "coin": "ETH",
+            "name": "ethereum",
+            "fname": "Ethereum",
+            "chain_id": 1337,
+            "protocol":{
+                "type": "ETH"
+            },
+            "chain_id": 1,
+            "rpcport": 80,
+            "mm2": 1,
+            "gas_limit": {
+                "erc20_payment": 120000,
+                "erc20_receiver_spend": 130000,
+                "erc20_sender_refund": 110000
+            }
+        }]
+    });
+
+    let ctx = MmCtxBuilder::new().with_conf(conf).into_mm_arc();
+    CryptoCtx::init_with_iguana_passphrase(ctx.clone(), "123456").unwrap();
+
+    let req = json!({
+        "urls":ETH_SEPOLIA_NODES,
+        "swap_contract_address":ETH_SEPOLIA_SWAP_CONTRACT
+    });
+    let coin = block_on(lp_coininit(&ctx, "ETH", &req)).unwrap();
+    let eth_coin = match coin {
+        MmCoinEnum::EthCoin(eth_coin) => eth_coin,
+        _ => panic!("not eth coin"),
+    };
+    assert!(
+        eth_coin.gas_limit.erc20_payment.unwrap() == 120000
+            && eth_coin.gas_limit.erc20_receiver_spend.unwrap() == 130000
+            && eth_coin.gas_limit.erc20_sender_refund.unwrap() == 110000
+    );
+}

--- a/mm2src/coins/eth/for_tests.rs
+++ b/mm2src/coins/eth/for_tests.rs
@@ -49,6 +49,7 @@ pub(crate) fn eth_coin_from_keypair(
         EthCoinType::Nft { ref platform } => platform.to_string(),
     };
     let my_address = key_pair.address();
+    let coin_conf = coin_conf(&ctx, &ticker);
 
     let eth_coin = EthCoin(Arc::new(EthCoinImpl {
         coin_type,
@@ -73,6 +74,11 @@ pub(crate) fn eth_coin_from_keypair(
         erc20_tokens_infos: Default::default(),
         nfts_infos: Arc::new(Default::default()),
         platform_fee_estimator_state: Arc::new(FeeEstimatorState::CoinNotSupported),
+        gas_limit: if coin_conf["gas_limit"].is_null() {
+            Default::default()
+        } else {
+            json::from_value(coin_conf["gas_limit"].clone()).expect("expected valid gas_limit config")
+        },
         abortable_system: AbortableQueue::default(),
     }));
     (ctx, eth_coin)

--- a/mm2src/coins/eth/for_tests.rs
+++ b/mm2src/coins/eth/for_tests.rs
@@ -50,6 +50,7 @@ pub(crate) fn eth_coin_from_keypair(
     };
     let my_address = key_pair.address();
     let coin_conf = coin_conf(&ctx, &ticker);
+    let gas_limit = extract_gas_limit_from_conf(&coin_conf).expect("expected valid gas_limit config");
 
     let eth_coin = EthCoin(Arc::new(EthCoinImpl {
         coin_type,
@@ -74,7 +75,7 @@ pub(crate) fn eth_coin_from_keypair(
         erc20_tokens_infos: Default::default(),
         nfts_infos: Arc::new(Default::default()),
         platform_fee_estimator_state: Arc::new(FeeEstimatorState::CoinNotSupported),
-        gas_limit: extract_gas_limit_from_conf(&coin_conf).expect("expected valid gas_limit config"),
+        gas_limit,
         abortable_system: AbortableQueue::default(),
     }));
     (ctx, eth_coin)

--- a/mm2src/coins/eth/for_tests.rs
+++ b/mm2src/coins/eth/for_tests.rs
@@ -74,11 +74,7 @@ pub(crate) fn eth_coin_from_keypair(
         erc20_tokens_infos: Default::default(),
         nfts_infos: Arc::new(Default::default()),
         platform_fee_estimator_state: Arc::new(FeeEstimatorState::CoinNotSupported),
-        gas_limit: if coin_conf["gas_limit"].is_null() {
-            Default::default()
-        } else {
-            json::from_value(coin_conf["gas_limit"].clone()).expect("expected valid gas_limit config")
-        },
+        gas_limit: extract_gas_limit_from_conf(&coin_conf).expect("expected valid gas_limit config"),
         abortable_system: AbortableQueue::default(),
     }));
     (ctx, eth_coin)

--- a/mm2src/coins/eth/nft_swap_v2/mod.rs
+++ b/mm2src/coins/eth/nft_swap_v2/mod.rs
@@ -14,8 +14,8 @@ mod structs;
 use structs::{ExpectedHtlcParams, PaymentType, ValidationParams};
 
 use super::ContractType;
-use crate::eth::{addr_from_raw_pubkey, decode_contract_call, gas_limit, EthCoin, EthCoinType, MakerPaymentStateV2,
-                 SignedEthTx, TryToAddress, ERC1155_CONTRACT, ERC721_CONTRACT, NFT_SWAP_CONTRACT};
+use crate::eth::{addr_from_raw_pubkey, decode_contract_call, EthCoin, EthCoinType, MakerPaymentStateV2, SignedEthTx,
+                 TryToAddress, ERC1155_CONTRACT, ERC721_CONTRACT, NFT_SWAP_CONTRACT};
 use crate::{ParseCoinAssocTypes, RefundPaymentArgs, SendNftMakerPaymentArgs, SpendNftMakerPaymentArgs, TransactionErr,
             ValidateNftMakerPaymentArgs};
 
@@ -39,7 +39,7 @@ impl EthCoin {
                     0.into(),
                     Action::Call(*args.nft_swap_info.token_address),
                     data,
-                    U256::from(self.gas_limit.eth_max_trade_gas.unwrap_or(gas_limit::ETH_MAX_TRADE_GAS)), // TODO: fix to a more accurate const or estimated value
+                    U256::from(self.gas_limit.eth_max_trade_gas), // TODO: fix to a more accurate const or estimated value
                 )
                 .compat()
                 .await
@@ -158,7 +158,7 @@ impl EthCoin {
                     0.into(),
                     Action::Call(*etomic_swap_contract),
                     data,
-                    U256::from(self.gas_limit.eth_max_trade_gas.unwrap_or(gas_limit::ETH_MAX_TRADE_GAS)), // TODO: fix to a more accurate const or estimated value
+                    U256::from(self.gas_limit.eth_max_trade_gas), // TODO: fix to a more accurate const or estimated value
                 )
                 .compat()
                 .await

--- a/mm2src/coins/eth/nft_swap_v2/mod.rs
+++ b/mm2src/coins/eth/nft_swap_v2/mod.rs
@@ -14,8 +14,8 @@ mod structs;
 use structs::{ExpectedHtlcParams, PaymentType, ValidationParams};
 
 use super::ContractType;
-use crate::eth::{addr_from_raw_pubkey, decode_contract_call, gas_limit::ETH_MAX_TRADE_GAS, EthCoin, EthCoinType,
-                 MakerPaymentStateV2, SignedEthTx, TryToAddress, ERC1155_CONTRACT, ERC721_CONTRACT, NFT_SWAP_CONTRACT};
+use crate::eth::{addr_from_raw_pubkey, decode_contract_call, gas_limit, EthCoin, EthCoinType, MakerPaymentStateV2,
+                 SignedEthTx, TryToAddress, ERC1155_CONTRACT, ERC721_CONTRACT, NFT_SWAP_CONTRACT};
 use crate::{ParseCoinAssocTypes, RefundPaymentArgs, SendNftMakerPaymentArgs, SpendNftMakerPaymentArgs, TransactionErr,
             ValidateNftMakerPaymentArgs};
 
@@ -39,7 +39,7 @@ impl EthCoin {
                     0.into(),
                     Action::Call(*args.nft_swap_info.token_address),
                     data,
-                    U256::from(ETH_MAX_TRADE_GAS), // TODO: fix to a more accurate const or estimated value
+                    U256::from(self.gas_limit.eth_max_trade_gas.unwrap_or(gas_limit::ETH_MAX_TRADE_GAS)), // TODO: fix to a more accurate const or estimated value
                 )
                 .compat()
                 .await
@@ -158,7 +158,7 @@ impl EthCoin {
                     0.into(),
                     Action::Call(*etomic_swap_contract),
                     data,
-                    U256::from(ETH_MAX_TRADE_GAS), // TODO: fix to a more accurate const or estimated value
+                    U256::from(self.gas_limit.eth_max_trade_gas.unwrap_or(gas_limit::ETH_MAX_TRADE_GAS)), // TODO: fix to a more accurate const or estimated value
                 )
                 .compat()
                 .await

--- a/mm2src/coins/eth/v2_activation.rs
+++ b/mm2src/coins/eth/v2_activation.rs
@@ -400,6 +400,8 @@ impl EthCoin {
         };
         let platform_fee_estimator_state = FeeEstimatorState::init_fee_estimator(&ctx, &conf, &coin_type).await?;
         let max_eth_tx_type = get_max_eth_tx_type_conf(&ctx, &conf, &coin_type).await?;
+        let gas_limit = extract_gas_limit_from_conf(&conf)
+            .map_to_mm(|e| EthTokenActivationError::InternalError(format!("invalid gas_limit config {}", e)))?;
 
         let token = EthCoinImpl {
             priv_key_policy: self.priv_key_policy.clone(),
@@ -427,8 +429,7 @@ impl EthCoin {
             erc20_tokens_infos: Default::default(),
             nfts_infos: Default::default(),
             platform_fee_estimator_state,
-            gas_limit: extract_gas_limit_from_conf(&conf)
-                .map_to_mm(|e| EthTokenActivationError::InternalError(format!("invalid gas_limit config {}", e)))?,
+            gas_limit,
             abortable_system,
         };
 
@@ -465,6 +466,8 @@ impl EthCoin {
         };
         let platform_fee_estimator_state = FeeEstimatorState::init_fee_estimator(&ctx, &conf, &coin_type).await?;
         let max_eth_tx_type = get_max_eth_tx_type_conf(&ctx, &conf, &coin_type).await?;
+        let gas_limit = extract_gas_limit_from_conf(&conf)
+            .map_to_mm(|e| EthTokenActivationError::InternalError(format!("invalid gas_limit config {}", e)))?;
 
         let global_nft = EthCoinImpl {
             ticker,
@@ -489,8 +492,7 @@ impl EthCoin {
             erc20_tokens_infos: Default::default(),
             nfts_infos: Arc::new(AsyncMutex::new(nft_infos)),
             platform_fee_estimator_state,
-            gas_limit: extract_gas_limit_from_conf(&conf)
-                .map_to_mm(|e| EthTokenActivationError::InternalError(format!("invalid gas_limit config {}", e)))?,
+            gas_limit,
             abortable_system,
         };
         Ok(EthCoin(Arc::new(global_nft)))
@@ -603,6 +605,8 @@ pub async fn eth_coin_from_conf_and_request_v2(
     let coin_type = EthCoinType::Eth;
     let platform_fee_estimator_state = FeeEstimatorState::init_fee_estimator(ctx, conf, &coin_type).await?;
     let max_eth_tx_type = get_max_eth_tx_type_conf(ctx, conf, &coin_type).await?;
+    let gas_limit = extract_gas_limit_from_conf(conf)
+        .map_to_mm(|e| EthActivationV2Error::InternalError(format!("invalid gas_limit config {}", e)))?;
 
     let coin = EthCoinImpl {
         priv_key_policy,
@@ -627,8 +631,7 @@ pub async fn eth_coin_from_conf_and_request_v2(
         erc20_tokens_infos: Default::default(),
         nfts_infos: Default::default(),
         platform_fee_estimator_state,
-        gas_limit: extract_gas_limit_from_conf(conf)
-            .map_to_mm(|e| EthActivationV2Error::InternalError(format!("invalid gas_limit config {}", e)))?,
+        gas_limit,
         abortable_system,
     };
 

--- a/mm2src/coins/eth/v2_activation.rs
+++ b/mm2src/coins/eth/v2_activation.rs
@@ -427,12 +427,8 @@ impl EthCoin {
             erc20_tokens_infos: Default::default(),
             nfts_infos: Default::default(),
             platform_fee_estimator_state,
-            gas_limit: if conf["gas_limit"].is_null() {
-                Default::default()
-            } else {
-                json::from_value(conf["gas_limit"].clone())
-                    .map_to_mm(|e| EthTokenActivationError::InternalError(format!("invalid gas_limit config {}", e)))?
-            },
+            gas_limit: extract_gas_limit_from_conf(&conf)
+                .map_to_mm(|e| EthTokenActivationError::InternalError(format!("invalid gas_limit config {}", e)))?,
             abortable_system,
         };
 
@@ -493,12 +489,8 @@ impl EthCoin {
             erc20_tokens_infos: Default::default(),
             nfts_infos: Arc::new(AsyncMutex::new(nft_infos)),
             platform_fee_estimator_state,
-            gas_limit: if conf["gas_limit"].is_null() {
-                Default::default()
-            } else {
-                json::from_value(conf["gas_limit"].clone())
-                    .map_to_mm(|e| EthTokenActivationError::InternalError(format!("invalid gas_limit config {}", e)))?
-            },
+            gas_limit: extract_gas_limit_from_conf(&conf)
+                .map_to_mm(|e| EthTokenActivationError::InternalError(format!("invalid gas_limit config {}", e)))?,
             abortable_system,
         };
         Ok(EthCoin(Arc::new(global_nft)))
@@ -635,12 +627,8 @@ pub async fn eth_coin_from_conf_and_request_v2(
         erc20_tokens_infos: Default::default(),
         nfts_infos: Default::default(),
         platform_fee_estimator_state,
-        gas_limit: if conf["gas_limit"].is_null() {
-            Default::default()
-        } else {
-            json::from_value(conf["gas_limit"].clone())
-                .map_to_mm(|e| EthActivationV2Error::InternalError(format!("invalid gas_limit config {}", e)))?
-        },
+        gas_limit: extract_gas_limit_from_conf(conf)
+            .map_to_mm(|e| EthActivationV2Error::InternalError(format!("invalid gas_limit config {}", e)))?,
         abortable_system,
     };
 

--- a/mm2src/coins/eth/v2_activation.rs
+++ b/mm2src/coins/eth/v2_activation.rs
@@ -427,6 +427,13 @@ impl EthCoin {
             erc20_tokens_infos: Default::default(),
             nfts_infos: Default::default(),
             platform_fee_estimator_state,
+            gas_limit: if conf["gas_limit"].is_null() {
+                Default::default()
+            } else {
+                json::from_value(conf["gas_limit"].clone()).map_to_mm(|e| {
+                    EthTokenActivationError::InternalError(format!("invalid gas_limit config {}", e))
+                })?
+            },
             abortable_system,
         };
 
@@ -487,6 +494,13 @@ impl EthCoin {
             erc20_tokens_infos: Default::default(),
             nfts_infos: Arc::new(AsyncMutex::new(nft_infos)),
             platform_fee_estimator_state,
+            gas_limit: if conf["gas_limit"].is_null() {
+                Default::default()
+            } else {
+                json::from_value(conf["gas_limit"].clone()).map_to_mm(|e| {
+                    EthTokenActivationError::InternalError(format!("invalid gas_limit config {}", e))
+                })?
+            },
             abortable_system,
         };
         Ok(EthCoin(Arc::new(global_nft)))
@@ -623,6 +637,13 @@ pub async fn eth_coin_from_conf_and_request_v2(
         erc20_tokens_infos: Default::default(),
         nfts_infos: Default::default(),
         platform_fee_estimator_state,
+        gas_limit: if conf["gas_limit"].is_null() {
+            Default::default()
+        } else {
+            json::from_value(conf["gas_limit"].clone()).map_to_mm(|e| {
+                EthActivationV2Error::InternalError(format!("invalid gas_limit config {}", e))
+            })?
+        },
         abortable_system,
     };
 

--- a/mm2src/coins/eth/v2_activation.rs
+++ b/mm2src/coins/eth/v2_activation.rs
@@ -430,9 +430,8 @@ impl EthCoin {
             gas_limit: if conf["gas_limit"].is_null() {
                 Default::default()
             } else {
-                json::from_value(conf["gas_limit"].clone()).map_to_mm(|e| {
-                    EthTokenActivationError::InternalError(format!("invalid gas_limit config {}", e))
-                })?
+                json::from_value(conf["gas_limit"].clone())
+                    .map_to_mm(|e| EthTokenActivationError::InternalError(format!("invalid gas_limit config {}", e)))?
             },
             abortable_system,
         };
@@ -497,9 +496,8 @@ impl EthCoin {
             gas_limit: if conf["gas_limit"].is_null() {
                 Default::default()
             } else {
-                json::from_value(conf["gas_limit"].clone()).map_to_mm(|e| {
-                    EthTokenActivationError::InternalError(format!("invalid gas_limit config {}", e))
-                })?
+                json::from_value(conf["gas_limit"].clone())
+                    .map_to_mm(|e| EthTokenActivationError::InternalError(format!("invalid gas_limit config {}", e)))?
             },
             abortable_system,
         };
@@ -640,9 +638,8 @@ pub async fn eth_coin_from_conf_and_request_v2(
         gas_limit: if conf["gas_limit"].is_null() {
             Default::default()
         } else {
-            json::from_value(conf["gas_limit"].clone()).map_to_mm(|e| {
-                EthActivationV2Error::InternalError(format!("invalid gas_limit config {}", e))
-            })?
+            json::from_value(conf["gas_limit"].clone())
+                .map_to_mm(|e| EthActivationV2Error::InternalError(format!("invalid gas_limit config {}", e)))?
         },
         abortable_system,
     };


### PR DESCRIPTION
In PR #2051 there were added several gas limit constants to allocate gas price more precisely for different swap operations and for sending coin and tokens, instead of the old single capped value. However there are also erc20 tokens which are called over proxy contracts, which require more gas.
This PR:
- increases the default consts for erc20 ops (to the old value actually) to ensure proxied erc20 would have enough gas 
- adds gas_limit param to coins file to allow setting lower (or higher) gas limits for selected tokens

Fixes #2135

Sample of `gas_limit` (with all available limit values) in the coins file:
```
{
    "coin": "ETH",
    "gas_limit": {
        "eth_send_coins": 21000,               -- Gas limit for sending coins 
        "eth_send_erc20": 65000,              -- Gas limit for sending ERC20 tokens
        "eth_payment": 75000,                    -- Gas limit for swap payment tx with coins
        "erc20_payment": 120000,              -- Gas limit for swap payment tx with ERC20 tokens
        "eth_receiver_spend": 55000,         -- Gas limit for swap receiver spend tx with coins 
        "erc20_receiver_spend": 130000,    -- Gas limit for swap receiver spend tx with ERC20 tokens
        "eth_sender_refund": 110000,          -- Gas limit for swap refund tx with coins
        "erc20_sender_refund": 110000,      -- Gas limit for swap refund tx with with ERC20 tokens
        "eth_max_trade_gas": 150000.        -- Gas limit for other operations
    }
}
```
Both `gas_limit` and all of its params are optional. 