### PR TITLE
chrone(tendermint-activation): make `komodo_proxy` optional param 

### DIFF
--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -137,6 +137,7 @@ impl TendermintKeyPair {
 #[derive(Clone, Deserialize)]
 pub struct RpcNode {
     url: String,
+    #[serde(default)]
     komodo_proxy: bool,
 }
 


### PR DESCRIPTION
self-explanatory

cc @cipig 