### PR TITLE
feat(wallets): add `get_wallet_names` rpc

### DIFF
--- a/mm2src/mm2_core/src/lib.rs
+++ b/mm2src/mm2_core/src/lib.rs
@@ -19,4 +19,6 @@ impl DbNamespaceId {
         let mut rng = thread_rng();
         DbNamespaceId::Test(rng.gen())
     }
+
+    pub fn for_test_with_id(id: u64) -> DbNamespaceId { DbNamespaceId::Test(id) }
 }

--- a/mm2src/mm2_core/src/lib.rs
+++ b/mm2src/mm2_core/src/lib.rs
@@ -1,10 +1,11 @@
-use derive_more::Display;
-use rand::{thread_rng, Rng};
+#[cfg(target_arch = "wasm32")] use derive_more::Display;
+#[cfg(target_arch = "wasm32")] use rand::{thread_rng, Rng};
 
 pub mod data_asker;
 pub mod event_dispatcher;
 pub mod mm_ctx;
 
+#[cfg(target_arch = "wasm32")]
 #[derive(Clone, Copy, Display, PartialEq, Default)]
 pub enum DbNamespaceId {
     #[display(fmt = "MAIN")]
@@ -14,11 +15,13 @@ pub enum DbNamespaceId {
     Test(u64),
 }
 
+#[cfg(target_arch = "wasm32")]
 impl DbNamespaceId {
     pub fn for_test() -> DbNamespaceId {
         let mut rng = thread_rng();
         DbNamespaceId::Test(rng.gen())
     }
 
+    #[inline(always)]
     pub fn for_test_with_id(id: u64) -> DbNamespaceId { DbNamespaceId::Test(id) }
 }

--- a/mm2src/mm2_core/src/mm_ctx.rs
+++ b/mm2src/mm2_core/src/mm_ctx.rs
@@ -739,6 +739,12 @@ impl MmCtxBuilder {
         self
     }
 
+    #[cfg(target_arch = "wasm32")]
+    pub fn with_test_db_namespace_with_id(mut self, id: u64) -> Self {
+        self.db_namespace = DbNamespaceId::for_test_with_id(id);
+        self
+    }
+
     pub fn into_mm_arc(self) -> MmArc {
         // NB: We avoid recreating LogState
         // in order not to interfere with the integration tests checking LogState drop on shutdown.

--- a/mm2src/mm2_core/src/mm_ctx.rs
+++ b/mm2src/mm2_core/src/mm_ctx.rs
@@ -288,9 +288,11 @@ impl MmCtx {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
+    pub fn db_root(&self) -> PathBuf { path_to_db_root(self.conf["dbdir"].as_str()) }
+
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn wallet_file_path(&self, wallet_name: &str) -> PathBuf {
-        let db_root = path_to_db_root(self.conf["dbdir"].as_str());
-        db_root.join(wallet_name.to_string() + ".dat")
+        self.db_root().join(wallet_name.to_string() + ".dat")
     }
 
     /// MM database path.  

--- a/mm2src/mm2_io/src/fs.rs
+++ b/mm2src/mm2_io/src/fs.rs
@@ -269,6 +269,7 @@ where
 
 /// Read the `dir_path` entries trying to deserialize each as the `T` type from JSON files.
 /// Please note that files that couldn't be deserialized are skipped.
+#[inline(always)]
 pub async fn read_dir_json<T>(dir_path: &Path) -> FsJsonResult<Vec<T>>
 where
     T: DeserializeOwned,

--- a/mm2src/mm2_io/src/fs.rs
+++ b/mm2src/mm2_io/src/fs.rs
@@ -193,11 +193,11 @@ where
 }
 
 async fn filter_files_with_extension(dir_path: &Path, extension: &str) -> IoResult<Vec<PathBuf>> {
-    let ext = Some(OsStr::new(extension));
+    let ext = Some(OsStr::new(extension).to_ascii_lowercase());
     let entries = read_dir_async(dir_path)
         .await?
         .into_iter()
-        .filter(|path| path.extension() == ext)
+        .filter(|path| path.extension().map(|ext| ext.to_ascii_lowercase()) == ext)
         .collect();
     Ok(entries)
 }

--- a/mm2src/mm2_main/src/lp_wallet.rs
+++ b/mm2src/mm2_main/src/lp_wallet.rs
@@ -538,7 +538,7 @@ impl From<WalletsDBError> for GetWalletsError {
 /// Retrieves all created wallets and the currently activated wallet.
 pub async fn get_wallet_names_rpc(ctx: MmArc, _req: Json) -> MmResult<GetWalletNamesResponse, GetWalletsError> {
     // We want to return wallet names in the same order for both native and wasm32 targets.
-    let wallets = read_all_wallet_names(&ctx).await?.into_iter().sorted().collect();
+    let wallets = read_all_wallet_names(&ctx).await?.sorted().collect();
     // Note: `ok_or` is used here on `Constructible<Option<String>>` to handle the case where the wallet name is not set.
     // `wallet_name` can be `None` in the case of no-login mode.
     let activated_wallet = ctx.wallet_name.ok_or(GetWalletsError::Internal(

--- a/mm2src/mm2_main/src/lp_wallet.rs
+++ b/mm2src/mm2_main/src/lp_wallet.rs
@@ -537,6 +537,8 @@ impl From<WalletsDBError> for GetWalletsError {
 /// Retrieves all created wallets and the currently activated wallet.
 pub async fn get_wallet_names_rpc(ctx: MmArc, _req: Json) -> MmResult<GetWalletNamesResponse, GetWalletsError> {
     let wallets = read_all_wallet_names(&ctx).await?;
+    // Note: `ok_or` is used here on `Constructible<Option<String>>` to handle the case where the wallet name is not set.
+    // `wallet_name` can be `None` in the case of no-login mode.
     let activated_wallet = ctx.wallet_name.ok_or(GetWalletsError::Internal(
         "`wallet_name` not initialized yet!".to_string(),
     ))?;

--- a/mm2src/mm2_main/src/lp_wallet.rs
+++ b/mm2src/mm2_main/src/lp_wallet.rs
@@ -5,20 +5,20 @@ use http::StatusCode;
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::prelude::*;
 use serde::de::DeserializeOwned;
-use serde_json::{self as json};
+use serde_json::{self as json, Value as Json};
 
 cfg_wasm32! {
     use crate::lp_wallet::mnemonics_wasm_db::{WalletsDb, WalletsDBError};
     use mm2_core::mm_ctx::from_ctx;
     use mm2_db::indexed_db::{ConstructibleDb, DbLocked, InitDbResult};
-    use mnemonics_wasm_db::{read_encrypted_passphrase_if_available, save_encrypted_passphrase};
+    use mnemonics_wasm_db::{read_all_wallet_names, read_encrypted_passphrase_if_available, save_encrypted_passphrase};
     use std::sync::Arc;
 
     type WalletsDbLocked<'a> = DbLocked<'a, WalletsDb>;
 }
 
 cfg_native! {
-    use mnemonics_storage::{read_encrypted_passphrase_if_available, save_encrypted_passphrase, WalletsStorageError};
+    use mnemonics_storage::{read_all_wallet_names, read_encrypted_passphrase_if_available, save_encrypted_passphrase, WalletsStorageError};
 }
 
 #[cfg(not(target_arch = "wasm32"))] mod mnemonics_storage;
@@ -498,4 +498,51 @@ pub async fn get_mnemonic_rpc(ctx: MmArc, req: GetMnemonicRequest) -> MmResult<G
             })
         },
     }
+}
+
+/// The response to `get_wallet_names_rpc`, returns all created wallet names and the currently activated wallet name.
+#[derive(Serialize)]
+pub struct GetWalletNamesResponse {
+    wallet_names: Vec<String>,
+    activated_wallet: Option<String>,
+}
+
+#[derive(Debug, Display, Serialize, SerializeErrorType)]
+#[serde(tag = "error_type", content = "error_data")]
+pub enum GetWalletsError {
+    #[display(fmt = "Wallets storage error: {}", _0)]
+    WalletsStorageError(String),
+    #[display(fmt = "Internal error: {}", _0)]
+    Internal(String),
+}
+
+impl HttpStatusCode for GetWalletsError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            GetWalletsError::WalletsStorageError(_) | GetWalletsError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl From<WalletsStorageError> for GetWalletsError {
+    fn from(e: WalletsStorageError) -> Self { GetWalletsError::WalletsStorageError(e.to_string()) }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl From<WalletsDBError> for GetWalletsError {
+    fn from(e: WalletsDBError) -> Self { GetWalletsError::WalletsStorageError(e.to_string()) }
+}
+
+/// Retrieves all created wallets and the currently activated wallet.
+pub async fn get_wallet_names_rpc(ctx: MmArc, _req: Json) -> MmResult<GetWalletNamesResponse, GetWalletsError> {
+    let wallets = read_all_wallet_names(&ctx).await?;
+    let activated_wallet = ctx.wallet_name.ok_or(GetWalletsError::Internal(
+        "`wallet_name` not initialized yet!".to_string(),
+    ))?;
+
+    Ok(GetWalletNamesResponse {
+        wallet_names: wallets,
+        activated_wallet: activated_wallet.clone(),
+    })
 }

--- a/mm2src/mm2_main/src/lp_wallet/mnemonics_storage.rs
+++ b/mm2src/mm2_main/src/lp_wallet/mnemonics_storage.rs
@@ -62,7 +62,7 @@ pub(super) async fn read_encrypted_passphrase_if_available(ctx: &MmArc) -> Walle
     })
 }
 
-pub(super) async fn read_all_wallet_names(ctx: &MmArc) -> WalletsStorageResult<Vec<String>> {
+pub(super) async fn read_all_wallet_names(ctx: &MmArc) -> WalletsStorageResult<impl Iterator<Item = String>> {
     let wallet_names = list_files_by_extension(&ctx.db_root(), "dat", false)
         .await
         .mm_err(|e| WalletsStorageError::FsReadError(format!("Error reading wallets directory: {}", e)))?;

--- a/mm2src/mm2_main/src/lp_wallet/mnemonics_storage.rs
+++ b/mm2src/mm2_main/src/lp_wallet/mnemonics_storage.rs
@@ -1,7 +1,7 @@
 use crypto::EncryptedData;
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::prelude::*;
-use mm2_io::fs::{ensure_file_is_writable, read_file_stems_with_extension};
+use mm2_io::fs::{ensure_file_is_writable, list_files_by_extension};
 
 type WalletsStorageResult<T> = Result<T, MmError<WalletsStorageError>>;
 
@@ -63,7 +63,7 @@ pub(super) async fn read_encrypted_passphrase_if_available(ctx: &MmArc) -> Walle
 }
 
 pub(super) async fn read_all_wallet_names(ctx: &MmArc) -> WalletsStorageResult<Vec<String>> {
-    let wallet_names = read_file_stems_with_extension(&ctx.db_root(), "dat")
+    let wallet_names = list_files_by_extension(&ctx.db_root(), "dat", false)
         .await
         .mm_err(|e| WalletsStorageError::FsReadError(format!("Error reading wallets directory: {}", e)))?;
     Ok(wallet_names)

--- a/mm2src/mm2_main/src/lp_wallet/mnemonics_storage.rs
+++ b/mm2src/mm2_main/src/lp_wallet/mnemonics_storage.rs
@@ -1,7 +1,7 @@
 use crypto::EncryptedData;
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::prelude::*;
-use mm2_io::fs::ensure_file_is_writable;
+use mm2_io::fs::{ensure_file_is_writable, read_file_stems_with_extension};
 
 type WalletsStorageResult<T> = Result<T, MmError<WalletsStorageError>>;
 
@@ -60,4 +60,11 @@ pub(super) async fn read_encrypted_passphrase_if_available(ctx: &MmArc) -> Walle
             e
         ))
     })
