### PR TITLE
fix(ci-builds): use ssh-deploy action for all builds except windows

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -78,14 +78,14 @@ jobs:
         env:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
         if: ${{ env.AVAILABLE != '' }}
-        uses: garygrossgarten/github-action-scp@v0.8.0
+        uses: easingthemes/ssh-deploy@v5.0.3
         with:
-          host: ${{ secrets.FILE_SERVER_HOST }}
-          username: ${{ secrets.FILE_SERVER_USERNAME }}
-          port: ${{ secrets.FILE_SERVER_PORT }}
-          privateKey: ${{ secrets.FILE_SERVER_KEY }}
-          local: ${{ env.BRANCH_NAME }}
-          remote: "/uploads/${{ env.BRANCH_NAME }}"
+          REMOTE_HOST: ${{ secrets.FILE_SERVER_HOST }}
+          REMOTE_USER: ${{ secrets.FILE_SERVER_USERNAME }}
+          REMOTE_PORT: ${{ secrets.FILE_SERVER_PORT }}
+          SSH_PRIVATE_KEY: ${{ secrets.FILE_SERVER_KEY }}
+          SOURCE: "${{ env.BRANCH_NAME }}/"
+          TARGET: "/uploads/${{ env.BRANCH_NAME }}"
 
       - name: Login to dockerhub
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/dev'
@@ -155,14 +155,14 @@ jobs:
         env:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
         if: ${{ env.AVAILABLE != '' }}
-        uses: garygrossgarten/github-action-scp@v0.8.0
+        uses: easingthemes/ssh-deploy@v5.0.3
         with:
-          host: ${{ secrets.FILE_SERVER_HOST }}
-          username: ${{ secrets.FILE_SERVER_USERNAME }}
-          port: ${{ secrets.FILE_SERVER_PORT }}
-          privateKey: ${{ secrets.FILE_SERVER_KEY }}
-          local: ${{ env.BRANCH_NAME }}
-          remote: "/uploads/${{ env.BRANCH_NAME }}"
+          REMOTE_HOST: ${{ secrets.FILE_SERVER_HOST }}
+          REMOTE_USER: ${{ secrets.FILE_SERVER_USERNAME }}
+          REMOTE_PORT: ${{ secrets.FILE_SERVER_PORT }}
+          SSH_PRIVATE_KEY: ${{ secrets.FILE_SERVER_KEY }}
+          SOURCE: "${{ env.BRANCH_NAME }}/"
+          TARGET: "/uploads/${{ env.BRANCH_NAME }}"
 
   win-x86-64:
     timeout-minutes: 60
@@ -288,14 +288,14 @@ jobs:
         env:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
         if: ${{ env.AVAILABLE != '' }}
-        uses: garygrossgarten/github-action-scp@v0.8.0
+        uses: easingthemes/ssh-deploy@v5.0.3
         with:
-          host: ${{ secrets.FILE_SERVER_HOST }}
-          username: ${{ secrets.FILE_SERVER_USERNAME }}
-          port: ${{ secrets.FILE_SERVER_PORT }}
-          privateKey: ${{ secrets.FILE_SERVER_KEY }}
-          local: ${{ env.BRANCH_NAME }}
-          remote: "/uploads/${{ env.BRANCH_NAME }}"
+          REMOTE_HOST: ${{ secrets.FILE_SERVER_HOST }}
+          REMOTE_USER: ${{ secrets.FILE_SERVER_USERNAME }}
+          REMOTE_PORT: ${{ secrets.FILE_SERVER_PORT }}
+          SSH_PRIVATE_KEY: ${{ secrets.FILE_SERVER_KEY }}
+          SOURCE: "${{ env.BRANCH_NAME }}/"
+          TARGET: "/uploads/${{ env.BRANCH_NAME }}"
 
   wasm:
     timeout-minutes: 60
@@ -356,14 +356,14 @@ jobs:
         env:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
         if: ${{ env.AVAILABLE != '' }}
-        uses: garygrossgarten/github-action-scp@v0.8.0
+        uses: easingthemes/ssh-deploy@v5.0.3
         with:
