### PR TITLE
fix(db): stop creating the all-zeroes dir on KDF start

### DIFF
--- a/mm2src/mm2_core/src/mm_ctx.rs
+++ b/mm2src/mm2_core/src/mm_ctx.rs
@@ -287,10 +287,13 @@ impl MmCtx {
             })
     }
 
+    /// Returns the path to the MM databases root.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn db_root(&self) -> PathBuf { path_to_db_root(self.conf["dbdir"].as_str()) }
+
     #[cfg(not(target_arch = "wasm32"))]
     pub fn wallet_file_path(&self, wallet_name: &str) -> PathBuf {
-        let db_root = path_to_db_root(self.conf["dbdir"].as_str());
-        db_root.join(wallet_name.to_string() + ".dat")
+        self.db_root().join(wallet_name.to_string() + ".dat")
     }
 
     /// MM database path.  

--- a/mm2src/mm2_main/src/lp_native_dex.rs
+++ b/mm2src/mm2_main/src/lp_native_dex.rs
@@ -498,9 +498,11 @@ pub async fn lp_init_continue(ctx: MmArc) -> MmInitResult<()> {
 pub async fn lp_init(ctx: MmArc, version: String, datetime: String) -> MmInitResult<()> {
     info!("Version: {} DT {}", version, datetime);
 
+    // Ensure the database root directory exists before initializing the wallet passphrase.
+    // This is necessary to store the encrypted wallet passphrase if needed.
     #[cfg(not(target_arch = "wasm32"))]
     {
-        let dbdir = ctx.dbdir();
+        let dbdir = ctx.db_root();
         fs::create_dir_all(&dbdir).map_to_mm(|e| MmInitError::ErrorCreatingDbDir {
             path: dbdir.clone(),
             error: e.to_string(),


### PR DESCRIPTION
KDF was creating the default all zeroes db dir on start which is not used, this PR fixes this.