### PR TITLE
feat(CI): handle remote files in a safer way

### DIFF
--- a/.github/actions/deps-install/action.yml
+++ b/.github/actions/deps-install/action.yml
@@ -12,15 +12,30 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Download protoc (Linux)
+      if: runner.os == 'Linux' && contains(inputs.deps, 'protoc')
+      uses: ./.github/actions/download-and-verify
+      with:
+        url: "https://github.com/protocolbuffers/protobuf/releases/download/v25.3/protoc-25.3-linux-x86_64.zip"
+        output_file: "protoc-25.3-linux-x86_64.zip"
+        checksum: "f853e691868d0557425ea290bf7ba6384eef2fa9b04c323afab49a770ba9da80"
+
     - name: Install protoc (Linux)
       env:
         TMP: ${{ inputs.temp || runner.temp }}
       if: runner.os == 'Linux' && contains(inputs.deps, 'protoc')
       shell: bash
       run: |
-        wget https://github.com/protocolbuffers/protobuf/releases/download/v25.3/protoc-25.3-linux-x86_64.zip
-        unzip protoc-25.3-linux-x86_64 -d "$TMP/protobuf"
+        unzip protoc-25.3-linux-x86_64.zip -d "$TMP/protobuf"
         echo "$TMP/protobuf/bin" >> $GITHUB_PATH
+
+    - name: Download protoc (MacOS)
+      if: runner.os == 'macOS' && contains(inputs.deps, 'protoc')
+      uses: ./.github/actions/download-and-verify
+      with:
+        url: "https://github.com/protocolbuffers/protobuf/releases/download/v25.3/protoc-25.3-osx-x86_64.zip"
+        output_file: "protoc-25.3-osx-x86_64.zip"
+        checksum: "247e003b8e115405172eacc50bd19825209d85940728e766f0848eee7c80e2a1"
 
     - name: Install protoc (MacOS)
       env:
@@ -28,9 +43,16 @@ runs:
       if: runner.os == 'macOS' && contains(inputs.deps, 'protoc')
       shell: bash
       run: |
-        wget https://github.com/protocolbuffers/protobuf/releases/download/v25.3/protoc-25.3-osx-x86_64.zip
         unzip protoc-25.3-osx-x86_64.zip -d "$TMP/protobuf"
         echo "$TMP/protobuf/bin" >> $GITHUB_PATH
+
+
+    - name: Download protoc (Windows)
+      uses: ./.github/actions/download-and-verify
+      with:
+        url: "https://github.com/protocolbuffers/protobuf/releases/download/v25.3/protoc-25.3-win64.zip"
+        output_file: "protoc-25.3-win64.zip"
+        checksum: "d6b336b852726364313330631656b7f395dde5b1141b169f5c4b8d43cdf01482"
 
     - name: Install protoc (Windows)
       env:
@@ -38,7 +60,6 @@ runs:
       if: runner.os == 'Windows' && contains(inputs.deps, 'protoc')
       shell: powershell
       run: |
-        Invoke-WebRequest -Uri https://github.com/protocolbuffers/protobuf/releases/download/v25.3/protoc-25.3-win64.zip -OutFile protoc-25.3-win64.zip
         7z x protoc-25.3-win64.zip -o"$TMP\protobuf"
         echo "$TMP\protobuf\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 