-          host: ${{ secrets.FILE_SERVER_HOST }}
-          username: ${{ secrets.FILE_SERVER_USERNAME }}
-          port: ${{ secrets.FILE_SERVER_PORT }}
-          privateKey: ${{ secrets.FILE_SERVER_KEY }}
-          local: ${{ env.BRANCH_NAME }}
-          remote: "/uploads/${{ env.BRANCH_NAME }}"
+          REMOTE_HOST: ${{ secrets.FILE_SERVER_HOST }}
+          REMOTE_USER: ${{ secrets.FILE_SERVER_USERNAME }}
+          REMOTE_PORT: ${{ secrets.FILE_SERVER_PORT }}
+          SSH_PRIVATE_KEY: ${{ secrets.FILE_SERVER_KEY }}
+          SOURCE: "${{ env.BRANCH_NAME }}/"
+          TARGET: "/uploads/${{ env.BRANCH_NAME }}"
 
   ios-aarch64:
     timeout-minutes: 60
@@ -423,14 +423,14 @@ jobs:
         env:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
         if: ${{ env.AVAILABLE != '' }}
-        uses: garygrossgarten/github-action-scp@v0.8.0
+        uses: easingthemes/ssh-deploy@v5.0.3
         with:
-          host: ${{ secrets.FILE_SERVER_HOST }}
-          username: ${{ secrets.FILE_SERVER_USERNAME }}
-          port: ${{ secrets.FILE_SERVER_PORT }}
-          privateKey: ${{ secrets.FILE_SERVER_KEY }}
-          local: ${{ env.BRANCH_NAME }}
-          remote: "/uploads/${{ env.BRANCH_NAME }}"
+          REMOTE_HOST: ${{ secrets.FILE_SERVER_HOST }}
+          REMOTE_USER: ${{ secrets.FILE_SERVER_USERNAME }}
+          REMOTE_PORT: ${{ secrets.FILE_SERVER_PORT }}
+          SSH_PRIVATE_KEY: ${{ secrets.FILE_SERVER_KEY }}
+          SOURCE: "${{ env.BRANCH_NAME }}/"
+          TARGET: "/uploads/${{ env.BRANCH_NAME }}"
 
   android-aarch64:
     timeout-minutes: 60
@@ -504,14 +504,14 @@ jobs:
         env:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
         if: ${{ env.AVAILABLE != '' }}
-        uses: garygrossgarten/github-action-scp@v0.8.0
+        uses: easingthemes/ssh-deploy@v5.0.3
         with:
-          host: ${{ secrets.FILE_SERVER_HOST }}
-          username: ${{ secrets.FILE_SERVER_USERNAME }}
-          port: ${{ secrets.FILE_SERVER_PORT }}
-          privateKey: ${{ secrets.FILE_SERVER_KEY }}
-          local: ${{ env.BRANCH_NAME }}
-          remote: "/uploads/${{ env.BRANCH_NAME }}"
+          REMOTE_HOST: ${{ secrets.FILE_SERVER_HOST }}
+          REMOTE_USER: ${{ secrets.FILE_SERVER_USERNAME }}
+          REMOTE_PORT: ${{ secrets.FILE_SERVER_PORT }}
+          SSH_PRIVATE_KEY: ${{ secrets.FILE_SERVER_KEY }}
+          SOURCE: "${{ env.BRANCH_NAME }}/"
+          TARGET: "/uploads/${{ env.BRANCH_NAME }}"
 
   android-armv7:
     timeout-minutes: 60
@@ -585,14 +585,14 @@ jobs:
         env:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
         if: ${{ env.AVAILABLE != '' }}
-        uses: garygrossgarten/github-action-scp@v0.8.0
+        uses: easingthemes/ssh-deploy@v5.0.3
         with:
-          host: ${{ secrets.FILE_SERVER_HOST }}
-          username: ${{ secrets.FILE_SERVER_USERNAME }}
-          port: ${{ secrets.FILE_SERVER_PORT }}
-          privateKey: ${{ secrets.FILE_SERVER_KEY }}
-          local: ${{ env.BRANCH_NAME }}
-          remote: "/uploads/${{ env.BRANCH_NAME }}"
+          REMOTE_HOST: ${{ secrets.FILE_SERVER_HOST }}
+          REMOTE_USER: ${{ secrets.FILE_SERVER_USERNAME }}
+          REMOTE_PORT: ${{ secrets.FILE_SERVER_PORT }}
+          SSH_PRIVATE_KEY: ${{ secrets.FILE_SERVER_KEY }}
+          SOURCE: "${{ env.BRANCH_NAME }}/"
+          TARGET: "/uploads/${{ env.BRANCH_NAME }}"
 
   deployment-commitment:
     if: github.event_name != 'pull_request' && github.ref == 'refs/heads/dev'

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -69,14 +69,14 @@ jobs:
           mv $NAME ./$BRANCH_NAME/
 
       - name: Upload output
-        uses: garygrossgarten/github-action-scp@v0.8.0
+        uses: easingthemes/ssh-deploy@v5.0.3
         with:
