### PR TITLE
chore(cargo-config): migrate to `config.toml` to avoid warning

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,14 +8,14 @@ rustflags = [ "-Zshare-generics=y" ]
 # [target.x86_64-unknown-linux-gnu]
 # linker = "clang"
 # rustflags = [ "-Clink-arg=-fuse-ld=lld" ]
-# 
+#
 # # `brew install llvm`
 # [target.x86_64-apple-darwin]
 # rustflags = [
 #     "-C",
 #     "link-arg=-fuse-ld=/usr/local/opt/llvm/bin/ld64.lld",
 # ]
-# 
+#
 # [target.aarch64-apple-darwin]
 # rustflags = [
 #     "-C",


### PR DESCRIPTION
This is to avoid the below warning when running commands such as `cargo +nightly fmt`
```bash
/atomicDEX-API/.cargo/config` is deprecated in favor of `config.toml`
note: if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
```