### PR TITLE
fix(coins): add p2p feature to mm2_net dependency

### DIFF
--- a/mm2src/coins/Cargo.toml
+++ b/mm2src/coins/Cargo.toml
@@ -78,7 +78,7 @@ mm2_event_stream = { path = "../mm2_event_stream" }
 mm2_git = { path = "../mm2_git" }
 mm2_io = { path = "../mm2_io" }
 mm2_metrics = { path = "../mm2_metrics" }
-mm2_net = { path = "../mm2_net" }
+mm2_net = { path = "../mm2_net", features = ["p2p"] }
 mm2_number = { path = "../mm2_number"}
 mm2_rpc = { path = "../mm2_rpc" }
 mm2_state_machine = { path = "../mm2_state_machine" }


### PR DESCRIPTION
so that coins could be compiled (`cargo check`ed, `cargo test`ed) on its own

**To Test:**
Nothing, this internal KDF PR.