### PR TITLE
fix(restrictions): remove wallet-only restriction from max_maker_vol

### DIFF
--- a/mm2src/mm2_main/src/lp_swap/max_maker_vol_rpc.rs
+++ b/mm2src/mm2_main/src/lp_swap/max_maker_vol_rpc.rs
@@ -109,10 +109,10 @@ impl From<CheckBalanceError> for MaxMakerVolRpcError {
 impl HttpStatusCode for MaxMakerVolRpcError {
     fn status_code(&self) -> StatusCode {
         match self {
+            MaxMakerVolRpcError::NoSuchCoin { .. } => StatusCode::NOT_FOUND,
             MaxMakerVolRpcError::NotSufficientBalance { .. }
             | MaxMakerVolRpcError::NotSufficientBaseCoinBalance { .. }
-            | MaxMakerVolRpcError::VolumeTooLow { .. }
-            | MaxMakerVolRpcError::NoSuchCoin { .. } => StatusCode::BAD_REQUEST,
+            | MaxMakerVolRpcError::VolumeTooLow { .. } => StatusCode::BAD_REQUEST,
             MaxMakerVolRpcError::Transport(_) | MaxMakerVolRpcError::InternalError(_) => {
                 StatusCode::INTERNAL_SERVER_ERROR
             },


### PR DESCRIPTION
`max_maker_vol` RPC is actively used by client applications and does not rely on swap operations. This change allows wallet-only mode assets to use `max_maker_vol` RPC.