-          host: ${{ secrets.FILE_SERVER_HOST }}
-          username: ${{ secrets.FILE_SERVER_USERNAME }}
-          port: ${{ secrets.FILE_SERVER_PORT }}
-          privateKey: ${{ secrets.FILE_SERVER_KEY }}
-          local: ${{ env.BRANCH_NAME }}
-          remote: "/uploads/${{ env.BRANCH_NAME }}"
+          REMOTE_HOST: ${{ secrets.FILE_SERVER_HOST }}
+          REMOTE_USER: ${{ secrets.FILE_SERVER_USERNAME }}
+          REMOTE_PORT: ${{ secrets.FILE_SERVER_PORT }}
+          SSH_PRIVATE_KEY: ${{ secrets.FILE_SERVER_KEY }}
+          SOURCE: "${{ env.BRANCH_NAME }}/"
+          TARGET: "/uploads/${{ env.BRANCH_NAME }}"
 
       - name: Login to dockerhub
         run: docker login --username ${{ secrets.DOCKER_HUB_USERNAME }} --password ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}  docker.io
@@ -134,14 +134,14 @@ jobs:
           mv $NAME ./$BRANCH_NAME/
 
       - name: Upload output
-        uses: garygrossgarten/github-action-scp@v0.8.0
+        uses: easingthemes/ssh-deploy@v5.0.3
         with:
-          host: ${{ secrets.FILE_SERVER_HOST }}
-          username: ${{ secrets.FILE_SERVER_USERNAME }}
-          port: ${{ secrets.FILE_SERVER_PORT }}
-          privateKey: ${{ secrets.FILE_SERVER_KEY }}
-          local: ${{ env.BRANCH_NAME }}
-          remote: "/uploads/${{ env.BRANCH_NAME }}"
+          REMOTE_HOST: ${{ secrets.FILE_SERVER_HOST }}
+          REMOTE_USER: ${{ secrets.FILE_SERVER_USERNAME }}
+          REMOTE_PORT: ${{ secrets.FILE_SERVER_PORT }}
+          SSH_PRIVATE_KEY: ${{ secrets.FILE_SERVER_KEY }}
+          SOURCE: "${{ env.BRANCH_NAME }}/"
+          TARGET: "/uploads/${{ env.BRANCH_NAME }}"
 
   win-x86-64:
     timeout-minutes: 60
@@ -248,14 +248,14 @@ jobs:
           mv $NAME ./$BRANCH_NAME/
 
       - name: Upload output
-        uses: garygrossgarten/github-action-scp@v0.8.0
+        uses: easingthemes/ssh-deploy@v5.0.3
         with:
-          host: ${{ secrets.FILE_SERVER_HOST }}
-          username: ${{ secrets.FILE_SERVER_USERNAME }}
-          port: ${{ secrets.FILE_SERVER_PORT }}
-          privateKey: ${{ secrets.FILE_SERVER_KEY }}
-          local: ${{ env.BRANCH_NAME }}
-          remote: "/uploads/${{ env.BRANCH_NAME }}"
+          REMOTE_HOST: ${{ secrets.FILE_SERVER_HOST }}
+          REMOTE_USER: ${{ secrets.FILE_SERVER_USERNAME }}
+          REMOTE_PORT: ${{ secrets.FILE_SERVER_PORT }}
+          SSH_PRIVATE_KEY: ${{ secrets.FILE_SERVER_KEY }}
+          SOURCE: "${{ env.BRANCH_NAME }}/"
+          TARGET: "/uploads/${{ env.BRANCH_NAME }}"
 
   wasm:
     timeout-minutes: 60
@@ -310,14 +310,14 @@ jobs:
           mv $NAME ./$BRANCH_NAME/
 
       - name: Upload output
-        uses: garygrossgarten/github-action-scp@v0.8.0
+        uses: easingthemes/ssh-deploy@v5.0.3
         with:
-          host: ${{ secrets.FILE_SERVER_HOST }}
-          username: ${{ secrets.FILE_SERVER_USERNAME }}
-          port: ${{ secrets.FILE_SERVER_PORT }}
-          privateKey: ${{ secrets.FILE_SERVER_KEY }}
-          local: ${{ env.BRANCH_NAME }}
-          remote: "/uploads/${{ env.BRANCH_NAME }}"
+          REMOTE_HOST: ${{ secrets.FILE_SERVER_HOST }}
+          REMOTE_USER: ${{ secrets.FILE_SERVER_USERNAME }}
+          REMOTE_PORT: ${{ secrets.FILE_SERVER_PORT }}
+          SSH_PRIVATE_KEY: ${{ secrets.FILE_SERVER_KEY }}
+          SOURCE: "${{ env.BRANCH_NAME }}/"
+          TARGET: "/uploads/${{ env.BRANCH_NAME }}"
 
   ios-aarch64:
     timeout-minutes: 60