--- a/.github/actions/download-and-verify/action.yml
+++ b/.github/actions/download-and-verify/action.yml
@@ -1,0 +1,46 @@
+name: "Download and verify remote files"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Download (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: curl -L -o ${{ inputs.output_file }} ${{ inputs.url }}
+
+    - name: Download (Windows)
+      if: runner.os == 'Windows'
+      shell: powershell
+      run: Invoke-WebRequest -Uri ${{ inputs.url }} -OutFile ${{ inputs.output_file }}
+
+    - name: Verify (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        if [[ "$RUNNER_OS" == "macOS" ]]; then
+          echo "${{ inputs.checksum }} *${{ inputs.output_file }}" | shasum -a 256 -c
+        else
+          echo "${{ inputs.checksum }}  ${{ inputs.output_file }}" | sha256sum -c
+        fi
+
+    - name: Verify (Windows)
+      if: runner.os == 'Windows'
+      shell: powershell
+      run: |
+        $expectedChecksum = "${{ inputs.checksum }}"
+        $actualChecksum = (Get-FileHash -Path "${{ inputs.output_file }}" -Algorithm SHA256).Hash
+        if ($expectedChecksum -ne $actualChecksum) {
+          Write-Output "Checksum did not match! Expected: $expectedChecksum, Found: $actualChecksum"
+          exit 1
+        }
+
+inputs:
+  url:
+    description: "URL of the remote file."
+    required: true
+  output_file:
+    description: "Output path."
+    required: true
+  checksum:
+    description: "Expected checksum of the downloaded file."
+    required: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -219,7 +219,7 @@ jobs:
 
       - name: Test
         run: |
-          wget -O - https://raw.githubusercontent.com/KomodoPlatform/komodo/0adeeabdd484ef40539d1275c6a765f5c530ea79/zcutil/fetch-params-alt.sh | bash
+          wget -O - https://raw.githubusercontent.com/KomodoPlatform/komodo/v0.8.1//zcutil/fetch-params-alt.sh | bash
           cargo test --test 'docker_tests_main' --features run-docker-tests --no-fail-fast
 
   wasm:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Test
         run: |
-          wget -O - https://raw.githubusercontent.com/KomodoPlatform/komodo/master/zcutil/fetch-params-alt.sh | bash
+          wget -O - https://raw.githubusercontent.com/KomodoPlatform/komodo/0adeeabdd484ef40539d1275c6a765f5c530ea79/zcutil/fetch-params-alt.sh | bash
           cargo test --test 'mm2_tests_main' --no-fail-fast
 
   mac-x86-64-kdf-integration:
@@ -154,7 +154,7 @@ jobs:
 
       - name: Test
         run: |
-          wget -O - https://raw.githubusercontent.com/KomodoPlatform/komodo/master/zcutil/fetch-params-alt.sh | bash
+          wget -O - https://raw.githubusercontent.com/KomodoPlatform/komodo/0adeeabdd484ef40539d1275c6a765f5c530ea79/zcutil/fetch-params-alt.sh | bash
           cargo test --test 'mm2_tests_main' --no-fail-fast
 
   win-x86-64-kdf-integration:
@@ -183,8 +183,8 @@ jobs:
 
       - name: Test
         run: |
-          Invoke-WebRequest -Uri https://github.com/KomodoPlatform/komodo/raw/d456be35acd1f8584e1e4f971aea27bd0644d5c5/zcutil/wget64.exe -OutFile \wget64.exe
-          Invoke-WebRequest -Uri https://raw.githubusercontent.com/KomodoPlatform/komodo/master/zcutil/fetch-params-alt.bat -OutFile \cmd.bat && \cmd.bat
+          Invoke-WebRequest -Uri https://raw.githubusercontent.com/KomodoPlatform/komodo/0adeeabdd484ef40539d1275c6a765f5c530ea79/zcutil/zcutil/wget64.exe -OutFile \wget64.exe
+          Invoke-WebRequest -Uri https://raw.githubusercontent.com/KomodoPlatform/komodo/0adeeabdd484ef40539d1275c6a765f5c530ea79/zcutil/fetch-params-alt.bat -OutFile \cmd.bat && \cmd.bat
           cargo test --test 'mm2_tests_main' --no-fail-fast
 
   docker-tests:
@@ -213,7 +213,7 @@ jobs:
 
       - name: Test
         run: |
-          wget -O - https://raw.githubusercontent.com/KomodoPlatform/komodo/v0.8.1/zcutil/fetch-params-alt.sh | bash
+          wget -O - https://raw.githubusercontent.com/KomodoPlatform/komodo/0adeeabdd484ef40539d1275c6a765f5c530ea79/zcutil/fetch-params-alt.sh | bash
           cargo test --test 'docker_tests_main' --features run-docker-tests --no-fail-fast
 
   wasm:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -185,7 +185,7 @@ jobs:
         uses: ./.github/actions/download-and-verify
         with:
           url: "https://github.com/KomodoPlatform/komodo/raw/d456be35acd1f8584e1e4f971aea27bd0644d5c5/zcutil/wget64.exe"
-          output_file: "wget64.exe"
+          output_file: "/wget64.exe"
           checksum: "d80719431dc22b0e4a070f61fab982b113a4ed9a6d4cf25e64b5be390dcadb94"
 
       - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,9 +181,15 @@ jobs:
       - name: Cargo cache
         uses: ./.github/actions/cargo-cache
 
+      - name: Download wget64
+        uses: ./.github/actions/download-and-verify
+        with:
+          url: "https://github.com/KomodoPlatform/komodo/raw/d456be35acd1f8584e1e4f971aea27bd0644d5c5/zcutil/wget64.exe"
+          output_file: "wget64.exe"
+          checksum: "d80719431dc22b0e4a070f61fab982b113a4ed9a6d4cf25e64b5be390dcadb94"
+
       - name: Test
         run: |
-          Invoke-WebRequest -Uri https://raw.githubusercontent.com/KomodoPlatform/komodo/0adeeabdd484ef40539d1275c6a765f5c530ea79/zcutil/zcutil/wget64.exe -OutFile \wget64.exe
           Invoke-WebRequest -Uri https://raw.githubusercontent.com/KomodoPlatform/komodo/0adeeabdd484ef40539d1275c6a765f5c530ea79/zcutil/fetch-params-alt.bat -OutFile \cmd.bat && \cmd.bat
           cargo test --test 'mm2_tests_main' --no-fail-fast
 
@@ -241,11 +247,17 @@ jobs:
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
+      - name: Download geckodriver
+        uses: ./.github/actions/download-and-verify
+        with:
+          url: "https://github.com/mozilla/geckodriver/releases/download/v0.32.2/geckodriver-v0.32.2-linux64.tar.gz"
+          output_file: "geckodriver-v0.32.2-linux64.tar.gz"
+          checksum: "1eab226bf009599f5aa1d77d9ed4c374e10a03fd848b500be1b32cefd2cbec64"
+
       - name: Install firefox and geckodriver
         run: |
           sudo apt-get update -y
           sudo apt-get install -y firefox
-          wget https://github.com/mozilla/geckodriver/releases/download/v0.32.2/geckodriver-v0.32.2-linux64.tar.gz
           sudo tar -xzvf geckodriver-v0.32.2-linux64.tar.gz -C /bin
           sudo chmod +x /bin/geckodriver
 


### PR DESCRIPTION
This PR updates GHA runners to use locked scripts rather than always using the latest one from the master branch. It also adds  a new GHA helper/plugin to easily download files and verify their checksums.

cc @Alrighttt 