### PR TITLE
chore(WASM-builds): remove `wasm-opt` overriding

### DIFF
--- a/mm2src/mm2_bin_lib/Cargo.toml
+++ b/mm2src/mm2_bin_lib/Cargo.toml
@@ -10,11 +10,6 @@ authors = ["James Lee", "Artem Pikulin", "Artem Grinblat", "Omar S.", "Onur Ozka
 edition = "2018"
 default-run = "kdf"
 
-# wasm-opt reduces the size from 17 Mb to 14. But it runs for few minutes, which is not good for CI.
-# For production builds, it's recommended to run wasm-opt separately.
-[package.metadata.wasm-pack.profile.release]
-wasm-opt = false
-
 [features]
 custom-swap-locktime = ["mm2_main/custom-swap-locktime"] # only for testing purposes, should never be activated on release builds.
 native = ["mm2_main/native"] # Deprecated


### PR DESCRIPTION
Our WASM builds are fairly quicker than the other ones. We can afford couple extra minutes on that runner.