@@ -368,14 +368,14 @@ jobs:
           mv $NAME ./$BRANCH_NAME/
 
       - name: Upload output
-        uses: garygrossgarten/github-action-scp@v0.8.0
+        uses: easingthemes/ssh-deploy@v5.0.3
         with:
-          host: ${{ secrets.FILE_SERVER_HOST }}
-          username: ${{ secrets.FILE_SERVER_USERNAME }}
-          port: ${{ secrets.FILE_SERVER_PORT }}
-          privateKey: ${{ secrets.FILE_SERVER_KEY }}
-          local: ${{ env.BRANCH_NAME }}
-          remote: "/uploads/${{ env.BRANCH_NAME }}"
+          REMOTE_HOST: ${{ secrets.FILE_SERVER_HOST }}
+          REMOTE_USER: ${{ secrets.FILE_SERVER_USERNAME }}
+          REMOTE_PORT: ${{ secrets.FILE_SERVER_PORT }}
+          SSH_PRIVATE_KEY: ${{ secrets.FILE_SERVER_KEY }}
+          SOURCE: "${{ env.BRANCH_NAME }}/"
+          TARGET: "/uploads/${{ env.BRANCH_NAME }}"
 
   android-aarch64:
     timeout-minutes: 60
@@ -440,14 +440,14 @@ jobs:
           mv $NAME ./$BRANCH_NAME/
 
       - name: Upload output
-        uses: garygrossgarten/github-action-scp@v0.8.0
+        uses: easingthemes/ssh-deploy@v5.0.3
         with:
-          host: ${{ secrets.FILE_SERVER_HOST }}
-          username: ${{ secrets.FILE_SERVER_USERNAME }}
-          port: ${{ secrets.FILE_SERVER_PORT }}
-          privateKey: ${{ secrets.FILE_SERVER_KEY }}
-          local: ${{ env.BRANCH_NAME }}
-          remote: "/uploads/${{ env.BRANCH_NAME }}"
+          REMOTE_HOST: ${{ secrets.FILE_SERVER_HOST }}
+          REMOTE_USER: ${{ secrets.FILE_SERVER_USERNAME }}
+          REMOTE_PORT: ${{ secrets.FILE_SERVER_PORT }}
+          SSH_PRIVATE_KEY: ${{ secrets.FILE_SERVER_KEY }}
+          SOURCE: "${{ env.BRANCH_NAME }}/"
+          TARGET: "/uploads/${{ env.BRANCH_NAME }}"
 
   android-armv7:
     timeout-minutes: 60
@@ -512,11 +512,11 @@ jobs:
           mv $NAME ./$BRANCH_NAME/
 
       - name: Upload output
-        uses: garygrossgarten/github-action-scp@v0.8.0
+        uses: easingthemes/ssh-deploy@v5.0.3
         with:
-          host: ${{ secrets.FILE_SERVER_HOST }}
-          username: ${{ secrets.FILE_SERVER_USERNAME }}
-          port: ${{ secrets.FILE_SERVER_PORT }}
-          privateKey: ${{ secrets.FILE_SERVER_KEY }}
-          local: ${{ env.BRANCH_NAME }}
-          remote: "/uploads/${{ env.BRANCH_NAME }}"
+          REMOTE_HOST: ${{ secrets.FILE_SERVER_HOST }}
+          REMOTE_USER: ${{ secrets.FILE_SERVER_USERNAME }}
+          REMOTE_PORT: ${{ secrets.FILE_SERVER_PORT }}
+          SSH_PRIVATE_KEY: ${{ secrets.FILE_SERVER_KEY }}
+          SOURCE: "${{ env.BRANCH_NAME }}/"
+          TARGET: "/uploads/${{ env.BRANCH_NAME }}"


### PR DESCRIPTION
`github-action-scp` stopped working for all machines except windows for some reason, this PR switches to [easingthemes/ssh-deploy@v5.0.3](https://github.com/easingthemes/ssh-deploy/releases/tag/v5.0.3) for all builds uploads except windows ones. `ssh-deploy` uses rsync over ssh and brings some benefits such as using Node.js 20 in v5.0.3, data integrity of transferred files by using checksums and compressing file data during transfer among other things.