+}
+
+pub(super) async fn read_all_wallet_names(ctx: &MmArc) -> WalletsStorageResult<Vec<String>> {
+    let wallet_names = read_file_stems_with_extension(&ctx.db_root(), "dat")
+        .await
+        .mm_err(|e| WalletsStorageError::FsReadError(format!("Error reading wallets directory: {}", e)))?;
+    Ok(wallet_names)
 }

--- a/mm2src/mm2_main/src/lp_wallet/mnemonics_wasm_db.rs
+++ b/mm2src/mm2_main/src/lp_wallet/mnemonics_wasm_db.rs
@@ -145,7 +145,7 @@ pub(super) async fn read_encrypted_passphrase_if_available(ctx: &MmArc) -> Walle
         .transpose()
 }
 
-pub(super) async fn read_all_wallet_names(ctx: &MmArc) -> WalletsDBResult<Vec<String>> {
+pub(super) async fn read_all_wallet_names(ctx: &MmArc) -> WalletsDBResult<impl Iterator<Item = String>> {
     let wallets_ctx = WalletsContext::from_ctx(ctx).map_to_mm(WalletsDBError::Internal)?;
 
     let db = wallets_ctx.wallets_db().await?;
@@ -153,7 +153,7 @@ pub(super) async fn read_all_wallet_names(ctx: &MmArc) -> WalletsDBResult<Vec<St
     let table = transaction.table::<MnemonicsTable>().await?;
 
     let all_items = table.get_all_items().await?;
-    let wallet_names = all_items.into_iter().map(|(_, item)| item.wallet_name).collect();
+    let wallet_names = all_items.into_iter().map(|(_, item)| item.wallet_name);
 
     Ok(wallet_names)
 }

--- a/mm2src/mm2_main/src/lp_wallet/mnemonics_wasm_db.rs
+++ b/mm2src/mm2_main/src/lp_wallet/mnemonics_wasm_db.rs
@@ -144,3 +144,16 @@ pub(super) async fn read_encrypted_passphrase_if_available(ctx: &MmArc) -> Walle
         })
         .transpose()
 }
