### PR TITLE
feat(wallets): restrict wallet creation with `allow_registrations` flag

### DIFF
--- a/mm2src/mm2_core/src/mm_ctx.rs
+++ b/mm2src/mm2_core/src/mm_ctx.rs
@@ -246,6 +246,9 @@ impl MmCtx {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn is_https(&self) -> bool { self.conf["https"].as_bool().unwrap_or(false) }
 
+    /// Whether or not new wallets can be created.
+    pub fn allow_registrations(&self) -> bool { self.conf["allow_registrations"].as_bool().unwrap_or(true) }
+
     /// SANs for self-signed certificate generation.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn alt_names(&self) -> Result<Vec<String>, String> {

--- a/mm2src/mm2_main/src/lp_wallet.rs
+++ b/mm2src/mm2_main/src/lp_wallet.rs
@@ -230,13 +230,13 @@ async fn decrypt_validate_or_save_passphrase(
             // If an existing passphrase is found and it matches the decrypted passphrase, return it
             Ok(Some(decrypted_passphrase))
         },
-        None if ctx.allow_registrations() => {
-            save_encrypted_passphrase(ctx, wallet_name, &encrypted_passphrase_data)
-                .await
-                .mm_err(|e| WalletInitError::WalletsStorageError(e.to_string()))?;
-            Ok(Some(decrypted_passphrase))
-        },
         None => {
+            if ctx.allow_registrations() { 
+              save_encrypted_passphrase(ctx, wallet_name, &encrypted_passphrase_data)
+               .await
+               .mm_err(|e| WalletInitError::WalletsStorageError(e.to_string()))?;
+            return Ok(Some(decrypted_passphrase));
+         }
             // If no passphrase is found and registrations are not allowed, return an error
             Err(WalletInitError::WalletCreationNotAllowed.into())
         },

--- a/mm2src/mm2_main/src/lp_wallet.rs
+++ b/mm2src/mm2_main/src/lp_wallet.rs
@@ -43,6 +43,8 @@ pub enum WalletInitError {
         fmt = "Passphrase doesn't match the one from file, please create a new wallet if you want to use a new passphrase"
     )]
     PassphraseMismatch,
+    #[display(fmt = "Error initializing wallet. Wallet mnemonic/name is unknown and wallet creation is disabled")]
+    WalletCreationNotAllowed,
     #[display(fmt = "Error generating or decrypting mnemonic: {}", _0)]
     MnemonicError(String),
     #[display(fmt = "Error initializing crypto context: {}", _0)]
@@ -171,12 +173,16 @@ async fn retrieve_or_create_passphrase(
             // If an existing passphrase is found, return it
             Ok(Some(passphrase_from_file))
         },
-        None => {
-            // If no passphrase is found, generate a new one
+        None if ctx.allow_registrations() => {
+            // If no passphrase is found and registrations are allowed, generate a new one
             let new_passphrase = generate_mnemonic(ctx)?.to_string();
             // Encrypt and save the new passphrase
             encrypt_and_save_passphrase(ctx, wallet_name, &new_passphrase, wallet_password).await?;
             Ok(Some(new_passphrase))
+        },
+        None => {
+            // If no passphrase is found and registrations are not allowed, return an error
+            Err(WalletInitError::WalletCreationNotAllowed.into())
         },
     }
 }
@@ -193,10 +199,14 @@ async fn confirm_or_encrypt_and_store_passphrase(
             // If an existing passphrase is found and it matches the provided passphrase, return it
             Ok(Some(passphrase_from_file))
         },
-        None => {
-            // If no passphrase is found in the file, encrypt and save the provided passphrase
+        None if ctx.allow_registrations() => {
+            // If no passphrase is found in the file and registrations are allowed, encrypt and save the provided passphrase
             encrypt_and_save_passphrase(ctx, wallet_name, passphrase, wallet_password).await?;
             Ok(Some(passphrase.to_string()))
+        },
+        None => {
+            // If no passphrase is found and registrations are not allowed, return an error
+            Err(WalletInitError::WalletCreationNotAllowed.into())
         },
         _ => {
             // If an existing passphrase is found and it does not match the provided passphrase, return an error
@@ -220,11 +230,15 @@ async fn decrypt_validate_or_save_passphrase(
             // If an existing passphrase is found and it matches the decrypted passphrase, return it
             Ok(Some(decrypted_passphrase))
         },
-        None => {
+        None if ctx.allow_registrations() => {
             save_encrypted_passphrase(ctx, wallet_name, &encrypted_passphrase_data)
                 .await
                 .mm_err(|e| WalletInitError::WalletsStorageError(e.to_string()))?;
             Ok(Some(decrypted_passphrase))
+        },
+        None => {
+            // If no passphrase is found and registrations are not allowed, return an error
+            Err(WalletInitError::WalletCreationNotAllowed.into())
         },
         _ => {
             // If an existing passphrase is found and it does not match the decrypted passphrase, return an error
@@ -258,8 +272,14 @@ async fn process_passphrase_logic(
     match (wallet_name, passphrase) {
         (None, None) => Ok(None),
         // Legacy approach for passphrase, no `wallet_name` is needed in the config, in this case the passphrase is not encrypted and saved.
-        (None, Some(Passphrase::Decrypted(passphrase))) => Ok(Some(passphrase)),
         // Importing an encrypted passphrase without a wallet name is not supported since it's not possible to save the passphrase.
+        (None, Some(Passphrase::Decrypted(passphrase))) => {
+            if ctx.allow_registrations() {
+                Ok(Some(passphrase))
+            } else {
+                Err(WalletInitError::WalletCreationNotAllowed.into())
+            }
+        },
         (None, Some(Passphrase::Encrypted(_))) => Err(WalletInitError::FieldNotFoundInConfig {
             field: "wallet_name".to_owned(),
         }

--- a/mm2src/mm2_main/src/lp_wallet/mnemonics_storage.rs
+++ b/mm2src/mm2_main/src/lp_wallet/mnemonics_storage.rs
@@ -25,6 +25,17 @@ pub(super) async fn save_encrypted_passphrase(
     encrypted_passphrase_data: &EncryptedData,
 ) -> WalletsStorageResult<()> {
     let wallet_path = ctx.wallet_file_path(wallet_name);
+
+    // Check if the wallet file already exists
+    if !wallet_path.exists() {
+        // If it doesn't exist and registrations are not allowed, return an error
+        if !ctx.allow_registrations() {
+            return Err(MmError::new(WalletsStorageError::Internal(
+                "Wallet creation is not allowed. Registrations are disabled.".to_string(),
+            )));
+        }
+    }
+
     ensure_file_is_writable(&wallet_path).map_to_mm(WalletsStorageError::FsWriteError)?;
     mm2_io::fs::write_json(encrypted_passphrase_data, &wallet_path, true)
         .await


### PR DESCRIPTION
KDF startup throws an error if the `allow_registrations` config value is false and the seed is unknown (no name provided) or if a name is provided and it has not been registered before. Defaults to `true` (current `dev` behaviour)

This is used to emulate the sign-in vs register behaviour a typical auth service would provide.

TODO: Tests