### PR TITLE
fix(helpers): extend http to ws address conversion

### DIFF
--- a/mm2src/coins/tendermint/tendermint_balance_events.rs
+++ b/mm2src/coins/tendermint/tendermint_balance_events.rs
@@ -68,10 +68,10 @@ impl EventBehaviour for TendermintCoin {
 
             let socket_address = format!("{}/{}", http_uri_to_ws_address(node_uri), "websocket");
 
-            let mut wsocket = match tokio_tungstenite_wasm::connect(socket_address).await {
+            let mut wsocket = match tokio_tungstenite_wasm::connect(&socket_address).await {
                 Ok(ws) => ws,
                 Err(e) => {
-                    log::error!("{e}");
+                    log::error!("Couldn't connect to '{socket_address}': {e}");
                     continue;
                 },
             };

--- a/mm2src/common/common.rs
+++ b/mm2src/common/common.rs
@@ -1121,9 +1121,10 @@ pub fn http_uri_to_ws_address(uri: http::Uri) -> String {
     };
 
     let host_address = uri.host().expect("Host can't be empty.");
+    let path = if uri.path() == "/" { "" } else { uri.path() };
     let port = uri.port_u16().map(|p| format!(":{}", p)).unwrap_or_default();
 
-    format!("{}{}{}", address_prefix, host_address, port)
+    format!("{}{}{}{}", address_prefix, host_address, port, path)
 }
 
 #[test]
@@ -1132,13 +1133,22 @@ fn test_http_uri_to_ws_address() {
     let ws_connection = http_uri_to_ws_address(uri);
     assert_eq!(ws_connection, "wss://cosmos-rpc.polkachu.com");
 
-    let uri = "http://cosmos-rpc.polkachu.com".parse::<http::Uri>().unwrap();
+    let uri = "http://cosmos-rpc.polkachu.com/".parse::<http::Uri>().unwrap();
     let ws_connection = http_uri_to_ws_address(uri);
     assert_eq!(ws_connection, "ws://cosmos-rpc.polkachu.com");
 
     let uri = "http://34.82.96.8:26657".parse::<http::Uri>().unwrap();
     let ws_connection = http_uri_to_ws_address(uri);
     assert_eq!(ws_connection, "ws://34.82.96.8:26657");
+
+    let uri = "https://cosmos.blockpi.network/rpc/v1/65cc8a9ffe1627352b911dd4b7c751db4a3eaee3"
+        .parse::<http::Uri>()
+        .unwrap();
+    let ws_connection = http_uri_to_ws_address(uri);
+    assert_eq!(
+        ws_connection,
+        "wss://cosmos.blockpi.network/rpc/v1/65cc8a9ffe1627352b911dd4b7c751db4a3eaee3"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Extends `common::http_uri_to_ws_address` helper to include address path.