+
+pub(super) async fn read_all_wallet_names(ctx: &MmArc) -> WalletsDBResult<Vec<String>> {
+    let wallets_ctx = WalletsContext::from_ctx(ctx).map_to_mm(WalletsDBError::Internal)?;
+
+    let db = wallets_ctx.wallets_db().await?;
+    let transaction = db.transaction().await?;
+    let table = transaction.table::<MnemonicsTable>().await?;
+
+    let all_items = table.get_all_items().await?;
+    let wallet_names = all_items.into_iter().map(|(_, item)| item.wallet_name).collect();
+
+    Ok(wallet_names)
+}

--- a/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
+++ b/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
@@ -5,7 +5,7 @@ use crate::lp_native_dex::init_metamask::{cancel_connect_metamask, connect_metam
 use crate::lp_ordermatch::{best_orders_rpc_v2, orderbook_rpc_v2, start_simple_market_maker_bot,
                            stop_simple_market_maker_bot};
 use crate::lp_swap::swap_v2_rpcs::{active_swaps_rpc, my_recent_swaps_rpc, my_swap_status_rpc};
-use crate::lp_wallet::get_mnemonic_rpc;
+use crate::lp_wallet::{get_mnemonic_rpc, get_wallet_names_rpc};
 use crate::rpc::rate_limiter::{process_rate_limit, RateLimitContext};
 use crate::{lp_stats::{add_node_to_version_stat, remove_node_from_version_stat, start_version_stat_collection,
                        stop_version_stat_collection, update_version_stat_collection},
@@ -190,6 +190,7 @@ async fn dispatcher_v2(request: MmRpcRequest, ctx: MmArc) -> DispatcherResult<Re
         "get_raw_transaction" => handle_mmrpc(ctx, request, get_raw_transaction).await,
         "get_shared_db_id" => handle_mmrpc(ctx, request, get_shared_db_id).await,
         "get_staking_infos" => handle_mmrpc(ctx, request, get_staking_infos).await,
+        "get_wallet_names" => handle_mmrpc(ctx, request, get_wallet_names_rpc).await,
         "max_maker_vol" => handle_mmrpc(ctx, request, max_maker_vol).await,
         "my_recent_swaps" => handle_mmrpc(ctx, request, my_recent_swaps_rpc).await,
         "my_swap_status" => handle_mmrpc(ctx, request, my_swap_status_rpc).await,

--- a/mm2src/mm2_main/src/wasm_tests.rs
+++ b/mm2src/mm2_main/src/wasm_tests.rs
@@ -1,14 +1,14 @@
 use crate::lp_init;
-use common::executor::{spawn, Timer};
+use common::executor::{spawn, spawn_abortable, spawn_local_abortable, AbortOnDropHandle, Timer};
 use common::log::wasm_log::register_wasm_log;
 use mm2_core::mm_ctx::MmArc;
 use mm2_number::BigDecimal;
 use mm2_rpc::data::legacy::OrderbookResponse;
 use mm2_test_helpers::electrums::{doc_electrums, marty_electrums};
 use mm2_test_helpers::for_tests::{check_recent_swaps, enable_electrum_json, enable_utxo_v2_electrum,
-                                  enable_z_coin_light, morty_conf, pirate_conf, rick_conf, start_swaps,
-                                  test_qrc20_history_impl, wait_for_swaps_finish_and_check_status, MarketMakerIt,
-                                  Mm2InitPrivKeyPolicy, Mm2TestConf, Mm2TestConfForSwap, ARRR, MORTY,
+                                  enable_z_coin_light, get_wallet_names, morty_conf, pirate_conf, rick_conf,
+                                  start_swaps, test_qrc20_history_impl, wait_for_swaps_finish_and_check_status,
+                                  MarketMakerIt, Mm2InitPrivKeyPolicy, Mm2TestConf, Mm2TestConfForSwap, ARRR, MORTY,
                                   PIRATE_ELECTRUMS, PIRATE_LIGHTWALLETD_URLS, RICK};
 use mm2_test_helpers::get_passphrase;
 use mm2_test_helpers::structs::{Bip44Chain, EnableCoinBalance, HDAccountAddressId};
@@ -16,6 +16,7 @@ use serde_json::json;
 use wasm_bindgen_test::wasm_bindgen_test;
 
 const PIRATE_TEST_BALANCE_SEED: &str = "pirate test seed";
+const STOP_TIMEOUT_MS: u64 = 1000;
 
 /// Starts the WASM version of MM.
 fn wasm_start(ctx: MmArc) {
@@ -26,13 +27,7 @@ fn wasm_start(ctx: MmArc) {
 
 /// This function runs Alice and Bob nodes, activates coins, starts swaps,
 /// and then immediately stops the nodes to check if `MmArc` is dropped in a short period.
-async fn test_mm2_stops_impl(
-    pairs: &[(&'static str, &'static str)],
-    maker_price: f64,
-    taker_price: f64,
-    volume: f64,
-    stop_timeout_ms: u64,
-) {
+async fn test_mm2_stops_impl(pairs: &[(&'static str, &'static str)], maker_price: f64, taker_price: f64, volume: f64) {
     let coins = json!([rick_conf(), morty_conf()]);
 
     let bob_passphrase = get_passphrase!(".env.seed", "BOB_PASSPHRASE").unwrap();
@@ -69,20 +64,18 @@ async fn test_mm2_stops_impl(
     start_swaps(&mut mm_bob, &mut mm_alice, pairs, maker_price, taker_price, volume).await;
 
     mm_alice
-        .stop_and_wait_for_ctx_is_dropped(stop_timeout_ms)
+        .stop_and_wait_for_ctx_is_dropped(STOP_TIMEOUT_MS)
         .await
         .unwrap();
-    mm_bob.stop_and_wait_for_ctx_is_dropped(stop_timeout_ms).await.unwrap();
+    mm_bob.stop_and_wait_for_ctx_is_dropped(STOP_TIMEOUT_MS).await.unwrap();
 }
 
 #[wasm_bindgen_test]
 async fn test_mm2_stops_immediately() {
-    const STOP_TIMEOUT_MS: u64 = 1000;
-
     register_wasm_log();
 
     let pairs: &[_] = &[("RICK", "MORTY")];
-    test_mm2_stops_impl(pairs, 1., 1., 0.0001, STOP_TIMEOUT_MS).await;
+    test_mm2_stops_impl(pairs, 1., 1., 0.0001).await;
 }
 
 #[wasm_bindgen_test]
@@ -146,8 +139,6 @@ async fn trade_base_rel_electrum(
         assert_eq!(0, bob_orderbook.bids.len(), "{} {} bids must be empty", base, rel);
         assert_eq!(0, bob_orderbook.asks.len(), "{} {} asks must be empty", base, rel);
     }
-
-    const STOP_TIMEOUT_MS: u64 = 1000;
 
     mm_bob.stop_and_wait_for_ctx_is_dropped(STOP_TIMEOUT_MS).await.unwrap();
     mm_alice
@@ -265,4 +256,44 @@ async fn activate_z_coin_light() {
         _ => panic!("Expected EnableCoinBalance::Iguana"),
     };
     assert_eq!(balance.balance.spendable, BigDecimal::default());
+}
+
+#[wasm_bindgen_test]
+async fn test_get_wallet_names() {
+    const DB_NAMESPACE_NUM: u64 = 1;
+
+    let coins = json!([]);
+
+    // Initialize the first wallet with a specific name
+    let wallet_1 = Mm2TestConf::seednode_with_wallet_name(&coins, "wallet_1", "pass");
+    let mm_wallet_1 =
+        MarketMakerIt::start_with_db(wallet_1.conf, wallet_1.rpc_password, Some(wasm_start), DB_NAMESPACE_NUM)
+            .await
+            .unwrap();
+
+    // Retrieve and verify the wallet names for the first wallet
+    let get_wallet_names_1 = get_wallet_names(&mm_wallet_1).await;
+    assert_eq!(get_wallet_names_1.wallet_names, vec!["wallet_1"]);
+    assert_eq!(get_wallet_names_1.activated_wallet.unwrap(), "wallet_1");
+
+    // Stop the first wallet before starting the second one
+    mm_wallet_1
+        .stop_and_wait_for_ctx_is_dropped(STOP_TIMEOUT_MS)
+        .await
+        .unwrap();
+
+    // Initialize the second wallet with a different name
+    let wallet_2 = Mm2TestConf::seednode_with_wallet_name(&coins, "wallet_2", "pass");
+    let mm_wallet_2 =
+        MarketMakerIt::start_with_db(wallet_2.conf, wallet_2.rpc_password, Some(wasm_start), DB_NAMESPACE_NUM)
+            .await
+            .unwrap();
+
+    // Retrieve and verify the wallet names for the second wallet
+    let get_wallet_names_2 = get_wallet_names(&mm_wallet_2).await;
+    assert_eq!(get_wallet_names_2.wallet_names, vec!["wallet_1", "wallet_2"]);
+    assert_eq!(get_wallet_names_2.activated_wallet.unwrap(), "wallet_2");
+
+    // Stop the second wallet
+    mm_wallet_2.stop_and_wait_for_ctx_is_dropped(1000).await.unwrap();
 }

--- a/mm2src/mm2_main/src/wasm_tests.rs
+++ b/mm2src/mm2_main/src/wasm_tests.rs
@@ -295,5 +295,8 @@ async fn test_get_wallet_names() {
     assert_eq!(get_wallet_names_2.activated_wallet.unwrap(), "wallet_2");
 
     // Stop the second wallet
-    mm_wallet_2.stop_and_wait_for_ctx_is_dropped(1000).await.unwrap();
+    mm_wallet_2
+        .stop_and_wait_for_ctx_is_dropped(STOP_TIMEOUT_MS)
+        .await
+        .unwrap();
 }

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -310,6 +310,21 @@ impl Mm2TestConf {
         }
     }
 
+    pub fn seednode_with_wallet_name(coins: &Json, wallet_name: &str, wallet_password: &str) -> Self {
+        Mm2TestConf {
+            conf: json!({
+                "gui": "nogui",
+                "netid": 9998,
+                "coins": coins,
+                "rpc_password": DEFAULT_RPC_PASSWORD,
+                "i_am_seed": true,
+                "wallet_name": wallet_name,
+                "wallet_password": wallet_password,
+            }),
+            rpc_password: DEFAULT_RPC_PASSWORD.into(),
+        }
+    }
+
     pub fn light_node(passphrase: &str, coins: &Json, seednodes: &[&str]) -> Self {
         Mm2TestConf {
             conf: json!({
@@ -1357,17 +1372,49 @@ impl MarketMakerIt {
     /// Start a new MarketMaker locally.
     ///
     /// * `conf` - The command-line configuration passed to the MarketMaker.
-    ///            Unique P2P in-memory port is injected as `p2p_in_memory_port` unless this field is already present.
-    /// * `userpass` - RPC API key. We should probably extract it automatically from the MM log.
-    /// * `local` - Function to start the MarketMaker locally. Required for nodes running in a browser.
-    /// * `envs` - The enviroment variables passed to the process.
-    ///            The argument is ignore for nodes running in a browser.
+    /// * `userpass` - RPC API key.
+    /// * `local` - Function to start the MarketMaker locally.
+    /// * `envs` - The environment variables passed to the process.
+    ///            The argument is ignored for nodes running in a browser.
     #[cfg(target_arch = "wasm32")]
     pub async fn start_with_envs(
-        mut conf: Json,
+        conf: Json,
         userpass: String,
         local: Option<LocalStart>,
         _envs: &[(&str, &str)],
+    ) -> Result<MarketMakerIt, String> {
+        MarketMakerIt::start_market_maker(conf, userpass, local, None).await
+    }
+
+    /// Start a new MarketMaker locally with a specific database namespace.
+    ///
+    /// * `conf` - The command-line configuration passed to the MarketMaker.
+    /// * `userpass` - RPC API key.
+    /// * `local` - Function to start the MarketMaker locally.
+    /// * `db_namespace_id` - The test database namespace identifier.
+    #[cfg(target_arch = "wasm32")]
+    pub async fn start_with_db(
+        conf: Json,
+        userpass: String,
+        local: Option<LocalStart>,
+        db_namespace_id: u64,
+    ) -> Result<MarketMakerIt, String> {
+        MarketMakerIt::start_market_maker(conf, userpass, local, Some(db_namespace_id)).await
+    }
+
+    /// Common helper function to start the MarketMaker.
+    ///
+    /// * `conf` - The command-line configuration passed to the MarketMaker.
+    ///            Unique P2P in-memory port is injected as `p2p_in_memory_port` unless this field is already present.
+    /// * `userpass` - RPC API key. We should probably extract it automatically from the MM log.
+    /// * `local` - Function to start the MarketMaker locally. Required for nodes running in a browser.
+    /// * `db_namespace_id` - Optional test database namespace identifier.
+    #[cfg(target_arch = "wasm32")]
+    async fn start_market_maker(
+        mut conf: Json,
+        userpass: String,
+        local: Option<LocalStart>,
+        db_namespace_id: Option<u64>,
     ) -> Result<MarketMakerIt, String> {
         if conf["p2p_in_memory"].is_null() {
             conf["p2p_in_memory"] = Json::Bool(true);
@@ -1383,10 +1430,19 @@ impl MarketMakerIt {
             conf["p2p_in_memory_port"] = Json::Number(new_p2p_port.into());
         }
 
-        let ctx = mm2_core::mm_ctx::MmCtxBuilder::new()
-            .with_conf(conf.clone())
-            .with_test_db_namespace()
-            .into_mm_arc();
+        let ctx = {
+            let builder = MmCtxBuilder::new()
+                .with_conf(conf.clone());
+
+            let builder = if let Some(ns) = db_namespace_id {
+                builder.with_test_db_namespace_with_id(ns)
+            } else {
+                builder.with_test_db_namespace()
+            };
+
+            builder.into_mm_arc()
+        };
+
         let local = try_s!(local.ok_or("!local"));
         local(ctx.clone());
 
@@ -2840,6 +2896,20 @@ pub async fn get_shared_db_id(mm: &MarketMakerIt) -> GetSharedDbIdResult {
         .await
         .unwrap();
     assert_eq!(request.0, StatusCode::OK, "'get_shared_db_id' failed: {}", request.1);
+    let res: RpcSuccessResponse<_> = json::from_str(&request.1).unwrap();
+    res.result
+}
+
+pub async fn get_wallet_names(mm: &MarketMakerIt) -> GetWalletNamesResult {
+    let request = mm
+        .rpc(&json!({
+            "userpass": mm.userpass,
+            "method": "get_wallet_names",
+            "mmrpc": "2.0",
+        }))
+        .await
+        .unwrap();
+    assert_eq!(request.0, StatusCode::OK, "'get_wallet_names' failed: {}", request.1);
     let res: RpcSuccessResponse<_> = json::from_str(&request.1).unwrap();
     res.result
 }

--- a/mm2src/mm2_test_helpers/src/structs.rs
+++ b/mm2src/mm2_test_helpers/src/structs.rs
@@ -827,6 +827,13 @@ pub struct GetSharedDbIdResult {
     pub shared_db_id: String,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GetWalletNamesResult {
+    pub wallet_names: Vec<String>,
+    pub activated_wallet: Option<String>,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RpcV2Response<T> {

--- a/mm2src/proxy_signature/src/lib.rs
+++ b/mm2src/proxy_signature/src/lib.rs
@@ -74,7 +74,9 @@ impl ProxySign {
             return false;
         }
 
-        let Ok(public_key) = PublicKey::try_decode_protobuf(&self.raw_message.public_key_encoded) else { return false };
+        let Ok(public_key) = PublicKey::try_decode_protobuf(&self.raw_message.public_key_encoded) else {
+            return false;
+        };
 
         if self.address != public_key.to_peer_id().to_string() {
             return false;


### PR DESCRIPTION
This PR introduces the `get_wallet_names` RPC method, which allows clients to retrieve information about all wallet names and the currently active one.

- **`get_wallet_names` Method**: Retrieves all wallet names and the active wallet's name if there is an active one. If there is no active wallet (no-login mode), it returns null for the active wallet's name.

#### Example Request and Responses:

#### Request:
```json
{
    "userpass": "{{userpass}}",
    "mmrpc": "2.0",
    "method": "get_wallet_names"
}
```

#### No-Login Mode Response:
```json
{
    "mmrpc": "2.0",
    "result": {
        "wallet_names": ["Test 1", "Test 2"],
        "activated_wallet": null
    },
    "id": null
}
```

#### Activated Wallet Response:
```json
{
    "mmrpc": "2.0",
    "result": {
        "wallet_names": ["Test 1", "Test 2"],
        "activated_wallet": "Test 1"
    },
    "id": null
}
```

**To Test:** @KomodoPlatform/qa
Example request and responses are above, I already tested this and @CharlVS probably did too, so it's not a high priority.