### PR TITLE
ci(docker-tests): ignore tendermint IBC tests for now

### DIFF
--- a/mm2src/mm2_main/tests/docker_tests/docker_tests_common.rs
+++ b/mm2src/mm2_main/tests/docker_tests/docker_tests_common.rs
@@ -409,6 +409,7 @@ pub fn atom_node(docker: &'_ Cli, runtime_dir: PathBuf) -> DockerNode<'_> {
     }
 }
 
+#[allow(dead_code)]
 pub fn ibc_relayer_node(docker: &'_ Cli, runtime_dir: PathBuf) -> DockerNode<'_> {
     let relayer_node_runtime_dir = runtime_dir.join("ibc-relayer-data");
     assert!(relayer_node_runtime_dir.exists());
@@ -1145,6 +1146,7 @@ async fn get_current_gas_limit(web3: &Web3<Http>) {
     }
 }
 
+#[allow(dead_code)]
 pub fn wait_until_relayer_container_is_ready(container_id: &str) {
     const Q_RESULT: &str = "0: nucleus-atom         -> chns(✔) clnts(✔) conn(✔) (nucleus-testnet<>cosmoshub-testnet)";
 

--- a/mm2src/mm2_main/tests/docker_tests/tendermint_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/tendermint_tests.rs
@@ -312,6 +312,7 @@ fn test_custom_gas_limit_on_tendermint_withdraw() {
 }
 
 #[test]
+#[ignore]
 fn test_tendermint_ibc_withdraw() {
     // visit `{swagger_address}/ibc/core/channel/v1/channels?pagination.limit=10000` to see the full list of ibc channels
     const IBC_SOURCE_CHANNEL: &str = "channel-1";
@@ -358,6 +359,7 @@ fn test_tendermint_ibc_withdraw() {
 }
 
 #[test]
+#[ignore]
 fn test_tendermint_ibc_withdraw_hd() {
     // visit `{swagger_address}/ibc/core/channel/v1/channels?pagination.limit=10000` to see the full list of ibc channels
     const IBC_SOURCE_CHANNEL: &str = "channel-1";

--- a/mm2src/mm2_main/tests/docker_tests_main.rs
+++ b/mm2src/mm2_main/tests/docker_tests_main.rs
@@ -68,8 +68,8 @@ pub fn docker_tests_runner(tests: &[&TestDescAndFn]) {
         let runtime_dir = prepare_runtime_dir().unwrap();
 
         let nucleus_node = nucleus_node(&docker, runtime_dir.clone());
-        let atom_node = atom_node(&docker, runtime_dir.clone());
-        let ibc_relayer_node = ibc_relayer_node(&docker, runtime_dir);
+        let atom_node = atom_node(&docker, runtime_dir);
+        // let ibc_relayer_node = ibc_relayer_node(&docker, runtime_dir);
         let utxo_node = utxo_asset_docker_node(&docker, "MYCOIN", 7000);
         let utxo_node1 = utxo_asset_docker_node(&docker, "MYCOIN1", 8000);
         let qtum_node = qtum_docker_node(&docker, 9000);
@@ -90,7 +90,8 @@ pub fn docker_tests_runner(tests: &[&TestDescAndFn]) {
 
         wait_for_geth_node_ready();
         init_geth_node();
-        wait_until_relayer_container_is_ready(ibc_relayer_node.container.id());
+        thread::sleep(Duration::from_secs(10));
+        // wait_until_relayer_container_is_ready(ibc_relayer_node.container.id());
 
         containers.push(utxo_node);
         containers.push(utxo_node1);
@@ -99,7 +100,7 @@ pub fn docker_tests_runner(tests: &[&TestDescAndFn]) {
         containers.push(geth_node);
         containers.push(nucleus_node);
         containers.push(atom_node);
-        containers.push(ibc_relayer_node);
+        // containers.push(ibc_relayer_node);
     }
     // detect if docker is installed
     // skip the tests that use docker if not installed


### PR DESCRIPTION
This will help me while reviewing other PRs. @onur-ozkan you can enable them again when you have time to fix the IBC node.