### PR TITLE
chore(tests): don't use `.wait()` and use `block_on` instead

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+[[disallowed-methods]]
+path = "futures::future::Future::wait"
+replacement = "common::block_on_f01"
+reason = "Use the default KDF async executor."

--- a/mm2src/coins/qrc20/qrc20_tests.rs
+++ b/mm2src/coins/qrc20/qrc20_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{DexFee, TxFeeDetails, WaitForHTLCTxSpendArgs};
-use common::{block_on, wait_until_sec, DEX_FEE_ADDR_RAW_PUBKEY};
+use common::{block_on, block_on_f01, wait_until_sec, DEX_FEE_ADDR_RAW_PUBKEY};
 use crypto::Secp256k1Secret;
 use itertools::Itertools;
 use keys::Address;
@@ -96,7 +96,7 @@ fn test_withdraw_to_p2sh_address_should_fail() {
         memo: None,
         ibc_source_channel: None,
     };
-    let err = coin.withdraw(req).wait().unwrap_err().into_inner();
+    let err = block_on_f01(coin.withdraw(req)).unwrap_err().into_inner();
     let expect = WithdrawError::InvalidAddress("QRC20 can be sent to P2PKH addresses only".to_owned());
     assert_eq!(err, expect);
 }
@@ -140,7 +140,7 @@ fn test_withdraw_impl_fee_details() {
         memo: None,
         ibc_source_channel: None,
     };
-    let tx_details = coin.withdraw(withdraw_req).wait().unwrap();
+    let tx_details = block_on_f01(coin.withdraw(withdraw_req)).unwrap();
 
     let expected: Qrc20FeeDetails = json::from_value(json!({
         "coin": "QTUM",
@@ -287,7 +287,7 @@ fn test_wait_for_confirmations_excepted() {
         wait_until,
         check_every,
     };
-    coin.wait_for_confirmations(confirm_payment_input).wait().unwrap();
+    block_on_f01(coin.wait_for_confirmations(confirm_payment_input)).unwrap();
 
     // tx_hash: ed53b97deb2ad76974c972cb084f6ba63bd9f16c91c4a39106a20c6d14599b2a
     // `erc20Payment` contract call excepted
@@ -299,7 +299,7 @@ fn test_wait_for_confirmations_excepted() {
         wait_until,
         check_every,
     };
-    let error = coin.wait_for_confirmations(confirm_payment_input).wait().unwrap_err();
+    let error = block_on_f01(coin.wait_for_confirmations(confirm_payment_input)).unwrap_err();
     log!("error: {:?}", error);
     assert!(error.contains("Contract call failed with an error: Revert"));
 
@@ -313,7 +313,7 @@ fn test_wait_for_confirmations_excepted() {
         wait_until,
         check_every,
     };
-    let error = coin.wait_for_confirmations(confirm_payment_input).wait().unwrap_err();
+    let error = block_on_f01(coin.wait_for_confirmations(confirm_payment_input)).unwrap_err();
     log!("error: {:?}", error);
     assert!(error.contains("Contract call failed with an error: Revert"));
 }
@@ -333,67 +333,59 @@ fn test_validate_fee() {
 
     let amount = BigDecimal::from_str("0.01").unwrap();
 
-    let result = coin
-        .validate_fee(ValidateFeeArgs {
-            fee_tx: &tx,
-            expected_sender: &sender_pub,
-            fee_addr: &DEX_FEE_ADDR_RAW_PUBKEY,
-            dex_fee: &DexFee::Standard(amount.clone().into()),
-            min_block_number: 0,
-            uuid: &[],
-        })
-        .wait();
+    let result = block_on_f01(coin.validate_fee(ValidateFeeArgs {
+        fee_tx: &tx,
+        expected_sender: &sender_pub,
+        fee_addr: &DEX_FEE_ADDR_RAW_PUBKEY,
+        dex_fee: &DexFee::Standard(amount.clone().into()),
+        min_block_number: 0,
+        uuid: &[],
+    }));
     assert!(result.is_ok());
 
     let fee_addr_dif = hex::decode("03bc2c7ba671bae4a6fc835244c9762b41647b9827d4780a89a949b984a8ddcc05").unwrap();
-    let err = coin
-        .validate_fee(ValidateFeeArgs {
-            fee_tx: &tx,
-            expected_sender: &sender_pub,
-            fee_addr: &fee_addr_dif,
-            dex_fee: &DexFee::Standard(amount.clone().into()),
-            min_block_number: 0,
-            uuid: &[],
-        })
-        .wait()
-        .expect_err("Expected an error")
-        .into_inner();
+    let err = block_on_f01(coin.validate_fee(ValidateFeeArgs {
+        fee_tx: &tx,
+        expected_sender: &sender_pub,
+        fee_addr: &fee_addr_dif,
+        dex_fee: &DexFee::Standard(amount.clone().into()),
+        min_block_number: 0,
+        uuid: &[],
+    }))
+    .expect_err("Expected an error")
+    .into_inner();
     log!("error: {:?}", err);
     match err {
         ValidatePaymentError::WrongPaymentTx(err) => assert!(err.contains("QRC20 Fee tx was sent to wrong address")),
         _ => panic!("Expected `WrongPaymentTx` wrong receiver address, found {:?}", err),
     }
 
-    let err = coin
-        .validate_fee(ValidateFeeArgs {
-            fee_tx: &tx,
-            expected_sender: &DEX_FEE_ADDR_RAW_PUBKEY,
-            fee_addr: &DEX_FEE_ADDR_RAW_PUBKEY,
-            dex_fee: &DexFee::Standard(amount.clone().into()),
-            min_block_number: 0,
-            uuid: &[],
-        })
-        .wait()
-        .expect_err("Expected an error")
-        .into_inner();
+    let err = block_on_f01(coin.validate_fee(ValidateFeeArgs {
+        fee_tx: &tx,
+        expected_sender: &DEX_FEE_ADDR_RAW_PUBKEY,
+        fee_addr: &DEX_FEE_ADDR_RAW_PUBKEY,
+        dex_fee: &DexFee::Standard(amount.clone().into()),
+        min_block_number: 0,
+        uuid: &[],
+    }))
+    .expect_err("Expected an error")
+    .into_inner();
     log!("error: {:?}", err);
     match err {
         ValidatePaymentError::WrongPaymentTx(err) => assert!(err.contains("was sent from wrong address")),
         _ => panic!("Expected `WrongPaymentTx` wrong sender address, found {:?}", err),
     }
 
-    let err = coin
-        .validate_fee(ValidateFeeArgs {
-            fee_tx: &tx,
-            expected_sender: &sender_pub,
-            fee_addr: &DEX_FEE_ADDR_RAW_PUBKEY,
-            dex_fee: &DexFee::Standard(amount.clone().into()),
-            min_block_number: 2000000,
-            uuid: &[],
-        })
-        .wait()
-        .expect_err("Expected an error")
-        .into_inner();
+    let err = block_on_f01(coin.validate_fee(ValidateFeeArgs {
+        fee_tx: &tx,
+        expected_sender: &sender_pub,
+        fee_addr: &DEX_FEE_ADDR_RAW_PUBKEY,
+        dex_fee: &DexFee::Standard(amount.clone().into()),
+        min_block_number: 2000000,
+        uuid: &[],
+    }))
+    .expect_err("Expected an error")
+    .into_inner();
     log!("error: {:?}", err);
     match err {
         ValidatePaymentError::WrongPaymentTx(err) => assert!(err.contains("confirmed before min_block")),
@@ -401,18 +393,16 @@ fn test_validate_fee() {
     }
 
     let amount_dif = BigDecimal::from_str("0.02").unwrap();
-    let err = coin
-        .validate_fee(ValidateFeeArgs {
-            fee_tx: &tx,
-            expected_sender: &sender_pub,
-            fee_addr: &DEX_FEE_ADDR_RAW_PUBKEY,
-            dex_fee: &DexFee::Standard(amount_dif.into()),
-            min_block_number: 0,
-            uuid: &[],
-        })
-        .wait()
-        .expect_err("Expected an error")
-        .into_inner();
+    let err = block_on_f01(coin.validate_fee(ValidateFeeArgs {
+        fee_tx: &tx,
+        expected_sender: &sender_pub,
+        fee_addr: &DEX_FEE_ADDR_RAW_PUBKEY,
+        dex_fee: &DexFee::Standard(amount_dif.into()),
+        min_block_number: 0,
+        uuid: &[],
+    }))
+    .expect_err("Expected an error")
+    .into_inner();
     log!("error: {:?}", err);
     match err {
         ValidatePaymentError::WrongPaymentTx(err) => {
@@ -424,18 +414,16 @@ fn test_validate_fee() {
     // QTUM tx "8a51f0ffd45f34974de50f07c5bf2f0949da4e88433f8f75191953a442cf9310"
     let tx = TransactionEnum::UtxoTx("020000000113640281c9332caeddd02a8dd0d784809e1ad87bda3c972d89d5ae41f5494b85010000006a47304402207c5c904a93310b8672f4ecdbab356b65dd869a426e92f1064a567be7ccfc61ff02203e4173b9467127f7de4682513a21efb5980e66dbed4da91dff46534b8e77c7ef012102baefe72b3591de2070c0da3853226b00f082d72daa417688b61cb18c1d543d1afeffffff020001b2c4000000001976a9149e032d4b0090a11dc40fe6c47601499a35d55fbb88acbc4dd20c2f0000001976a9144208fa7be80dcf972f767194ad365950495064a488ac76e70800".into());
     let sender_pub = hex::decode("02baefe72b3591de2070c0da3853226b00f082d72daa417688b61cb18c1d543d1a").unwrap();
-    let err = coin
-        .validate_fee(ValidateFeeArgs {
-            fee_tx: &tx,
-            expected_sender: &sender_pub,
-            fee_addr: &DEX_FEE_ADDR_RAW_PUBKEY,
-            dex_fee: &DexFee::Standard(amount.into()),
-            min_block_number: 0,
-            uuid: &[],
-        })
-        .wait()
-        .expect_err("Expected an error")
-        .into_inner();
+    let err = block_on_f01(coin.validate_fee(ValidateFeeArgs {
+        fee_tx: &tx,
+        expected_sender: &sender_pub,
+        fee_addr: &DEX_FEE_ADDR_RAW_PUBKEY,
+        dex_fee: &DexFee::Standard(amount.into()),
+        min_block_number: 0,
+        uuid: &[],
+    }))
+    .expect_err("Expected an error")
+    .into_inner();
     log!("error: {:?}", err);
     match err {
         ValidatePaymentError::WrongPaymentTx(err) => assert!(err.contains("Expected 'transfer' contract call")),
@@ -462,18 +450,16 @@ fn test_wait_for_tx_spend_malicious() {
     let payment_tx = hex::decode("01000000016601daa208531d20532c460d0c86b74a275f4a126bbffcf4eafdf33835af2859010000006a47304402205825657548bc1b5acf3f4bb2f89635a02b04f3228cd08126e63c5834888e7ac402207ca05fa0a629a31908a97a508e15076e925f8e621b155312b7526a6666b06a76012103693bff1b39e8b5a306810023c29b95397eb395530b106b1820ea235fd81d9ce9ffffffff020000000000000000e35403a0860101284cc49b415b2a8620ad3b72361a5aeba5dffd333fb64750089d935a1ec974d6a91ef4f24ff6ba0000000000000000000000000000000000000000000000000000000001312d00000000000000000000000000d362e096e873eb7907e205fadc6175c6fec7bc44000000000000000000000000783cf0be521101942da509846ea476e683aad8324b6b2e5444c2639cc0fb7bcea5afba3f3cdce239000000000000000000000000000000000000000000000000000000000000000000000000000000005f855c7614ba8b71f3544b93e2f681f996da519a98ace0107ac2203de400000000001976a9149e032d4b0090a11dc40fe6c47601499a35d55fbb88ac415d855f").unwrap();
     let wait_until = now_sec() + 1;
     let from_block = 696245;
-    let found = coin
-        .wait_for_htlc_tx_spend(WaitForHTLCTxSpendArgs {
-            tx_bytes: &payment_tx,
-            secret_hash: &[],
-            wait_until,
-            from_block,
-            swap_contract_address: &coin.swap_contract_address(),
-            check_every: TAKER_PAYMENT_SPEND_SEARCH_INTERVAL,
-            watcher_reward: false,
-        })
-        .wait()
-        .unwrap();
+    let found = block_on_f01(coin.wait_for_htlc_tx_spend(WaitForHTLCTxSpendArgs {
+        tx_bytes: &payment_tx,
+        secret_hash: &[],
+        wait_until,
+        from_block,
+        swap_contract_address: &coin.swap_contract_address(),
+        check_every: TAKER_PAYMENT_SPEND_SEARCH_INTERVAL,
+        watcher_reward: false,
+    }))
+    .unwrap();
 
     let spend_tx = match found {
         TransactionEnum::UtxoTx(tx) => tx,
@@ -731,7 +717,7 @@ fn test_get_trade_fee() {
     // check if the coin's tx fee is expected
     check_tx_fee(&coin, ActualTxFee::FixedPerKb(EXPECTED_TX_FEE as u64));
 
-    let actual_trade_fee = coin.get_trade_fee().wait().unwrap();
+    let actual_trade_fee = block_on_f01(coin.get_trade_fee()).unwrap();
     let expected_trade_fee_amount = big_decimal_from_sat(
         2 * CONTRACT_CALL_GAS_FEE + SWAP_PAYMENT_GAS_FEE + EXPECTED_TX_FEE,
         coin.utxo.decimals,
@@ -905,10 +891,8 @@ fn test_receiver_trade_preimage() {
     // check if the coin's tx fee is expected
     check_tx_fee(&coin, ActualTxFee::FixedPerKb(EXPECTED_TX_FEE as u64));
 
-    let actual = coin
-        .get_receiver_trade_fee(FeeApproxStage::WithoutApprox)
-        .wait()
-        .expect("!get_receiver_trade_fee");
+    let actual =
+        block_on_f01(coin.get_receiver_trade_fee(FeeApproxStage::WithoutApprox)).expect("!get_receiver_trade_fee");
     // only one contract call should be included into the expected trade fee
     let expected_receiver_fee = big_decimal_from_sat(CONTRACT_CALL_GAS_FEE + EXPECTED_TX_FEE, coin.utxo.decimals);
     let expected = TradeFee {
@@ -935,7 +919,7 @@ fn test_taker_fee_tx_fee() {
         spendable: BigDecimal::from(5u32),
         unspendable: BigDecimal::from(0u32),
     };
-    assert_eq!(coin.my_balance().wait().expect("!my_balance"), expected_balance);
+    assert_eq!(block_on_f01(coin.my_balance()).expect("!my_balance"), expected_balance);
 
     let dex_fee_amount = BigDecimal::from(5u32);
     let actual = block_on(coin.get_fee_to_send_taker_fee(

--- a/mm2src/coins/solana/solana_tests.rs
+++ b/mm2src/coins/solana/solana_tests.rs
@@ -1,5 +1,5 @@
 use base58::ToBase58;
-use common::{block_on, Future01CompatExt};
+use common::{block_on, block_on_f01, Future01CompatExt};
 use rpc::v1::types::Bytes;
 use solana_client::rpc_request::TokenAccountsFilter;
 use solana_sdk::{bs58,
@@ -367,7 +367,7 @@ fn solana_coin_send_and_refund_maker_payment() {
         watcher_reward: None,
         wait_for_confirmation_until: 0,
     };
-    let tx = coin.send_maker_payment(args).wait().unwrap();
+    let tx = block_on_f01(coin.send_maker_payment(args)).unwrap();
     log!("swap tx {:?}", tx);
 
     let refund_args = RefundPaymentArgs {
@@ -415,7 +415,7 @@ fn solana_coin_send_and_spend_maker_payment() {
         wait_for_confirmation_until: 0,
     };
 
-    let tx = coin.send_maker_payment(maker_payment_args).wait().unwrap();
+    let tx = block_on_f01(coin.send_maker_payment(maker_payment_args)).unwrap();
     log!("swap tx {:?}", tx);
 
     let maker_pub = taker_pub;

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -3313,7 +3313,7 @@ fn parse_expected_sequence_number(e: &str) -> MmResult<u64, TendermintCoinRpcErr
 pub mod tendermint_coin_tests {
     use super::*;
 
-    use common::{block_on, wait_until_ms, DEX_FEE_ADDR_RAW_PUBKEY};
+    use common::{block_on, block_on_f01, wait_until_ms, DEX_FEE_ADDR_RAW_PUBKEY};
     use cosmrs::proto::cosmos::tx::v1beta1::{GetTxRequest, GetTxResponse, GetTxsEventResponse};
     use crypto::privkey::key_pair_from_seed;
     use std::mem::discriminant;
@@ -3691,18 +3691,16 @@ pub mod tendermint_coin_tests {
         });
 
         let invalid_amount: MmNumber = 1.into();
-        let error = coin
-            .validate_fee(ValidateFeeArgs {
-                fee_tx: &create_htlc_tx,
-                expected_sender: &[],
-                fee_addr: &DEX_FEE_ADDR_RAW_PUBKEY,
-                dex_fee: &DexFee::Standard(invalid_amount.clone()),
-                min_block_number: 0,
-                uuid: &[1; 16],
-            })
-            .wait()
-            .unwrap_err()
-            .into_inner();
+        let error = block_on_f01(coin.validate_fee(ValidateFeeArgs {
+            fee_tx: &create_htlc_tx,
+            expected_sender: &[],
+            fee_addr: &DEX_FEE_ADDR_RAW_PUBKEY,
+            dex_fee: &DexFee::Standard(invalid_amount.clone()),
+            min_block_number: 0,
+            uuid: &[1; 16],
+        }))
+        .unwrap_err()
+        .into_inner();
         println!("{}", error);
         match error {
             ValidatePaymentError::TxDeserializationError(err) => {
@@ -3725,18 +3723,16 @@ pub mod tendermint_coin_tests {
             data: TxRaw::decode(random_transfer_tx_bytes.as_slice()).unwrap(),
         });
 
-        let error = coin
-            .validate_fee(ValidateFeeArgs {
-                fee_tx: &random_transfer_tx,
-                expected_sender: &[],
-                fee_addr: &DEX_FEE_ADDR_RAW_PUBKEY,
-                dex_fee: &DexFee::Standard(invalid_amount.clone()),
-                min_block_number: 0,
-                uuid: &[1; 16],
-            })
-            .wait()
-            .unwrap_err()
-            .into_inner();
+        let error = block_on_f01(coin.validate_fee(ValidateFeeArgs {
+            fee_tx: &random_transfer_tx,
+            expected_sender: &[],
+            fee_addr: &DEX_FEE_ADDR_RAW_PUBKEY,
+            dex_fee: &DexFee::Standard(invalid_amount.clone()),
+            min_block_number: 0,
+            uuid: &[1; 16],
+        }))
+        .unwrap_err()
+        .into_inner();
         println!("{}", error);
         match error {
             ValidatePaymentError::WrongPaymentTx(err) => assert!(err.contains("sent to wrong address")),
@@ -3758,18 +3754,16 @@ pub mod tendermint_coin_tests {
             data: TxRaw::decode(dex_fee_tx.encode_to_vec().as_slice()).unwrap(),
         });
 
-        let error = coin
-            .validate_fee(ValidateFeeArgs {
-                fee_tx: &dex_fee_tx,
-                expected_sender: &[],
-                fee_addr: &DEX_FEE_ADDR_RAW_PUBKEY,
-                dex_fee: &DexFee::Standard(invalid_amount),
-                min_block_number: 0,
-                uuid: &[1; 16],
-            })
-            .wait()
-            .unwrap_err()
-            .into_inner();
+        let error = block_on_f01(coin.validate_fee(ValidateFeeArgs {
+            fee_tx: &dex_fee_tx,
+            expected_sender: &[],
+            fee_addr: &DEX_FEE_ADDR_RAW_PUBKEY,
+            dex_fee: &DexFee::Standard(invalid_amount),
+            min_block_number: 0,
+            uuid: &[1; 16],
+        }))
+        .unwrap_err()
+        .into_inner();
         println!("{}", error);
         match error {
             ValidatePaymentError::WrongPaymentTx(err) => assert!(err.contains("Invalid amount")),
@@ -3778,18 +3772,16 @@ pub mod tendermint_coin_tests {
 
         let valid_amount: BigDecimal = "0.0001".parse().unwrap();
         // valid amount but invalid sender
-        let error = coin
-            .validate_fee(ValidateFeeArgs {
-                fee_tx: &dex_fee_tx,
-                expected_sender: &DEX_FEE_ADDR_RAW_PUBKEY,
-                fee_addr: &DEX_FEE_ADDR_RAW_PUBKEY,
-                dex_fee: &DexFee::Standard(valid_amount.clone().into()),
-                min_block_number: 0,
-                uuid: &[1; 16],
-            })
-            .wait()
-            .unwrap_err()
-            .into_inner();
+        let error = block_on_f01(coin.validate_fee(ValidateFeeArgs {
+            fee_tx: &dex_fee_tx,
+            expected_sender: &DEX_FEE_ADDR_RAW_PUBKEY,
+            fee_addr: &DEX_FEE_ADDR_RAW_PUBKEY,
+            dex_fee: &DexFee::Standard(valid_amount.clone().into()),
+            min_block_number: 0,
+            uuid: &[1; 16],
+        }))
+        .unwrap_err()
+        .into_inner();
         println!("{}", error);
         match error {
             ValidatePaymentError::WrongPaymentTx(err) => assert!(err.contains("Invalid sender")),
@@ -3797,18 +3789,16 @@ pub mod tendermint_coin_tests {
         }
 
         // invalid memo
-        let error = coin
-            .validate_fee(ValidateFeeArgs {
-                fee_tx: &dex_fee_tx,
-                expected_sender: &pubkey,
-                fee_addr: &DEX_FEE_ADDR_RAW_PUBKEY,
-                dex_fee: &DexFee::Standard(valid_amount.into()),
-                min_block_number: 0,
-                uuid: &[1; 16],
-            })
-            .wait()
-            .unwrap_err()
-            .into_inner();
+        let error = block_on_f01(coin.validate_fee(ValidateFeeArgs {
+            fee_tx: &dex_fee_tx,
+            expected_sender: &pubkey,
+            fee_addr: &DEX_FEE_ADDR_RAW_PUBKEY,
+            dex_fee: &DexFee::Standard(valid_amount.into()),
+            min_block_number: 0,
+            uuid: &[1; 16],
+        }))
+        .unwrap_err()
+        .into_inner();
         println!("{}", error);
         match error {
             ValidatePaymentError::WrongPaymentTx(err) => assert!(err.contains("Invalid memo")),

--- a/mm2src/coins/utxo/slp.rs
+++ b/mm2src/coins/utxo/slp.rs
@@ -1945,6 +1945,7 @@ mod slp_tests {
     use crate::utxo::GetUtxoListOps;
     use crate::{utxo::bch::tbch_coin_for_test, TransactionErr};
     use common::block_on;
+    use common::block_on_f01;
     use mocktopus::mocking::{MockResult, Mockable};
     use std::mem::discriminant;
 
@@ -2206,11 +2207,11 @@ mod slp_tests {
         ];
 
         let tx_bytes_str = hex::encode(tx_bytes);
-        let err = fusd.send_raw_tx(&tx_bytes_str).wait().unwrap_err();
+        let err = block_on_f01(fusd.send_raw_tx(&tx_bytes_str)).unwrap_err();
         println!("{:?}", err);
         assert!(err.contains("is not valid with reason outputs greater than inputs"));
 
-        let err2 = fusd.send_raw_tx_bytes(tx_bytes).wait().unwrap_err();
+        let err2 = block_on_f01(fusd.send_raw_tx_bytes(tx_bytes)).unwrap_err();
         println!("{:?}", err2);
         assert!(err2.contains("is not valid with reason outputs greater than inputs"));
         assert_eq!(err, err2);

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -39,8 +39,7 @@ use crypto::{privkey::key_pair_from_seed, Bip44Chain, HDPathToAccount, RpcDeriva
 #[cfg(not(target_arch = "wasm32"))]
 use db_common::sqlite::rusqlite::Connection;
 use futures::channel::mpsc::channel;
-use futures::future::join_all;
-use futures::TryFutureExt;
+use futures::future::{join_all, Either, FutureExt, TryFutureExt};
 use keys::prefixes::*;
 use mm2_core::mm_ctx::MmCtxBuilder;
 use mm2_number::bigdecimal::{BigDecimal, Signed};
@@ -571,19 +570,22 @@ fn test_search_for_swap_tx_spend_electrum_was_refunded() {
 #[cfg(not(target_arch = "wasm32"))]
 fn test_withdraw_impl_set_fixed_fee() {
     UtxoStandardCoin::get_unspent_ordered_list.mock_safe(|coin, _| {
-        let cache = block_on(coin.as_ref().recently_spent_outpoints.lock());
-        let unspents = vec![UnspentInfo {
-            outpoint: OutPoint {
-                hash: 1.into(),
-                index: 0,
-            },
-            value: 1000000000,
-            height: Default::default(),
-            script: coin
-                .script_for_address(&block_on(coin.as_ref().derivation_method.unwrap_single_addr()))
-                .unwrap(),
-        }];
-        MockResult::Return(Box::pin(futures::future::ok((unspents, cache))))
+        let fut = async move {
+            let cache = coin.as_ref().recently_spent_outpoints.lock().await;
+            let unspents = vec![UnspentInfo {
+                outpoint: OutPoint {
+                    hash: 1.into(),
+                    index: 0,
+                },
+                value: 1000000000,
+                height: Default::default(),
+                script: coin
+                    .script_for_address(&coin.as_ref().derivation_method.unwrap_single_addr().await)
+                    .unwrap(),
+            }];
+            Ok((unspents, cache))
+        };
+        MockResult::Return(fut.boxed())
     });
 
     let client = NativeClient(Arc::new(NativeClientImpl::default()));
@@ -617,19 +619,22 @@ fn test_withdraw_impl_set_fixed_fee() {
 #[cfg(not(target_arch = "wasm32"))]
 fn test_withdraw_impl_sat_per_kb_fee() {
     UtxoStandardCoin::get_unspent_ordered_list.mock_safe(|coin, _| {
-        let cache = block_on(coin.as_ref().recently_spent_outpoints.lock());
-        let unspents = vec![UnspentInfo {
-            outpoint: OutPoint {
-                hash: 1.into(),
-                index: 0,
-            },
-            value: 1000000000,
-            height: Default::default(),
-            script: coin
-                .script_for_address(&block_on(coin.as_ref().derivation_method.unwrap_single_addr()))
-                .unwrap(),
-        }];
-        MockResult::Return(Box::pin(futures::future::ok((unspents, cache))))
+        let fut = async move {
+            let cache = coin.as_ref().recently_spent_outpoints.lock().await;
+            let unspents = vec![UnspentInfo {
+                outpoint: OutPoint {
+                    hash: 1.into(),
+                    index: 0,
+                },
+                value: 1000000000,
+                height: Default::default(),
+                script: coin
+                    .script_for_address(&coin.as_ref().derivation_method.unwrap_single_addr().await)
+                    .unwrap(),
+            }];
+            Ok((unspents, cache))
+        };
+        MockResult::Return(fut.boxed())
     });
 
     let client = NativeClient(Arc::new(NativeClientImpl::default()));
@@ -666,19 +671,22 @@ fn test_withdraw_impl_sat_per_kb_fee() {
 #[cfg(not(target_arch = "wasm32"))]
 fn test_withdraw_impl_sat_per_kb_fee_amount_equal_to_max() {
     UtxoStandardCoin::get_unspent_ordered_list.mock_safe(|coin, _| {
-        let cache = block_on(coin.as_ref().recently_spent_outpoints.lock());
-        let unspents = vec![UnspentInfo {
-            outpoint: OutPoint {
-                hash: 1.into(),
-                index: 0,
-            },
-            value: 1000000000,
-            height: Default::default(),
-            script: coin
-                .script_for_address(&block_on(coin.as_ref().derivation_method.unwrap_single_addr()))
-                .unwrap(),
-        }];
-        MockResult::Return(Box::pin(futures::future::ok((unspents, cache))))
+        let fut = async move {
+            let cache = coin.as_ref().recently_spent_outpoints.lock().await;
+            let unspents = vec![UnspentInfo {
+                outpoint: OutPoint {
+                    hash: 1.into(),
+                    index: 0,
+                },
+                value: 1000000000,
+                height: Default::default(),
+                script: coin
+                    .script_for_address(&coin.as_ref().derivation_method.unwrap_single_addr().await)
+                    .unwrap(),
+            }];
+            Ok((unspents, cache))
+        };
+        MockResult::Return(fut.boxed())
     });
 
     let client = NativeClient(Arc::new(NativeClientImpl::default()));
@@ -717,19 +725,22 @@ fn test_withdraw_impl_sat_per_kb_fee_amount_equal_to_max() {
 #[cfg(not(target_arch = "wasm32"))]
 fn test_withdraw_impl_sat_per_kb_fee_amount_equal_to_max_dust_included_to_fee() {
     UtxoStandardCoin::get_unspent_ordered_list.mock_safe(|coin, _| {
-        let cache = block_on(coin.as_ref().recently_spent_outpoints.lock());
-        let unspents = vec![UnspentInfo {
-            outpoint: OutPoint {
-                hash: 1.into(),
-                index: 0,
-            },
-            value: 1000000000,
-            height: Default::default(),
-            script: coin
-                .script_for_address(&block_on(coin.as_ref().derivation_method.unwrap_single_addr()))
-                .unwrap(),
-        }];
-        MockResult::Return(Box::pin(futures::future::ok((unspents, cache))))
+        let fut = async move {
+            let cache = coin.as_ref().recently_spent_outpoints.lock().await;
+            let unspents = vec![UnspentInfo {
+                outpoint: OutPoint {
+                    hash: 1.into(),
+                    index: 0,
+                },
+                value: 1000000000,
+                height: Default::default(),
+                script: coin
+                    .script_for_address(&coin.as_ref().derivation_method.unwrap_single_addr().await)
+                    .unwrap(),
+            }];
+            Ok((unspents, cache))
+        };
+        MockResult::Return(fut.boxed())
     });
 
     let client = NativeClient(Arc::new(NativeClientImpl::default()));
@@ -768,19 +779,22 @@ fn test_withdraw_impl_sat_per_kb_fee_amount_equal_to_max_dust_included_to_fee() 
 #[cfg(not(target_arch = "wasm32"))]
 fn test_withdraw_impl_sat_per_kb_fee_amount_over_max() {
     UtxoStandardCoin::get_unspent_ordered_list.mock_safe(|coin, _| {
-        let cache = block_on(coin.as_ref().recently_spent_outpoints.lock());
-        let unspents = vec![UnspentInfo {
-            outpoint: OutPoint {
-                hash: 1.into(),
-                index: 0,
-            },
-            value: 1000000000,
-            height: Default::default(),
-            script: coin
-                .script_for_address(&block_on(coin.as_ref().derivation_method.unwrap_single_addr()))
-                .unwrap(),
-        }];
-        MockResult::Return(Box::pin(futures::future::ok((unspents, cache))))
+        let fut = async move {
+            let cache = coin.as_ref().recently_spent_outpoints.lock().await;
+            let unspents = vec![UnspentInfo {
+                outpoint: OutPoint {
+                    hash: 1.into(),
+                    index: 0,
+                },
+                value: 1000000000,
+                height: Default::default(),
+                script: coin
+                    .script_for_address(&coin.as_ref().derivation_method.unwrap_single_addr().await)
+                    .unwrap(),
+            }];
+            Ok((unspents, cache))
+        };
+        MockResult::Return(fut.boxed())
     });
 
     let client = NativeClient(Arc::new(NativeClientImpl::default()));
@@ -806,19 +820,22 @@ fn test_withdraw_impl_sat_per_kb_fee_amount_over_max() {
 #[cfg(not(target_arch = "wasm32"))]
 fn test_withdraw_impl_sat_per_kb_fee_max() {
     UtxoStandardCoin::get_unspent_ordered_list.mock_safe(|coin, _| {
-        let cache = block_on(coin.as_ref().recently_spent_outpoints.lock());
-        let unspents = vec![UnspentInfo {
-            outpoint: OutPoint {
-                hash: 1.into(),
-                index: 0,
-            },
-            value: 1000000000,
-            height: Default::default(),
-            script: coin
-                .script_for_address(&block_on(coin.as_ref().derivation_method.unwrap_single_addr()))
-                .unwrap(),
-        }];
-        MockResult::Return(Box::pin(futures::future::ok((unspents, cache))))
+        let fut = async move {
+            let cache = coin.as_ref().recently_spent_outpoints.lock().await;
+            let unspents = vec![UnspentInfo {
+                outpoint: OutPoint {
+                    hash: 1.into(),
+                    index: 0,
+                },
+                value: 1000000000,
+                height: Default::default(),
+                script: coin
+                    .script_for_address(&coin.as_ref().derivation_method.unwrap_single_addr().await)
+                    .unwrap(),
+            }];
+            Ok((unspents, cache))
+        };
+        MockResult::Return(fut.boxed())
     });
 
     let client = NativeClient(Arc::new(NativeClientImpl::default()));
@@ -862,20 +879,23 @@ fn test_withdraw_kmd_rewards_impl(
     let verbose: RpcTransaction = json::from_str(verbose_serialized).unwrap();
     let unspent_height = verbose.height;
     UtxoStandardCoin::get_unspent_ordered_list.mock_safe(move |coin: &UtxoStandardCoin, _| {
-        let tx: UtxoTx = tx_hex.into();
-        let unspents = vec![UnspentInfo {
-            outpoint: OutPoint {
-                hash: tx.hash(),
-                index: 0,
-            },
-            value: tx.outputs[0].value,
-            height: unspent_height,
-            script: coin
-                .script_for_address(&block_on(coin.as_ref().derivation_method.unwrap_single_addr()))
-                .unwrap(),
-        }];
-        let cache = block_on(coin.as_ref().recently_spent_outpoints.lock());
-        MockResult::Return(Box::pin(futures::future::ok((unspents, cache))))
+        let fut = async move {
+            let tx: UtxoTx = tx_hex.into();
+            let unspents = vec![UnspentInfo {
+                outpoint: OutPoint {
+                    hash: tx.hash(),
+                    index: 0,
+                },
+                value: tx.outputs[0].value,
+                height: unspent_height,
+                script: coin
+                    .script_for_address(&coin.as_ref().derivation_method.unwrap_single_addr().await)
+                    .unwrap(),
+            }];
+            let cache = coin.as_ref().recently_spent_outpoints.lock().await;
+            Ok((unspents, cache))
+        };
+        MockResult::Return(fut.boxed())
     });
     UtxoStandardCoin::get_current_mtp
         .mock_safe(move |_fields| MockResult::Return(Box::pin(futures::future::ok(current_mtp))));
@@ -954,20 +974,23 @@ fn test_withdraw_rick_rewards_none() {
     const TX_HEX: &str = "0400008085202f8901df8119c507aa61d32332cd246dbfeb3818a4f96e76492454c1fbba5aa097977e000000004847304402205a7e229ea6929c97fd6dde254c19e4eb890a90353249721701ae7a1c477d99c402206a8b7c5bf42b5095585731d6b4c589ce557f63c20aed69ff242eca22ecfcdc7a01feffffff02d04d1bffbc050000232102afdbba3e3c90db5f0f4064118f79cf308f926c68afd64ea7afc930975663e4c4ac402dd913000000001976a9143e17014eca06281ee600adffa34b4afb0922a22288ac2bdab86035a00e000000000000000000000000";
 
     UtxoStandardCoin::get_unspent_ordered_list.mock_safe(move |coin, _| {
-        let tx: UtxoTx = TX_HEX.into();
-        let unspents = vec![UnspentInfo {
-            outpoint: OutPoint {
-                hash: tx.hash(),
-                index: 0,
-            },
-            value: tx.outputs[0].value,
-            height: Some(1431628),
-            script: coin
-                .script_for_address(&block_on(coin.as_ref().derivation_method.unwrap_single_addr()))
-                .unwrap(),
-        }];
-        let cache = block_on(coin.as_ref().recently_spent_outpoints.lock());
-        MockResult::Return(Box::pin(futures::future::ok((unspents, cache))))
+        let fut = async move {
+            let tx: UtxoTx = TX_HEX.into();
+            let unspents = vec![UnspentInfo {
+                outpoint: OutPoint {
+                    hash: tx.hash(),
+                    index: 0,
+                },
+                value: tx.outputs[0].value,
+                height: Some(1431628),
+                script: coin
+                    .script_for_address(&coin.as_ref().derivation_method.unwrap_single_addr().await)
+                    .unwrap(),
+            }];
+            let cache = coin.as_ref().recently_spent_outpoints.lock().await;
+            Ok((unspents, cache))
+        };
+        MockResult::Return(fut.boxed())
     });
 
     let withdraw_req = WithdrawRequest {
@@ -1773,42 +1796,42 @@ fn test_qtum_remove_delegation() {
 #[test]
 fn test_qtum_my_balance() {
     QtumCoin::get_mature_unspent_ordered_list.mock_safe(move |coin, _address| {
-        let cache = block_on(coin.as_ref().recently_spent_outpoints.lock());
-        // spendable balance (66.0)
-        let mature = vec![
-            UnspentInfo {
+        let fut = async move {
+            let cache = coin.as_ref().recently_spent_outpoints.lock().await;
+            // spendable balance (66.0)
+            let mature = vec![
+                UnspentInfo {
+                    outpoint: OutPoint {
+                        hash: 1.into(),
+                        index: 0,
+                    },
+                    value: 5000000000,
+                    height: Default::default(),
+                    script: Vec::new().into(),
+                },
+                UnspentInfo {
+                    outpoint: OutPoint {
+                        hash: 1.into(),
+                        index: 0,
+                    },
+                    value: 1600000000,
+                    height: Default::default(),
+                    script: Vec::new().into(),
+                },
+            ];
+            // unspendable (2.0)
+            let immature = vec![UnspentInfo {
                 outpoint: OutPoint {
                     hash: 1.into(),
                     index: 0,
                 },
-                value: 5000000000,
+                value: 200000000,
                 height: Default::default(),
                 script: Vec::new().into(),
-            },
-            UnspentInfo {
-                outpoint: OutPoint {
-                    hash: 1.into(),
-                    index: 0,
-                },
-                value: 1600000000,
-                height: Default::default(),
-                script: Vec::new().into(),
-            },
-        ];
-        // unspendable (2.0)
-        let immature = vec![UnspentInfo {
-            outpoint: OutPoint {
-                hash: 1.into(),
-                index: 0,
-            },
-            value: 200000000,
-            height: Default::default(),
-            script: Vec::new().into(),
-        }];
-        MockResult::Return(Box::pin(futures::future::ok((
-            MatureUnspentList { mature, immature },
-            cache,
-        ))))
+            }];
+            Ok((MatureUnspentList { mature, immature }, cache))
+        };
+        MockResult::Return(fut.boxed())
     });
 
     let conf = json!({"coin":"tQTUM","rpcport":13889,"pubtype":120,"p2shtype":110});
@@ -3177,19 +3200,22 @@ fn test_withdraw_to_p2pkh() {
     let coin = utxo_coin_for_test(UtxoRpcClientEnum::Native(client), None, false);
 
     UtxoStandardCoin::get_unspent_ordered_list.mock_safe(|coin, _| {
-        let cache = block_on(coin.as_ref().recently_spent_outpoints.lock());
-        let unspents = vec![UnspentInfo {
-            outpoint: OutPoint {
-                hash: 1.into(),
-                index: 0,
-            },
-            value: 1000000000,
-            height: Default::default(),
-            script: coin
-                .script_for_address(&block_on(coin.as_ref().derivation_method.unwrap_single_addr()))
-                .unwrap(),
-        }];
-        MockResult::Return(Box::pin(futures::future::ok((unspents, cache))))
+        let fut = async move {
+            let cache = coin.as_ref().recently_spent_outpoints.lock().await;
+            let unspents = vec![UnspentInfo {
+                outpoint: OutPoint {
+                    hash: 1.into(),
+                    index: 0,
+                },
+                value: 1000000000,
+                height: Default::default(),
+                script: coin
+                    .script_for_address(&coin.as_ref().derivation_method.unwrap_single_addr().await)
+                    .unwrap(),
+            }];
+            Ok((unspents, cache))
+        };
+        MockResult::Return(fut.boxed())
     });
 
     // Create a p2pkh address for the test coin
@@ -3234,19 +3260,22 @@ fn test_withdraw_to_p2sh() {
     let coin = utxo_coin_for_test(UtxoRpcClientEnum::Native(client), None, false);
 
     UtxoStandardCoin::get_unspent_ordered_list.mock_safe(|coin, _| {
-        let cache = block_on(coin.as_ref().recently_spent_outpoints.lock());
-        let unspents = vec![UnspentInfo {
-            outpoint: OutPoint {
-                hash: 1.into(),
-                index: 0,
-            },
-            value: 1000000000,
-            height: Default::default(),
-            script: coin
-                .script_for_address(&block_on(coin.as_ref().derivation_method.unwrap_single_addr()))
-                .unwrap(),
-        }];
-        MockResult::Return(Box::pin(futures::future::ok((unspents, cache))))
+        let fut = async move {
+            let cache = coin.as_ref().recently_spent_outpoints.lock().await;
+            let unspents = vec![UnspentInfo {
+                outpoint: OutPoint {
+                    hash: 1.into(),
+                    index: 0,
+                },
+                value: 1000000000,
+                height: Default::default(),
+                script: coin
+                    .script_for_address(&coin.as_ref().derivation_method.unwrap_single_addr().await)
+                    .unwrap(),
+            }];
+            Ok((unspents, cache))
+        };
+        MockResult::Return(fut.boxed())
     });
 
     // Create a p2sh address for the test coin
@@ -3291,19 +3320,22 @@ fn test_withdraw_to_p2wpkh() {
     let coin = utxo_coin_for_test(UtxoRpcClientEnum::Native(client), None, true);
 
     UtxoStandardCoin::get_unspent_ordered_list.mock_safe(|coin, _| {
-        let cache = block_on(coin.as_ref().recently_spent_outpoints.lock());
-        let unspents = vec![UnspentInfo {
-            outpoint: OutPoint {
-                hash: 1.into(),
-                index: 0,
-            },
-            value: 1000000000,
-            height: Default::default(),
-            script: coin
-                .script_for_address(&block_on(coin.as_ref().derivation_method.unwrap_single_addr()))
-                .unwrap(),
-        }];
-        MockResult::Return(Box::pin(futures::future::ok((unspents, cache))))
+        let fut = async move {
+            let cache = coin.as_ref().recently_spent_outpoints.lock().await;
+            let unspents = vec![UnspentInfo {
+                outpoint: OutPoint {
+                    hash: 1.into(),
+                    index: 0,
+                },
+                value: 1000000000,
+                height: Default::default(),
+                script: coin
+                    .script_for_address(&coin.as_ref().derivation_method.unwrap_single_addr().await)
+                    .unwrap(),
+            }];
+            Ok((unspents, cache))
+        };
+        MockResult::Return(fut.boxed())
     });
 
     // Create a p2wpkh address for the test coin
@@ -3348,22 +3380,29 @@ fn test_withdraw_p2pk_balance() {
     let coin = utxo_coin_for_test(UtxoRpcClientEnum::Native(client), None, false);
 
     UtxoStandardCoin::get_unspent_ordered_list.mock_safe(|coin, _| {
-        let cache = block_on(coin.as_ref().recently_spent_outpoints.lock());
-        let unspents = vec![UnspentInfo {
-            outpoint: OutPoint {
-                hash: 1.into(),
-                index: 0,
-            },
-            value: 1000000000,
-            height: Default::default(),
-            // Use a p2pk output script for this UTXO
-            script: output_script_p2pk(
-                &block_on(coin.as_ref().derivation_method.unwrap_single_addr())
-                    .pubkey()
-                    .unwrap(),
-            ),
-        }];
-        MockResult::Return(Box::pin(futures::future::ok((unspents, cache))))
+        let fut = async move {
+            let cache = coin.as_ref().recently_spent_outpoints.lock().await;
+            let unspents = vec![UnspentInfo {
+                outpoint: OutPoint {
+                    hash: 1.into(),
+                    index: 0,
+                },
+                value: 1000000000,
+                height: Default::default(),
+                // Use a p2pk output script for this UTXO
+                script: output_script_p2pk(
+                    &coin
+                        .as_ref()
+                        .derivation_method
+                        .unwrap_single_addr()
+                        .await
+                        .pubkey()
+                        .unwrap(),
+                ),
+            }];
+            Ok((unspents, cache))
+        };
+        MockResult::Return(fut.boxed())
     });
 
     // Create a dummy p2pkh address to withdraw the coins to.
@@ -3400,8 +3439,11 @@ fn test_utxo_standard_with_check_utxo_maturity_true() {
 
     UtxoStandardCoin::get_mature_unspent_ordered_list.mock_safe(|coin, _| {
         unsafe { GET_MATURE_UNSPENT_ORDERED_LIST_CALLED = true };
-        let cache = block_on(coin.as_ref().recently_spent_outpoints.lock());
-        MockResult::Return(Box::pin(futures::future::ok((MatureUnspentList::default(), cache))))
+        let fut = async move {
+            let cache = coin.as_ref().recently_spent_outpoints.lock().await;
+            Ok((MatureUnspentList::default(), cache))
+        };
+        MockResult::Return(fut.boxed())
     });
 
     let conf = json!({"coin":"RICK","asset":"RICK","rpcport":25435,"txversion":4,"overwintered":1,"mm2":1,"protocol":{"type":"UTXO"}});
@@ -3432,9 +3474,11 @@ fn test_utxo_standard_without_check_utxo_maturity() {
 
     UtxoStandardCoin::get_all_unspent_ordered_list.mock_safe(|coin, _| {
         unsafe { GET_ALL_UNSPENT_ORDERED_LIST_CALLED = true };
-        let cache = block_on(coin.as_ref().recently_spent_outpoints.lock());
-        let unspents = Vec::new();
-        MockResult::Return(Box::pin(futures::future::ok((unspents, cache))))
+        let fut = async move {
+            let cache = coin.as_ref().recently_spent_outpoints.lock().await;
+            Ok((Vec::new(), cache))
+        };
+        MockResult::Return(fut.boxed())
     });
 
     UtxoStandardCoin::get_mature_unspent_ordered_list.mock_safe(|_, _| {
@@ -3468,8 +3512,11 @@ fn test_qtum_without_check_utxo_maturity() {
 
     QtumCoin::get_mature_unspent_ordered_list.mock_safe(|coin, _| {
         unsafe { GET_MATURE_UNSPENT_ORDERED_LIST_CALLED = true };
-        let cache = block_on(coin.as_ref().recently_spent_outpoints.lock());
-        MockResult::Return(Box::pin(futures::future::ok((MatureUnspentList::default(), cache))))
+        let fut = async move {
+            let cache = coin.as_ref().recently_spent_outpoints.lock().await;
+            Ok((MatureUnspentList::default(), cache))
+        };
+        MockResult::Return(fut.boxed())
     });
 
     let conf = json!({"coin":"tQTUM","rpcport":13889,"pubtype":120,"p2shtype":110});
@@ -3572,9 +3619,12 @@ fn test_qtum_with_check_utxo_maturity_false() {
 
     QtumCoin::get_all_unspent_ordered_list.mock_safe(|coin, _address| {
         unsafe { GET_ALL_UNSPENT_ORDERED_LIST_CALLED = true };
-        let cache = block_on(coin.as_ref().recently_spent_outpoints.lock());
-        let unspents = Vec::new();
-        MockResult::Return(Box::pin(futures::future::ok((unspents, cache))))
+        let fut = async move {
+            let cache = coin.as_ref().recently_spent_outpoints.lock().await;
+            let unspents = Vec::new();
+            Ok((unspents, cache))
+        };
+        MockResult::Return(fut.boxed())
     });
     QtumCoin::get_mature_unspent_ordered_list.mock_safe(|_, _| {
         panic!(
@@ -4516,7 +4566,6 @@ fn test_utxo_validate_valid_and_invalid_pubkey() {
 #[test]
 fn test_block_header_utxo_loop() {
     use crate::utxo::utxo_builder::{block_header_utxo_loop, BlockHeaderUtxoLoopExtraArgs};
-    use futures::future::{Either, FutureExt};
     use keys::hash::H256 as H256Json;
 
     static mut CURRENT_BLOCK_COUNT: u64 = 13;

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -34,7 +34,7 @@ use crate::{BlockHeightAndTime, CoinBalance, ConfirmPaymentInput, DexFee, Iguana
 use crate::{WaitForHTLCTxSpendArgs, WithdrawFee};
 use chain::{BlockHeader, BlockHeaderBits, OutPoint};
 use common::executor::Timer;
-use common::{block_on, wait_until_sec, OrdRange, PagingOptionsEnum, DEX_FEE_ADDR_RAW_PUBKEY};
+use common::{block_on, block_on_f01, wait_until_sec, OrdRange, PagingOptionsEnum, DEX_FEE_ADDR_RAW_PUBKEY};
 use crypto::{privkey::key_pair_from_seed, Bip44Chain, HDPathToAccount, RpcDerivationPath, Secp256k1Secret};
 #[cfg(not(target_arch = "wasm32"))]
 use db_common::sqlite::rusqlite::Connection;
@@ -438,18 +438,16 @@ fn test_wait_for_payment_spend_timeout_native() {
     let wait_until = now_sec() - 1;
     let from_block = 1000;
 
-    assert!(coin
-        .wait_for_htlc_tx_spend(WaitForHTLCTxSpendArgs {
-            tx_bytes: &transaction,
-            secret_hash: &[],
-            wait_until,
-            from_block,
-            swap_contract_address: &None,
-            check_every: TAKER_PAYMENT_SPEND_SEARCH_INTERVAL,
-            watcher_reward: false
-        })
-        .wait()
-        .is_err());
+    assert!(block_on_f01(coin.wait_for_htlc_tx_spend(WaitForHTLCTxSpendArgs {
+        tx_bytes: &transaction,
+        secret_hash: &[],
+        wait_until,
+        from_block,
+        swap_contract_address: &None,
+        check_every: TAKER_PAYMENT_SPEND_SEARCH_INTERVAL,
+        watcher_reward: false
+    }))
+    .is_err());
     assert!(unsafe { OUTPUT_SPEND_CALLED });
 }
 
@@ -486,18 +484,16 @@ fn test_wait_for_payment_spend_timeout_electrum() {
     let wait_until = now_sec() - 1;
     let from_block = 1000;
 
-    assert!(coin
-        .wait_for_htlc_tx_spend(WaitForHTLCTxSpendArgs {
-            tx_bytes: &transaction,
-            secret_hash: &[],
-            wait_until,
-            from_block,
-            swap_contract_address: &None,
-            check_every: TAKER_PAYMENT_SPEND_SEARCH_INTERVAL,
-            watcher_reward: false
-        })
-        .wait()
-        .is_err());
+    assert!(block_on_f01(coin.wait_for_htlc_tx_spend(WaitForHTLCTxSpendArgs {
+        tx_bytes: &transaction,
+        secret_hash: &[],
+        wait_until,
+        from_block,
+        swap_contract_address: &None,
+        check_every: TAKER_PAYMENT_SPEND_SEARCH_INTERVAL,
+        watcher_reward: false
+    }))
+    .is_err());
     assert!(unsafe { OUTPUT_SPEND_CALLED });
 }
 
@@ -613,7 +609,7 @@ fn test_withdraw_impl_set_fixed_fee() {
         }
         .into(),
     );
-    let tx_details = coin.withdraw(withdraw_req).wait().unwrap();
+    let tx_details = block_on_f01(coin.withdraw(withdraw_req)).unwrap();
     assert_eq!(expected, tx_details.fee_details);
 }
 
@@ -662,7 +658,7 @@ fn test_withdraw_impl_sat_per_kb_fee() {
         }
         .into(),
     );
-    let tx_details = coin.withdraw(withdraw_req).wait().unwrap();
+    let tx_details = block_on_f01(coin.withdraw(withdraw_req)).unwrap();
     assert_eq!(expected, tx_details.fee_details);
 }
 
@@ -701,7 +697,7 @@ fn test_withdraw_impl_sat_per_kb_fee_amount_equal_to_max() {
         memo: None,
         ibc_source_channel: None,
     };
-    let tx_details = coin.withdraw(withdraw_req).wait().unwrap();
+    let tx_details = block_on_f01(coin.withdraw(withdraw_req)).unwrap();
     // The resulting transaction size might be 210 or 211 bytes depending on signature size
     // MM2 always expects the worst case during fee calculation
     // 0.1 * 211 / 1000 = 0.0211
@@ -752,7 +748,7 @@ fn test_withdraw_impl_sat_per_kb_fee_amount_equal_to_max_dust_included_to_fee() 
         memo: None,
         ibc_source_channel: None,
     };
-    let tx_details = coin.withdraw(withdraw_req).wait().unwrap();
+    let tx_details = block_on_f01(coin.withdraw(withdraw_req)).unwrap();
     // The resulting transaction size might be 210 or 211 bytes depending on signature size
     // MM2 always expects the worst case during fee calculation
     // 0.1 * 211 / 1000 = 0.0211
@@ -803,7 +799,7 @@ fn test_withdraw_impl_sat_per_kb_fee_amount_over_max() {
         memo: None,
         ibc_source_channel: None,
     };
-    coin.withdraw(withdraw_req).wait().unwrap_err();
+    block_on_f01(coin.withdraw(withdraw_req)).unwrap_err();
 }
 
 #[test]
@@ -851,7 +847,7 @@ fn test_withdraw_impl_sat_per_kb_fee_max() {
         }
         .into(),
     );
-    let tx_details = coin.withdraw(withdraw_req).wait().unwrap();
+    let tx_details = block_on_f01(coin.withdraw(withdraw_req)).unwrap();
     assert_eq!(expected, tx_details.fee_details);
 }
 
@@ -909,7 +905,7 @@ fn test_withdraw_kmd_rewards_impl(
         coin: Some("KMD".into()),
         amount: "0.00001".parse().unwrap(),
     });
-    let tx_details = coin.withdraw(withdraw_req).wait().unwrap();
+    let tx_details = block_on_f01(coin.withdraw(withdraw_req)).unwrap();
     assert_eq!(tx_details.fee_details, Some(expected_fee));
 
     let expected_rewards = expected_rewards.map(|amount| KmdRewardsDetails {
@@ -988,7 +984,7 @@ fn test_withdraw_rick_rewards_none() {
         coin: Some(TEST_COIN_NAME.into()),
         amount: "0.00001".parse().unwrap(),
     });
-    let tx_details = coin.withdraw(withdraw_req).wait().unwrap();
+    let tx_details = block_on_f01(coin.withdraw(withdraw_req)).unwrap();
     assert_eq!(tx_details.fee_details, Some(expected_fee));
     assert_eq!(tx_details.kmd_rewards, None);
 }
@@ -1066,7 +1062,7 @@ fn test_electrum_rpc_client_error() {
     let client = electrum_client_for_test(&["electrum1.cipig.net:10060"]);
 
     let empty_hash = H256Json::default();
-    let err = client.get_verbose_transaction(&empty_hash).wait().unwrap_err();
+    let err = block_on_f01(client.get_verbose_transaction(&empty_hash)).unwrap_err();
 
     // use the static string instead because the actual error message cannot be obtain
     // by serde_json serialization
@@ -1305,10 +1301,7 @@ fn test_get_median_time_past_from_electrum_kmd() {
         "electrum3.cipig.net:10001",
     ]);
 
-    let mtp = client
-        .get_median_time_past(1773390, KMD_MTP_BLOCK_COUNT, CoinVariant::Standard)
-        .wait()
-        .unwrap();
+    let mtp = block_on_f01(client.get_median_time_past(1773390, KMD_MTP_BLOCK_COUNT, CoinVariant::Standard)).unwrap();
     // the MTP is block time of 1773385 in this case
     assert_eq!(1583159915, mtp);
 }
@@ -1321,10 +1314,7 @@ fn test_get_median_time_past_from_electrum_btc() {
         "electrum3.cipig.net:10000",
     ]);
 
-    let mtp = client
-        .get_median_time_past(632858, KMD_MTP_BLOCK_COUNT, CoinVariant::Standard)
-        .wait()
-        .unwrap();
+    let mtp = block_on_f01(client.get_median_time_past(632858, KMD_MTP_BLOCK_COUNT, CoinVariant::Standard)).unwrap();
     assert_eq!(1591173041, mtp);
 }
 
@@ -1348,10 +1338,7 @@ fn test_get_median_time_past_from_native_has_median_in_get_block() {
         )
     });
 
-    let mtp = client
-        .get_median_time_past(632858, KMD_MTP_BLOCK_COUNT, CoinVariant::Standard)
-        .wait()
-        .unwrap();
+    let mtp = block_on_f01(client.get_median_time_past(632858, KMD_MTP_BLOCK_COUNT, CoinVariant::Standard)).unwrap();
     assert_eq!(1591173041, mtp);
 }
 
@@ -1394,10 +1381,7 @@ fn test_get_median_time_past_from_native_does_not_have_median_in_get_block() {
         MockResult::Return(Box::new(futures01::future::ok(block)))
     });
 
-    let mtp = client
-        .get_median_time_past(632858, KMD_MTP_BLOCK_COUNT, CoinVariant::Standard)
-        .wait()
-        .unwrap();
+    let mtp = block_on_f01(client.get_median_time_past(632858, KMD_MTP_BLOCK_COUNT, CoinVariant::Standard)).unwrap();
     assert_eq!(1591173041, mtp);
 }
 
@@ -1597,13 +1581,11 @@ fn test_spam_rick() {
 fn test_one_unavailable_electrum_proto_version() {
     // check if the electrum-mona.bitbank.cc:50001 doesn't support the protocol version 1.4
     let client = electrum_client_for_test(&["electrum-mona.bitbank.cc:50001"]);
-    let result = client
-        .server_version(
-            "electrum-mona.bitbank.cc:50001",
-            "AtomicDEX",
-            &OrdRange::new(1.4, 1.4).unwrap(),
-        )
-        .wait();
+    let result = block_on_f01(client.server_version(
+        "electrum-mona.bitbank.cc:50001",
+        "AtomicDEX",
+        &OrdRange::new(1.4, 1.4).unwrap(),
+    ));
     assert!(result
         .err()
         .unwrap()
@@ -1628,7 +1610,7 @@ fn test_one_unavailable_electrum_proto_version() {
 
     block_on(async { Timer::sleep(0.5).await });
 
-    assert!(coin.as_ref().rpc_client.get_block_count().wait().is_ok());
+    assert!(block_on_f01(coin.as_ref().rpc_client.get_block_count()).is_ok());
 }
 
 #[test]
@@ -1685,7 +1667,7 @@ fn test_qtum_add_delegation() {
         address: address.to_string(),
         fee: Some(10),
     };
-    let res = coin.add_delegation(request).wait().unwrap();
+    let res = block_on_f01(coin.add_delegation(request)).unwrap();
     // Eligible for delegation
     assert!(res.my_balance_change.is_negative());
     assert_eq!(res.total_amount, res.spent_by_me);
@@ -1695,7 +1677,7 @@ fn test_qtum_add_delegation() {
         address: "fake_address".to_string(),
         fee: Some(10),
     };
-    let res = coin.add_delegation(request).wait();
+    let res = block_on_f01(coin.add_delegation(request));
     // Wrong address
     assert!(res.is_err());
 }
@@ -1728,7 +1710,7 @@ fn test_qtum_add_delegation_on_already_delegating() {
         address: address.to_string(),
         fee: Some(10),
     };
-    let res = coin.add_delegation(request).wait();
+    let res = block_on_f01(coin.add_delegation(request));
     // Already Delegating
     assert!(res.is_err());
 }
@@ -1754,7 +1736,7 @@ fn test_qtum_get_delegation_infos() {
         keypair.private().secret,
     ))
     .unwrap();
-    let staking_infos = coin.get_delegation_infos().wait().unwrap();
+    let staking_infos = block_on_f01(coin.get_delegation_infos()).unwrap();
     match staking_infos.staking_infos_details {
         StakingInfosDetails::Qtum(staking_details) => {
             assert!(staking_details.am_i_staking);
@@ -1784,7 +1766,7 @@ fn test_qtum_remove_delegation() {
         keypair.private().secret,
     ))
     .unwrap();
-    let res = coin.remove_delegation().wait();
+    let res = block_on_f01(coin.remove_delegation());
     assert!(res.is_ok());
 }
 
@@ -1845,7 +1827,7 @@ fn test_qtum_my_balance() {
     let params = UtxoActivationParams::from_legacy_req(&req).unwrap();
     let coin = block_on(qtum_coin_with_priv_key(&ctx, "tQTUM", &conf, &params, priv_key)).unwrap();
 
-    let CoinBalance { spendable, unspendable } = coin.my_balance().wait().unwrap();
+    let CoinBalance { spendable, unspendable } = block_on_f01(coin.my_balance()).unwrap();
     let expected_spendable = BigDecimal::from(66);
     let expected_unspendable = BigDecimal::from(2);
     assert_eq!(spendable, expected_spendable);
@@ -1881,7 +1863,7 @@ fn test_qtum_my_balance_with_check_utxo_maturity_false() {
     let params = UtxoActivationParams::from_legacy_req(&req).unwrap();
     let coin = block_on(qtum_coin_with_priv_key(&ctx, "tQTUM", &conf, &params, priv_key)).unwrap();
 
-    let CoinBalance { spendable, unspendable } = coin.my_balance().wait().unwrap();
+    let CoinBalance { spendable, unspendable } = block_on_f01(coin.my_balance()).unwrap();
     let expected_spendable = BigDecimal::from(DISPLAY_BALANCE);
     let expected_unspendable = BigDecimal::from(0);
     assert_eq!(spendable, expected_spendable);
@@ -1899,7 +1881,7 @@ fn test_get_mature_unspent_ordered_map_from_cache_impl(
     const TX_HASH: &str = "b43f9ed47f7b97d4766b6f1614136fa0c55b9a52c97342428333521fa13ad714";
     let tx_hash: H256Json = hex::decode(TX_HASH).unwrap().as_slice().into();
     let client = electrum_client_for_test(DOC_ELECTRUM_ADDRS);
-    let mut verbose = client.get_verbose_transaction(&tx_hash).wait().unwrap();
+    let mut verbose = block_on_f01(client.get_verbose_transaction(&tx_hash)).unwrap();
     verbose.confirmations = cached_confs;
     verbose.height = cached_height;
 
@@ -2517,15 +2499,13 @@ fn test_find_output_spend_skips_conflicting_transactions() {
     let tx: UtxoTx = "0400008085202f89027f57730fcbbc2c72fb18bcc3766a713044831a117bb1cade3ed88644864f7333020000006a47304402206e3737b2fcf078b61b16fa67340cc3e79c5d5e2dc9ffda09608371552a3887450220460a332aa1b8ad8f2de92d319666f70751078b221199951f80265b4f7cef8543012102d8c948c6af848c588517288168faa397d6ba3ea924596d03d1d84f224b5123c2ffffffff42b916a80430b80a77e114445b08cf120735447a524de10742fac8f6a9d4170f000000006a473044022004aa053edafb9d161ea8146e0c21ed1593aa6b9404dd44294bcdf920a1695fd902202365eac15dbcc5e9f83e2eed56a8f2f0e5aded36206f9c3fabc668fd4665fa2d012102d8c948c6af848c588517288168faa397d6ba3ea924596d03d1d84f224b5123c2ffffffff03547b16000000000017a9143e8ad0e2bf573d32cb0b3d3a304d9ebcd0c2023b870000000000000000166a144e2b3c0323ab3c2dc6f86dc5ec0729f11e42f56103970400000000001976a91450f4f098306f988d8843004689fae28c83ef16e888ac89c5925f000000000000000000000000000000".into();
     let vout = 0;
     let from_block = 0;
-    let actual = client
-        .find_output_spend(
-            tx.hash(),
-            &tx.outputs[vout].script_pubkey,
-            vout,
-            BlockHashOrHeight::Height(from_block),
-            TxHashAlgo::DSHA256,
-        )
-        .wait();
+    let actual = block_on_f01(client.find_output_spend(
+        tx.hash(),
+        &tx.outputs[vout].script_pubkey,
+        vout,
+        BlockHashOrHeight::Height(from_block),
+        TxHashAlgo::DSHA256,
+    ));
     assert_eq!(actual, Ok(None));
     assert_eq!(unsafe { GET_RAW_TRANSACTION_BYTES_CALLED }, 1);
 }
@@ -2609,7 +2589,7 @@ fn test_get_sender_trade_fee_dynamic_tx_fee() {
     );
     coin_fields.tx_fee = TxFee::Dynamic(EstimateFeeMethod::Standard);
     let coin = utxo_coin_from_fields(coin_fields);
-    let my_balance = coin.my_spendable_balance().wait().expect("!my_balance");
+    let my_balance = block_on_f01(coin.my_spendable_balance()).expect("!my_balance");
     let expected_balance = BigDecimal::from_str("2.22222").expect("!BigDecimal::from_str");
     assert_eq!(my_balance, expected_balance);
 
@@ -2657,7 +2637,9 @@ fn test_validate_fee_wrong_sender() {
         min_block_number: 0,
         uuid: &[],
     };
-    let error = coin.validate_fee(validate_fee_args).wait().unwrap_err().into_inner();
+    let error = block_on_f01(coin.validate_fee(validate_fee_args))
+        .unwrap_err()
+        .into_inner();
     log!("error: {:?}", error);
     match error {
         ValidatePaymentError::WrongPaymentTx(err) => assert!(err.contains(INVALID_SENDER_ERR_LOG)),
@@ -2682,7 +2664,9 @@ fn test_validate_fee_min_block() {
         min_block_number: 278455,
         uuid: &[],
     };
-    let error = coin.validate_fee(validate_fee_args).wait().unwrap_err().into_inner();
+    let error = block_on_f01(coin.validate_fee(validate_fee_args))
+        .unwrap_err()
+        .into_inner();
     match error {
         ValidatePaymentError::WrongPaymentTx(err) => assert!(err.contains("confirmed before min_block")),
         _ => panic!("Expected `WrongPaymentTx` early confirmation, found {:?}", error),
@@ -2711,7 +2695,7 @@ fn test_validate_fee_bch_70_bytes_signature() {
         min_block_number: 0,
         uuid: &[],
     };
-    coin.validate_fee(validate_fee_args).wait().unwrap();
+    block_on_f01(coin.validate_fee(validate_fee_args)).unwrap();
 }
 
 #[test]
@@ -2766,7 +2750,7 @@ fn firo_lelantus_tx() {
         "electrumx02.firo.org:50001",
         "electrumx03.firo.org:50001",
     ]);
-    let _tx = electrum.get_verbose_transaction(&tx_hash).wait().unwrap();
+    let _tx = block_on_f01(electrum.get_verbose_transaction(&tx_hash)).unwrap();
 }
 
 #[test]
@@ -2903,9 +2887,7 @@ fn doge_mtp() {
         "electrum2.cipig.net:10060",
         "electrum3.cipig.net:10060",
     ]);
-    let mtp = electrum
-        .get_median_time_past(3631820, NonZeroU64::new(11).unwrap(), CoinVariant::Standard)
-        .wait()
+    let mtp = block_on_f01(electrum.get_median_time_past(3631820, NonZeroU64::new(11).unwrap(), CoinVariant::Standard))
         .unwrap();
     assert_eq!(mtp, 1614849084);
 }
@@ -2917,9 +2899,7 @@ fn firo_mtp() {
         "electrumx02.firo.org:50001",
         "electrumx03.firo.org:50001",
     ]);
-    let mtp = electrum
-        .get_median_time_past(356730, NonZeroU64::new(11).unwrap(), CoinVariant::Standard)
-        .wait()
+    let mtp = block_on_f01(electrum.get_median_time_past(356730, NonZeroU64::new(11).unwrap(), CoinVariant::Standard))
         .unwrap();
     assert_eq!(mtp, 1616492629);
 }
@@ -2927,9 +2907,7 @@ fn firo_mtp() {
 #[test]
 fn verus_mtp() {
     let electrum = electrum_client_for_test(&["el0.verus.io:17485", "el1.verus.io:17485", "el2.verus.io:17485"]);
-    let mtp = electrum
-        .get_median_time_past(1480113, NonZeroU64::new(11).unwrap(), CoinVariant::Standard)
-        .wait()
+    let mtp = block_on_f01(electrum.get_median_time_past(1480113, NonZeroU64::new(11).unwrap(), CoinVariant::Standard))
         .unwrap();
     assert_eq!(mtp, 1618579909);
 }
@@ -2941,9 +2919,7 @@ fn sys_mtp() {
         "electrum2.cipig.net:10064",
         "electrum3.cipig.net:10064",
     ]);
-    let mtp = electrum
-        .get_median_time_past(1006678, NonZeroU64::new(11).unwrap(), CoinVariant::Standard)
-        .wait()
+    let mtp = block_on_f01(electrum.get_median_time_past(1006678, NonZeroU64::new(11).unwrap(), CoinVariant::Standard))
         .unwrap();
     assert_eq!(mtp, 1620019628);
 }
@@ -2955,9 +2931,7 @@ fn btc_mtp() {
         "electrum2.cipig.net:10000",
         "electrum3.cipig.net:10000",
     ]);
-    let mtp = electrum
-        .get_median_time_past(681659, NonZeroU64::new(11).unwrap(), CoinVariant::Standard)
-        .wait()
+    let mtp = block_on_f01(electrum.get_median_time_past(681659, NonZeroU64::new(11).unwrap(), CoinVariant::Standard))
         .unwrap();
     assert_eq!(mtp, 1620019527);
 }
@@ -2969,9 +2943,7 @@ fn rvn_mtp() {
         "electrum2.cipig.net:10051",
         "electrum3.cipig.net:10051",
     ]);
-    let mtp = electrum
-        .get_median_time_past(1968120, NonZeroU64::new(11).unwrap(), CoinVariant::Standard)
-        .wait()
+    let mtp = block_on_f01(electrum.get_median_time_past(1968120, NonZeroU64::new(11).unwrap(), CoinVariant::Standard))
         .unwrap();
     assert_eq!(mtp, 1633946264);
 }
@@ -2983,10 +2955,8 @@ fn qtum_mtp() {
         "electrum2.cipig.net:10050",
         "electrum3.cipig.net:10050",
     ]);
-    let mtp = electrum
-        .get_median_time_past(681659, NonZeroU64::new(11).unwrap(), CoinVariant::Qtum)
-        .wait()
-        .unwrap();
+    let mtp =
+        block_on_f01(electrum.get_median_time_past(681659, NonZeroU64::new(11).unwrap(), CoinVariant::Qtum)).unwrap();
     assert_eq!(mtp, 1598854128);
 }
 
@@ -2997,9 +2967,7 @@ fn zer_mtp() {
         "electrum2.cipig.net:10065",
         "electrum3.cipig.net:10065",
     ]);
-    let mtp = electrum
-        .get_median_time_past(1130915, NonZeroU64::new(11).unwrap(), CoinVariant::Standard)
-        .wait()
+    let mtp = block_on_f01(electrum.get_median_time_past(1130915, NonZeroU64::new(11).unwrap(), CoinVariant::Standard))
         .unwrap();
     assert_eq!(mtp, 1623240214);
 }
@@ -3196,7 +3164,7 @@ fn test_withdraw_to_p2pk_fails() {
     };
 
     assert!(matches!(
-        coin.withdraw(withdraw_req).wait().unwrap_err().into_inner(),
+        block_on_f01(coin.withdraw(withdraw_req)).unwrap_err().into_inner(),
         WithdrawError::InvalidAddress(..)
     ))
 }
@@ -3249,7 +3217,7 @@ fn test_withdraw_to_p2pkh() {
         memo: None,
         ibc_source_channel: None,
     };
-    let tx_details = coin.withdraw(withdraw_req).wait().unwrap();
+    let tx_details = block_on_f01(coin.withdraw(withdraw_req)).unwrap();
     let transaction: UtxoTx = deserialize(tx_details.tx.tx_hex().unwrap().as_slice()).unwrap();
     let output_script: Script = transaction.outputs[0].script_pubkey.clone().into();
 
@@ -3306,7 +3274,7 @@ fn test_withdraw_to_p2sh() {
         memo: None,
         ibc_source_channel: None,
     };
-    let tx_details = coin.withdraw(withdraw_req).wait().unwrap();
+    let tx_details = block_on_f01(coin.withdraw(withdraw_req)).unwrap();
     let transaction: UtxoTx = deserialize(tx_details.tx.tx_hex().unwrap().as_slice()).unwrap();
     let output_script: Script = transaction.outputs[0].script_pubkey.clone().into();
 
@@ -3363,7 +3331,7 @@ fn test_withdraw_to_p2wpkh() {
         memo: None,
         ibc_source_channel: None,
     };
-    let tx_details = coin.withdraw(withdraw_req).wait().unwrap();
+    let tx_details = block_on_f01(coin.withdraw(withdraw_req)).unwrap();
     let transaction: UtxoTx = deserialize(tx_details.tx.tx_hex().unwrap().as_slice()).unwrap();
     let output_script: Script = transaction.outputs[0].script_pubkey.clone().into();
 
@@ -3411,7 +3379,7 @@ fn test_withdraw_p2pk_balance() {
         memo: None,
         ibc_source_channel: None,
     };
-    let tx_details = coin.withdraw(withdraw_req).wait().unwrap();
+    let tx_details = block_on_f01(coin.withdraw(withdraw_req)).unwrap();
     let transaction: UtxoTx = deserialize(tx_details.tx.tx_hex().unwrap().as_slice()).unwrap();
 
     // The change should be in a p2pkh script.
@@ -3451,7 +3419,7 @@ fn test_utxo_standard_with_check_utxo_maturity_true() {
 
     let address = Address::from_legacyaddress("R9o9xTocqr6CeEDGDH6mEYpwLoMz6jNjMW", &KMD_PREFIXES).unwrap();
     // Don't use `block_on` here because it's used within a mock of [`GetUtxoListOps::get_mature_unspent_ordered_list`].
-    coin.get_unspent_ordered_list(&address).compat().wait().unwrap();
+    block_on_f01(coin.get_unspent_ordered_list(&address).compat()).unwrap();
     assert!(unsafe { GET_MATURE_UNSPENT_ORDERED_LIST_CALLED });
 }
 
@@ -3487,7 +3455,7 @@ fn test_utxo_standard_without_check_utxo_maturity() {
 
     let address = Address::from_legacyaddress("R9o9xTocqr6CeEDGDH6mEYpwLoMz6jNjMW", &KMD_PREFIXES).unwrap();
     // Don't use `block_on` here because it's used within a mock of [`UtxoStandardCoin::get_all_unspent_ordered_list`].
-    coin.get_unspent_ordered_list(&address).compat().wait().unwrap();
+    block_on_f01(coin.get_unspent_ordered_list(&address).compat()).unwrap();
     assert!(unsafe { GET_ALL_UNSPENT_ORDERED_LIST_CALLED });
 }
 
@@ -3526,7 +3494,7 @@ fn test_qtum_without_check_utxo_maturity() {
     )
     .unwrap();
     // Don't use `block_on` here because it's used within a mock of [`QtumCoin::get_mature_unspent_ordered_list`].
-    coin.get_unspent_ordered_list(&address).compat().wait().unwrap();
+    block_on_f01(coin.get_unspent_ordered_list(&address).compat()).unwrap();
     assert!(unsafe { GET_MATURE_UNSPENT_ORDERED_LIST_CALLED });
 }
 
@@ -3637,7 +3605,7 @@ fn test_qtum_with_check_utxo_maturity_false() {
     )
     .unwrap();
     // Don't use `block_on` here because it's used within a mock of [`QtumCoin::get_all_unspent_ordered_list`].
-    coin.get_unspent_ordered_list(&address).compat().wait().unwrap();
+    block_on_f01(coin.get_unspent_ordered_list(&address).compat()).unwrap();
     assert!(unsafe { GET_ALL_UNSPENT_ORDERED_LIST_CALLED });
 }
 
@@ -4365,7 +4333,9 @@ fn test_for_non_existent_tx_hex_utxo_electrum() {
         wait_until: timeout,
         check_every: 1,
     };
-    let actual = coin.wait_for_confirmations(confirm_payment_input).wait().err().unwrap();
+    let actual = block_on_f01(coin.wait_for_confirmations(confirm_payment_input))
+        .err()
+        .unwrap();
     assert!(actual.contains(
         "Tx d342ff9da528a2e262bddf2b6f9a27d1beb7aeb03f0fc8d9eac2987266447e44 was not found on chain after 10 tries"
     ));
@@ -4408,10 +4378,7 @@ fn test_native_display_balances() {
         Address::from_legacyaddress("RJeDDtDRtKUoL8BCKdH7TNCHqUKr7kQRsi", &KMD_PREFIXES).unwrap(),
         Address::from_legacyaddress("RQHn9VPHBqNjYwyKfJbZCiaxVrWPKGQjeF", &KMD_PREFIXES).unwrap(),
     ];
-    let actual = rpc_client
-        .display_balances(addresses, TEST_COIN_DECIMALS)
-        .wait()
-        .unwrap();
+    let actual = block_on_f01(rpc_client.display_balances(addresses, TEST_COIN_DECIMALS)).unwrap();
 
     let expected: Vec<(Address, BigDecimal)> = vec![
         (

--- a/mm2src/common/common.rs
+++ b/mm2src/common/common.rs
@@ -634,29 +634,20 @@ pub fn var(name: &str) -> Result<String, String> {
 #[cfg(target_arch = "wasm32")]
 pub fn var(_name: &str) -> Result<String, String> { ERR!("Environment variable not supported in WASM") }
 
-#[cfg(not(target_arch = "wasm32"))]
+/// Runs the given future on MM2's executor and waits for the result.
+///
+/// This is compatible with futures 0.1.
 pub fn block_on_f01<F>(f: F) -> Result<F::Item, F::Error>
 where
     F: Future,
 {
-    if var("TRACE_BLOCK_ON").map(|v| v == "true") == Ok(true) {
-        let mut trace = String::with_capacity(4096);
-        stack_trace(&mut stack_trace_frame, &mut |l| trace.push_str(l));
-        log::info!("block_on_f01 at\n{}", trace);
-    }
-
-    wio::CORE.0.block_on(f.compat())
-}
-
-#[cfg(target_arch = "wasm32")]
-pub fn block_on_f01<F>(_f: F) -> Result<F::Item, F::Error>
-where
-    F: Future,
-{
-    panic!("block_on_f01 is not supported in WASM!");
+    block_on(f.compat())
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+/// Runs the given future on MM2's executor and waits for the result.
+///
+/// This is compatible with futures 0.3.
 pub fn block_on<F>(f: F) -> F::Output
 where
     F: Future03,

--- a/mm2src/mm2_err_handle/src/map_to_mm_fut.rs
+++ b/mm2src/mm2_err_handle/src/map_to_mm_fut.rs
@@ -21,7 +21,7 @@ where
     ///
     /// ```rust
     /// let fut = futures01::future::err("An error".to_owned());
-    /// let mapped_res: Result<(), MmError<usize>> = fut.map_to_mm_fut(|e| e.len()).wait();
+    /// let mapped_res: Result<(), MmError<usize>> = block_on_f01(fut.map_to_mm_fut(|e| e.len()));
     /// ```
     #[track_caller]
     fn map_to_mm_fut<F>(self, f: F) -> MapToMmFuture<'a, T, E1, E2>

--- a/mm2src/mm2_err_handle/src/mm_error.rs
+++ b/mm2src/mm2_err_handle/src/mm_error.rs
@@ -332,6 +332,7 @@ impl<T: FormattedTrace> FormattedTrace for Vec<T> {
 mod tests {
     use super::*;
     use crate::prelude::*;
+    use common::block_on_f01;
     use futures01::Future;
     use ser_error_derive::SerializeErrorType;
     use serde_json::{self as json, json};
@@ -425,10 +426,8 @@ mod tests {
         }
 
         let into_mm_line = line!() + 2;
-        let mm_err = generate_error("An error")
-            .map_to_mm_fut(|error| error.len())
-            .wait()
-            .expect_err("Expected an error");
+        let mm_err =
+            block_on_f01(generate_error("An error").map_to_mm_fut(|error| error.len())).expect_err("Expected an error");
         assert_eq!(mm_err.etype, 8);
         assert_eq!(mm_err.trace, vec![TraceLocation::new("mm_error", into_mm_line)]);
     }

--- a/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
+++ b/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
@@ -12,10 +12,9 @@ use coins::TxFeeDetails;
 use coins::{ConfirmPaymentInput, FoundSwapTxSpend, MarketCoinOps, MmCoin, RefundPaymentArgs,
             SearchForSwapTxSpendInput, SendPaymentArgs, SpendPaymentArgs, SwapOps, SwapTxTypeWithSecretHash,
             TransactionEnum, WithdrawRequest};
-use common::{block_on, executor::Timer, get_utc_timestamp, now_sec, wait_until_sec};
+use common::{block_on, block_on_f01, executor::Timer, get_utc_timestamp, now_sec, wait_until_sec};
 use crypto::privkey::key_pair_from_seed;
 use crypto::{CryptoCtx, DerivationPath, KeyPairPolicy};
-use futures01::Future;
 use http::StatusCode;
 use mm2_number::{BigDecimal, BigRational, MmNumber};
 use mm2_test_helpers::for_tests::{check_my_swap_status_amounts, disable_coin, disable_coin_err, enable_eth_coin,
@@ -51,7 +50,7 @@ fn test_search_for_swap_tx_spend_native_was_refunded_taker() {
         watcher_reward: None,
         wait_for_confirmation_until: 0,
     };
-    let tx = coin.send_taker_payment(taker_payment_args).wait().unwrap();
+    let tx = block_on_f01(coin.send_taker_payment(taker_payment_args)).unwrap();
 
     let confirm_payment_input = ConfirmPaymentInput {
         payment_tx: tx.tx_hex(),
@@ -60,7 +59,7 @@ fn test_search_for_swap_tx_spend_native_was_refunded_taker() {
         wait_until: timeout,
         check_every: 1,
     };
-    coin.wait_for_confirmations(confirm_payment_input).wait().unwrap();
+    block_on_f01(coin.wait_for_confirmations(confirm_payment_input)).unwrap();
     let maker_refunds_payment_args = RefundPaymentArgs {
         payment_tx: &tx.tx_hex(),
         time_lock,
@@ -81,7 +80,7 @@ fn test_search_for_swap_tx_spend_native_was_refunded_taker() {
         wait_until: timeout,
         check_every: 1,
     };
-    coin.wait_for_confirmations(confirm_payment_input).wait().unwrap();
+    block_on_f01(coin.wait_for_confirmations(confirm_payment_input)).unwrap();
 
     let search_input = SearchForSwapTxSpendInput {
         time_lock,
@@ -113,7 +112,9 @@ fn test_for_non_existent_tx_hex_utxo() {
         wait_until: timeout,
         check_every: 1,
     };
-    let actual = coin.wait_for_confirmations(confirm_payment_input).wait().err().unwrap();
+    let actual = block_on_f01(coin.wait_for_confirmations(confirm_payment_input))
+        .err()
+        .unwrap();
     assert!(actual.contains(
         "Tx d342ff9da528a2e262bddf2b6f9a27d1beb7aeb03f0fc8d9eac2987266447e44 was not found on chain after 10 tries"
     ));
@@ -138,7 +139,7 @@ fn test_search_for_swap_tx_spend_native_was_refunded_maker() {
         watcher_reward: None,
         wait_for_confirmation_until: 0,
     };
-    let tx = coin.send_maker_payment(maker_payment_args).wait().unwrap();
+    let tx = block_on_f01(coin.send_maker_payment(maker_payment_args)).unwrap();
 
     let confirm_payment_input = ConfirmPaymentInput {
         payment_tx: tx.tx_hex(),
@@ -147,7 +148,7 @@ fn test_search_for_swap_tx_spend_native_was_refunded_maker() {
         wait_until: timeout,
         check_every: 1,
     };
-    coin.wait_for_confirmations(confirm_payment_input).wait().unwrap();
+    block_on_f01(coin.wait_for_confirmations(confirm_payment_input)).unwrap();
     let maker_refunds_payment_args = RefundPaymentArgs {
         payment_tx: &tx.tx_hex(),
         time_lock,
@@ -168,7 +169,7 @@ fn test_search_for_swap_tx_spend_native_was_refunded_maker() {
         wait_until: timeout,
         check_every: 1,
     };
-    coin.wait_for_confirmations(confirm_payment_input).wait().unwrap();
+    block_on_f01(coin.wait_for_confirmations(confirm_payment_input)).unwrap();
 
     let search_input = SearchForSwapTxSpendInput {
         time_lock,
@@ -207,7 +208,7 @@ fn test_search_for_taker_swap_tx_spend_native_was_spent_by_maker() {
         watcher_reward: None,
         wait_for_confirmation_until: 0,
     };
-    let tx = coin.send_taker_payment(taker_payment_args).wait().unwrap();
+    let tx = block_on_f01(coin.send_taker_payment(taker_payment_args)).unwrap();
 
     let confirm_payment_input = ConfirmPaymentInput {
         payment_tx: tx.tx_hex(),
@@ -216,7 +217,7 @@ fn test_search_for_taker_swap_tx_spend_native_was_spent_by_maker() {
         wait_until: timeout,
         check_every: 1,
     };
-    coin.wait_for_confirmations(confirm_payment_input).wait().unwrap();
+    block_on_f01(coin.wait_for_confirmations(confirm_payment_input)).unwrap();
     let maker_spends_payment_args = SpendPaymentArgs {
         other_payment_tx: &tx.tx_hex(),
         time_lock,
@@ -236,7 +237,7 @@ fn test_search_for_taker_swap_tx_spend_native_was_spent_by_maker() {
         wait_until: timeout,
         check_every: 1,
     };
-    coin.wait_for_confirmations(confirm_payment_input).wait().unwrap();
+    block_on_f01(coin.wait_for_confirmations(confirm_payment_input)).unwrap();
 
     let search_input = SearchForSwapTxSpendInput {
         time_lock,
@@ -275,7 +276,7 @@ fn test_search_for_maker_swap_tx_spend_native_was_spent_by_taker() {
         watcher_reward: None,
         wait_for_confirmation_until: 0,
     };
-    let tx = coin.send_maker_payment(maker_payment_args).wait().unwrap();
+    let tx = block_on_f01(coin.send_maker_payment(maker_payment_args)).unwrap();
 
     let confirm_payment_input = ConfirmPaymentInput {
         payment_tx: tx.tx_hex(),
@@ -284,7 +285,7 @@ fn test_search_for_maker_swap_tx_spend_native_was_spent_by_taker() {
         wait_until: timeout,
         check_every: 1,
     };
-    coin.wait_for_confirmations(confirm_payment_input).wait().unwrap();
+    block_on_f01(coin.wait_for_confirmations(confirm_payment_input)).unwrap();
     let taker_spends_payment_args = SpendPaymentArgs {
         other_payment_tx: &tx.tx_hex(),
         time_lock,
@@ -304,7 +305,7 @@ fn test_search_for_maker_swap_tx_spend_native_was_spent_by_taker() {
         wait_until: timeout,
         check_every: 1,
     };
-    coin.wait_for_confirmations(confirm_payment_input).wait().unwrap();
+    block_on_f01(coin.wait_for_confirmations(confirm_payment_input)).unwrap();
 
     let search_input = SearchForSwapTxSpendInput {
         time_lock,
@@ -346,7 +347,7 @@ fn test_one_hundred_maker_payments_in_a_row_native() {
             watcher_reward: None,
             wait_for_confirmation_until: 0,
         };
-        let tx = coin.send_maker_payment(maker_payment_args).wait().unwrap();
+        let tx = block_on_f01(coin.send_maker_payment(maker_payment_args)).unwrap();
         if let TransactionEnum::UtxoTx(tx) = tx {
             unspents.push(UnspentInfo {
                 outpoint: OutPoint {
@@ -2472,16 +2473,12 @@ fn test_maker_order_should_not_kick_start_and_appear_in_orderbook_if_balance_is_
     bob_conf["log"] = mm_bob.folder.join("mm2_dup.log").to_str().unwrap().into();
     block_on(mm_bob.stop()).unwrap();
 
-    let withdraw = coin
-        .withdraw(WithdrawRequest::new_max(
-            "MYCOIN".to_string(),
-            "RRYmiZSDo3UdHHqj1rLKf8cbJroyv9NxXw".to_string(),
-        ))
-        .wait()
-        .unwrap();
-    coin.send_raw_tx(&hex::encode(&withdraw.tx.tx_hex().unwrap().0))
-        .wait()
-        .unwrap();
+    let withdraw = block_on_f01(coin.withdraw(WithdrawRequest::new_max(
+        "MYCOIN".to_string(),
+        "RRYmiZSDo3UdHHqj1rLKf8cbJroyv9NxXw".to_string(),
+    )))
+    .unwrap();
+    block_on_f01(coin.send_raw_tx(&hex::encode(&withdraw.tx.tx_hex().unwrap().0))).unwrap();
     let confirm_payment_input = ConfirmPaymentInput {
         payment_tx: withdraw.tx.tx_hex().unwrap().0.to_owned(),
         confirmations: 1,
@@ -2489,7 +2486,7 @@ fn test_maker_order_should_not_kick_start_and_appear_in_orderbook_if_balance_is_
         wait_until: wait_until_sec(10),
         check_every: 1,
     };
-    coin.wait_for_confirmations(confirm_payment_input).wait().unwrap();
+    block_on_f01(coin.wait_for_confirmations(confirm_payment_input)).unwrap();
 
     let mm_bob_dup = MarketMakerIt::start(bob_conf, "pass".to_string(), None).unwrap();
     let (_bob_dup_dump_log, _bob_dup_dump_dashboard) = mm_dump(&mm_bob_dup.log_path);

--- a/mm2src/mm2_main/tests/docker_tests/eth_docker_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/eth_docker_tests.rs
@@ -19,10 +19,9 @@ use coins::{lp_coinfind, CoinProtocol, CoinWithDerivationMethod, CoinsContext, C
             SendNftMakerPaymentArgs, SendPaymentArgs, SendTakerFundingArgs, SpendNftMakerPaymentArgs,
             SpendPaymentArgs, SwapOps, SwapTxFeePolicy, SwapTxTypeWithSecretHash, TakerCoinSwapOpsV2, ToBytes,
             Transaction, TxPreimageWithSig, ValidateNftMakerPaymentArgs, ValidateTakerFundingArgs};
-use common::{block_on, now_sec};
+use common::{block_on, block_on_f01, now_sec};
 use crypto::Secp256k1Secret;
 use ethereum_types::U256;
-use futures01::Future;
 use mm2_core::mm_ctx::MmArc;
 use mm2_number::{BigDecimal, BigUint};
 use mm2_test_helpers::for_tests::{erc20_dev_conf, eth_dev_conf, eth_sepolia_conf, nft_dev_conf, sepolia_erc20_dev_conf};
@@ -540,7 +539,7 @@ fn send_and_refund_eth_maker_payment_impl(swap_txfee_policy: SwapTxFeePolicy) {
         watcher_reward: None,
         wait_for_confirmation_until: 0,
     };
-    let eth_maker_payment = eth_coin.send_maker_payment(send_payment_args).wait().unwrap();
+    let eth_maker_payment = block_on_f01(eth_coin.send_maker_payment(send_payment_args)).unwrap();
 
     let confirm_input = ConfirmPaymentInput {
         payment_tx: eth_maker_payment.tx_hex(),
@@ -549,7 +548,7 @@ fn send_and_refund_eth_maker_payment_impl(swap_txfee_policy: SwapTxFeePolicy) {
         wait_until: now_sec() + 60,
         check_every: 1,
     };
-    eth_coin.wait_for_confirmations(confirm_input).wait().unwrap();
+    block_on_f01(eth_coin.wait_for_confirmations(confirm_input)).unwrap();
 
     let refund_args = RefundPaymentArgs {
         payment_tx: &eth_maker_payment.tx_hex(),
@@ -572,7 +571,7 @@ fn send_and_refund_eth_maker_payment_impl(swap_txfee_policy: SwapTxFeePolicy) {
         wait_until: now_sec() + 60,
         check_every: 1,
     };
-    eth_coin.wait_for_confirmations(confirm_input).wait().unwrap();
+    block_on_f01(eth_coin.wait_for_confirmations(confirm_input)).unwrap();
 
     let search_input = SearchForSwapTxSpendInput {
         time_lock,
@@ -626,7 +625,7 @@ fn send_and_spend_eth_maker_payment_impl(swap_txfee_policy: SwapTxFeePolicy) {
         watcher_reward: None,
         wait_for_confirmation_until: 0,
     };
-    let eth_maker_payment = maker_eth_coin.send_maker_payment(send_payment_args).wait().unwrap();
+    let eth_maker_payment = block_on_f01(maker_eth_coin.send_maker_payment(send_payment_args)).unwrap();
 
     let confirm_input = ConfirmPaymentInput {
         payment_tx: eth_maker_payment.tx_hex(),
@@ -635,7 +634,7 @@ fn send_and_spend_eth_maker_payment_impl(swap_txfee_policy: SwapTxFeePolicy) {
         wait_until: now_sec() + 60,
         check_every: 1,
     };
-    taker_eth_coin.wait_for_confirmations(confirm_input).wait().unwrap();
+    block_on_f01(taker_eth_coin.wait_for_confirmations(confirm_input)).unwrap();
 
     let spend_args = SpendPaymentArgs {
         other_payment_tx: &eth_maker_payment.tx_hex(),
@@ -657,7 +656,7 @@ fn send_and_spend_eth_maker_payment_impl(swap_txfee_policy: SwapTxFeePolicy) {
         wait_until: now_sec() + 60,
         check_every: 1,
     };
-    taker_eth_coin.wait_for_confirmations(confirm_input).wait().unwrap();
+    block_on_f01(taker_eth_coin.wait_for_confirmations(confirm_input)).unwrap();
 
     let search_input = SearchForSwapTxSpendInput {
         time_lock,
@@ -709,7 +708,7 @@ fn send_and_refund_erc20_maker_payment_impl(swap_txfee_policy: SwapTxFeePolicy) 
         watcher_reward: None,
         wait_for_confirmation_until: now_sec() + 60,
     };
-    let eth_maker_payment = erc20_coin.send_maker_payment(send_payment_args).wait().unwrap();
+    let eth_maker_payment = block_on_f01(erc20_coin.send_maker_payment(send_payment_args)).unwrap();
 
     let confirm_input = ConfirmPaymentInput {
         payment_tx: eth_maker_payment.tx_hex(),
@@ -718,7 +717,7 @@ fn send_and_refund_erc20_maker_payment_impl(swap_txfee_policy: SwapTxFeePolicy) 
         wait_until: now_sec() + 60,
         check_every: 1,
     };
-    erc20_coin.wait_for_confirmations(confirm_input).wait().unwrap();
+    block_on_f01(erc20_coin.wait_for_confirmations(confirm_input)).unwrap();
 
     let refund_args = RefundPaymentArgs {
         payment_tx: &eth_maker_payment.tx_hex(),
@@ -741,7 +740,7 @@ fn send_and_refund_erc20_maker_payment_impl(swap_txfee_policy: SwapTxFeePolicy) 
         wait_until: now_sec() + 60,
         check_every: 1,
     };
-    erc20_coin.wait_for_confirmations(confirm_input).wait().unwrap();
+    block_on_f01(erc20_coin.wait_for_confirmations(confirm_input)).unwrap();
 
     let search_input = SearchForSwapTxSpendInput {
         time_lock,
@@ -798,7 +797,7 @@ fn send_and_spend_erc20_maker_payment_impl(swap_txfee_policy: SwapTxFeePolicy) {
         watcher_reward: None,
         wait_for_confirmation_until: now_sec() + 60,
     };
-    let eth_maker_payment = maker_erc20_coin.send_maker_payment(send_payment_args).wait().unwrap();
+    let eth_maker_payment = block_on_f01(maker_erc20_coin.send_maker_payment(send_payment_args)).unwrap();
 
     let confirm_input = ConfirmPaymentInput {
         payment_tx: eth_maker_payment.tx_hex(),
@@ -807,7 +806,7 @@ fn send_and_spend_erc20_maker_payment_impl(swap_txfee_policy: SwapTxFeePolicy) {
         wait_until: now_sec() + 60,
         check_every: 1,
     };
-    taker_erc20_coin.wait_for_confirmations(confirm_input).wait().unwrap();
+    block_on_f01(taker_erc20_coin.wait_for_confirmations(confirm_input)).unwrap();
 
     let spend_args = SpendPaymentArgs {
         other_payment_tx: &eth_maker_payment.tx_hex(),
@@ -829,7 +828,7 @@ fn send_and_spend_erc20_maker_payment_impl(swap_txfee_policy: SwapTxFeePolicy) {
         wait_until: now_sec() + 60,
         check_every: 1,
     };
-    taker_erc20_coin.wait_for_confirmations(confirm_input).wait().unwrap();
+    block_on_f01(taker_erc20_coin.wait_for_confirmations(confirm_input)).unwrap();
 
     let search_input = SearchForSwapTxSpendInput {
         time_lock,
@@ -971,12 +970,12 @@ fn test_nonce_several_urls() {
     // Use one working and one failing URL.
     let coin = eth_coin_with_random_privkey_using_urls(swap_contract(), &[GETH_RPC_URL, "http://127.0.0.1:0"]);
     let my_address = block_on(coin.derivation_method().single_addr_or_err()).unwrap();
-    let (old_nonce, _) = coin.clone().get_addr_nonce(my_address).wait().unwrap();
+    let (old_nonce, _) = block_on_f01(coin.clone().get_addr_nonce(my_address)).unwrap();
 
     // Send a payment to increase the nonce.
-    coin.send_to_address(my_address, 200000000.into()).wait().unwrap();
+    block_on_f01(coin.send_to_address(my_address, 200000000.into())).unwrap();
 
-    let (new_nonce, _) = coin.get_addr_nonce(my_address).wait().unwrap();
+    let (new_nonce, _) = block_on_f01(coin.get_addr_nonce(my_address)).unwrap();
     assert_eq!(old_nonce + 1, new_nonce);
 }
 
@@ -1308,7 +1307,7 @@ fn wait_for_confirmations(coin: &EthCoin, tx: &SignedEthTx, wait_seconds: u64) {
         wait_until: now_sec() + wait_seconds,
         check_every: 1,
     };
-    coin.wait_for_confirmations(confirm_input).wait().unwrap();
+    block_on_f01(coin.wait_for_confirmations(confirm_input)).unwrap();
 }
 
 fn validate_nft_maker_payment(setup: &NftTestSetup, maker_payment: &SignedEthTx, amount: BigDecimal) {

--- a/mm2src/mm2_main/tests/docker_tests/swap_proto_v2_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/swap_proto_v2_tests.rs
@@ -6,8 +6,7 @@ use coins::{ConfirmPaymentInput, DexFee, FundingTxSpend, GenTakerFundingSpendArg
             RefundMakerPaymentSecretArgs, RefundMakerPaymentTimelockArgs, RefundTakerPaymentArgs,
             SendMakerPaymentArgs, SendTakerFundingArgs, SwapTxTypeWithSecretHash, TakerCoinSwapOpsV2, Transaction,
             ValidateMakerPaymentArgs, ValidateTakerFundingArgs};
-use common::{block_on, now_sec, DEX_FEE_ADDR_RAW_PUBKEY};
-use futures01::Future;
+use common::{block_on, block_on_f01, now_sec, DEX_FEE_ADDR_RAW_PUBKEY};
 use mm2_number::MmNumber;
 use mm2_test_helpers::for_tests::{active_swaps, check_recent_swaps, coins_needed_for_kickstart, disable_coin,
                                   disable_coin_err, enable_native, get_locked_amount, mm_dump, my_swap_status,
@@ -93,7 +92,7 @@ fn send_and_refund_taker_funding_timelock() {
         wait_until: now_sec() + 20,
         check_every: 1,
     };
-    coin.wait_for_confirmations(confirm_input).wait().unwrap();
+    block_on_f01(coin.wait_for_confirmations(confirm_input)).unwrap();
 
     let found_refund_tx =
         block_on(coin.search_for_taker_funding_spend(&taker_funding_utxo_tx, 1, taker_secret_hash)).unwrap();
@@ -180,7 +179,7 @@ fn send_and_refund_taker_funding_secret() {
         wait_until: now_sec() + 20,
         check_every: 1,
     };
-    coin.wait_for_confirmations(confirm_input).wait().unwrap();
+    block_on_f01(coin.wait_for_confirmations(confirm_input)).unwrap();
 
     let found_refund_tx =
         block_on(coin.search_for_taker_funding_spend(&taker_funding_utxo_tx, 1, taker_secret_hash)).unwrap();
@@ -268,7 +267,7 @@ fn send_and_spend_taker_funding() {
         wait_until: now_sec() + 20,
         check_every: 1,
     };
-    taker_coin.wait_for_confirmations(confirm_input).wait().unwrap();
+    block_on_f01(taker_coin.wait_for_confirmations(confirm_input)).unwrap();
 
     let found_spend_tx =
         block_on(taker_coin.search_for_taker_funding_spend(&taker_funding_utxo_tx, 1, taker_secret_hash)).unwrap();

--- a/mm2src/mm2_main/tests/docker_tests/swap_watcher_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/swap_watcher_tests.rs
@@ -13,9 +13,8 @@ use coins::{ConfirmPaymentInput, FoundSwapTxSpend, MarketCoinOps, MmCoin, MmCoin
             INVALID_CONTRACT_ADDRESS_ERR_LOG, INVALID_PAYMENT_STATE_ERR_LOG, INVALID_RECEIVER_ERR_LOG,
             INVALID_REFUND_TX_ERR_LOG, INVALID_SCRIPT_ERR_LOG, INVALID_SENDER_ERR_LOG, INVALID_SWAP_ID_ERR_LOG,
             OLD_TRANSACTION_ERR_LOG};
-use common::{block_on, now_sec, wait_until_sec, DEX_FEE_ADDR_RAW_PUBKEY};
+use common::{block_on, block_on_f01, now_sec, wait_until_sec, DEX_FEE_ADDR_RAW_PUBKEY};
 use crypto::privkey::{key_pair_from_secret, key_pair_from_seed};
-use futures01::Future;
 use mm2_main::lp_swap::{dex_fee_amount, dex_fee_amount_from_taker_coin, generate_secret, get_payment_locktime,
                         MAKER_PAYMENT_SENT_LOG, MAKER_PAYMENT_SPEND_FOUND_LOG, MAKER_PAYMENT_SPEND_SENT_LOG,
                         REFUND_TEST_FAILURE_LOG, TAKER_PAYMENT_REFUND_SENT_LOG, WATCHER_MESSAGE_SENT_LOG};
@@ -1208,15 +1207,13 @@ fn test_watcher_validate_taker_fee_utxo() {
     let taker_amount = MmNumber::from((10, 1));
     let fee_amount = dex_fee_amount_from_taker_coin(&taker_coin, maker_coin.ticker(), &taker_amount);
 
-    let taker_fee = taker_coin
-        .send_taker_fee(
-            &DEX_FEE_ADDR_RAW_PUBKEY,
-            fee_amount,
-            Uuid::new_v4().as_bytes(),
-            lock_duration,
-        )
-        .wait()
-        .unwrap();
+    let taker_fee = block_on_f01(taker_coin.send_taker_fee(
+        &DEX_FEE_ADDR_RAW_PUBKEY,
+        fee_amount,
+        Uuid::new_v4().as_bytes(),
+        lock_duration,
+    ))
+    .unwrap();
 
     let confirm_payment_input = ConfirmPaymentInput {
         payment_tx: taker_fee.tx_hex(),
@@ -1226,30 +1223,26 @@ fn test_watcher_validate_taker_fee_utxo() {
         check_every: 1,
     };
 
-    taker_coin.wait_for_confirmations(confirm_payment_input).wait().unwrap();
+    block_on_f01(taker_coin.wait_for_confirmations(confirm_payment_input)).unwrap();
 
-    let validate_taker_fee_res = taker_coin
-        .watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
-            taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
-            sender_pubkey: taker_pubkey.to_vec(),
-            min_block_number: 0,
-            fee_addr: DEX_FEE_ADDR_RAW_PUBKEY.to_vec(),
-            lock_duration,
-        })
-        .wait();
+    let validate_taker_fee_res = block_on_f01(taker_coin.watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
+        taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
+        sender_pubkey: taker_pubkey.to_vec(),
+        min_block_number: 0,
+        fee_addr: DEX_FEE_ADDR_RAW_PUBKEY.to_vec(),
+        lock_duration,
+    }));
     assert!(validate_taker_fee_res.is_ok());
 
-    let error = taker_coin
-        .watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
-            taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
-            sender_pubkey: maker_coin.my_public_key().unwrap().to_vec(),
-            min_block_number: 0,
-            fee_addr: DEX_FEE_ADDR_RAW_PUBKEY.to_vec(),
-            lock_duration,
-        })
-        .wait()
-        .unwrap_err()
-        .into_inner();
+    let error = block_on_f01(taker_coin.watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
+        taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
+        sender_pubkey: maker_coin.my_public_key().unwrap().to_vec(),
+        min_block_number: 0,
+        fee_addr: DEX_FEE_ADDR_RAW_PUBKEY.to_vec(),
+        lock_duration,
+    }))
+    .unwrap_err()
+    .into_inner();
 
     log!("error: {:?}", error);
     match error {
@@ -1259,17 +1252,15 @@ fn test_watcher_validate_taker_fee_utxo() {
         _ => panic!("Expected `WrongPaymentTx` invalid public key, found {:?}", error),
     }
 
-    let error = taker_coin
-        .watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
-            taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
-            sender_pubkey: taker_pubkey.to_vec(),
-            min_block_number: std::u64::MAX,
-            fee_addr: DEX_FEE_ADDR_RAW_PUBKEY.to_vec(),
-            lock_duration,
-        })
-        .wait()
-        .unwrap_err()
-        .into_inner();
+    let error = block_on_f01(taker_coin.watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
+        taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
+        sender_pubkey: taker_pubkey.to_vec(),
+        min_block_number: std::u64::MAX,
+        fee_addr: DEX_FEE_ADDR_RAW_PUBKEY.to_vec(),
+        lock_duration,
+    }))
+    .unwrap_err()
+    .into_inner();
     log!("error: {:?}", error);
     match error {
         ValidatePaymentError::WrongPaymentTx(err) => {
@@ -1281,17 +1272,15 @@ fn test_watcher_validate_taker_fee_utxo() {
         ),
     }
 
-    let error = taker_coin
-        .watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
-            taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
-            sender_pubkey: taker_pubkey.to_vec(),
-            min_block_number: 0,
-            fee_addr: DEX_FEE_ADDR_RAW_PUBKEY.to_vec(),
-            lock_duration: 0,
-        })
-        .wait()
-        .unwrap_err()
-        .into_inner();
+    let error = block_on_f01(taker_coin.watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
+        taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
+        sender_pubkey: taker_pubkey.to_vec(),
+        min_block_number: 0,
+        fee_addr: DEX_FEE_ADDR_RAW_PUBKEY.to_vec(),
+        lock_duration: 0,
+    }))
+    .unwrap_err()
+    .into_inner();
     log!("error: {:?}", error);
     match error {
         ValidatePaymentError::WrongPaymentTx(err) => {
@@ -1300,17 +1289,15 @@ fn test_watcher_validate_taker_fee_utxo() {
         _ => panic!("Expected `WrongPaymentTx` transaction too old, found {:?}", error),
     }
 
-    let error = taker_coin
-        .watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
-            taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
-            sender_pubkey: taker_pubkey.to_vec(),
-            min_block_number: 0,
-            fee_addr: taker_pubkey.to_vec(),
-            lock_duration,
-        })
-        .wait()
-        .unwrap_err()
-        .into_inner();
+    let error = block_on_f01(taker_coin.watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
+        taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
+        sender_pubkey: taker_pubkey.to_vec(),
+        min_block_number: 0,
+        fee_addr: taker_pubkey.to_vec(),
+        lock_duration,
+    }))
+    .unwrap_err()
+    .into_inner();
     log!("error: {:?}", error);
     match error {
         ValidatePaymentError::WrongPaymentTx(err) => {
@@ -1334,15 +1321,13 @@ fn test_watcher_validate_taker_fee_eth() {
 
     let taker_amount = MmNumber::from((1, 1));
     let fee_amount = dex_fee_amount_from_taker_coin(&taker_coin, "ETH", &taker_amount);
-    let taker_fee = taker_coin
-        .send_taker_fee(
-            &DEX_FEE_ADDR_RAW_PUBKEY,
-            fee_amount,
-            Uuid::new_v4().as_bytes(),
-            lock_duration,
-        )
-        .wait()
-        .unwrap();
+    let taker_fee = block_on_f01(taker_coin.send_taker_fee(
+        &DEX_FEE_ADDR_RAW_PUBKEY,
+        fee_amount,
+        Uuid::new_v4().as_bytes(),
+        lock_duration,
+    ))
+    .unwrap();
 
     let confirm_payment_input = ConfirmPaymentInput {
         payment_tx: taker_fee.tx_hex(),
@@ -1351,31 +1336,27 @@ fn test_watcher_validate_taker_fee_eth() {
         wait_until: timeout,
         check_every: 1,
     };
-    taker_coin.wait_for_confirmations(confirm_payment_input).wait().unwrap();
+    block_on_f01(taker_coin.wait_for_confirmations(confirm_payment_input)).unwrap();
 
-    let validate_taker_fee_res = taker_coin
-        .watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
-            taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
-            sender_pubkey: taker_pubkey.to_vec(),
-            min_block_number: 0,
-            fee_addr: DEX_FEE_ADDR_RAW_PUBKEY.to_vec(),
-            lock_duration,
-        })
-        .wait();
+    let validate_taker_fee_res = block_on_f01(taker_coin.watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
+        taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
+        sender_pubkey: taker_pubkey.to_vec(),
+        min_block_number: 0,
+        fee_addr: DEX_FEE_ADDR_RAW_PUBKEY.to_vec(),
+        lock_duration,
+    }));
     assert!(validate_taker_fee_res.is_ok());
 
     let wrong_keypair = key_pair_from_secret(random_secp256k1_secret().as_slice()).unwrap();
-    let error = taker_coin
-        .watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
-            taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
-            sender_pubkey: wrong_keypair.public().to_vec(),
-            min_block_number: 0,
-            fee_addr: DEX_FEE_ADDR_RAW_PUBKEY.to_vec(),
-            lock_duration,
-        })
-        .wait()
-        .unwrap_err()
-        .into_inner();
+    let error = block_on_f01(taker_coin.watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
+        taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
+        sender_pubkey: wrong_keypair.public().to_vec(),
+        min_block_number: 0,
+        fee_addr: DEX_FEE_ADDR_RAW_PUBKEY.to_vec(),
+        lock_duration,
+    }))
+    .unwrap_err()
+    .into_inner();
 
     log!("error: {:?}", error);
     match error {
@@ -1385,17 +1366,15 @@ fn test_watcher_validate_taker_fee_eth() {
         _ => panic!("Expected `WrongPaymentTx` invalid public key, found {:?}", error),
     }
 
-    let error = taker_coin
-        .watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
-            taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
-            sender_pubkey: taker_pubkey.to_vec(),
-            min_block_number: std::u64::MAX,
-            fee_addr: DEX_FEE_ADDR_RAW_PUBKEY.to_vec(),
-            lock_duration,
-        })
-        .wait()
-        .unwrap_err()
-        .into_inner();
+    let error = block_on_f01(taker_coin.watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
+        taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
+        sender_pubkey: taker_pubkey.to_vec(),
+        min_block_number: std::u64::MAX,
+        fee_addr: DEX_FEE_ADDR_RAW_PUBKEY.to_vec(),
+        lock_duration,
+    }))
+    .unwrap_err()
+    .into_inner();
     log!("error: {:?}", error);
     match error {
         ValidatePaymentError::WrongPaymentTx(err) => {
@@ -1407,17 +1386,15 @@ fn test_watcher_validate_taker_fee_eth() {
         ),
     }
 
-    let error = taker_coin
-        .watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
-            taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
-            sender_pubkey: taker_pubkey.to_vec(),
-            min_block_number: 0,
-            fee_addr: taker_pubkey.to_vec(),
-            lock_duration,
-        })
-        .wait()
-        .unwrap_err()
-        .into_inner();
+    let error = block_on_f01(taker_coin.watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
+        taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
+        sender_pubkey: taker_pubkey.to_vec(),
+        min_block_number: 0,
+        fee_addr: taker_pubkey.to_vec(),
+        lock_duration,
+    }))
+    .unwrap_err()
+    .into_inner();
     log!("error: {:?}", error);
     match error {
         ValidatePaymentError::WrongPaymentTx(err) => {
@@ -1441,15 +1418,13 @@ fn test_watcher_validate_taker_fee_erc20() {
 
     let taker_amount = MmNumber::from((1, 1));
     let fee_amount = dex_fee_amount_from_taker_coin(&taker_coin, "ETH", &taker_amount);
-    let taker_fee = taker_coin
-        .send_taker_fee(
-            &DEX_FEE_ADDR_RAW_PUBKEY,
-            fee_amount,
-            Uuid::new_v4().as_bytes(),
-            lock_duration,
-        )
-        .wait()
-        .unwrap();
+    let taker_fee = block_on_f01(taker_coin.send_taker_fee(
+        &DEX_FEE_ADDR_RAW_PUBKEY,
+        fee_amount,
+        Uuid::new_v4().as_bytes(),
+        lock_duration,
+    ))
+    .unwrap();
 
     let confirm_payment_input = ConfirmPaymentInput {
         payment_tx: taker_fee.tx_hex(),
@@ -1458,31 +1433,27 @@ fn test_watcher_validate_taker_fee_erc20() {
         wait_until: timeout,
         check_every: 1,
     };
-    taker_coin.wait_for_confirmations(confirm_payment_input).wait().unwrap();
+    block_on_f01(taker_coin.wait_for_confirmations(confirm_payment_input)).unwrap();
 
-    let validate_taker_fee_res = taker_coin
-        .watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
-            taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
-            sender_pubkey: taker_pubkey.to_vec(),
-            min_block_number: 0,
-            fee_addr: DEX_FEE_ADDR_RAW_PUBKEY.to_vec(),
-            lock_duration,
-        })
-        .wait();
+    let validate_taker_fee_res = block_on_f01(taker_coin.watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
+        taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
+        sender_pubkey: taker_pubkey.to_vec(),
+        min_block_number: 0,
+        fee_addr: DEX_FEE_ADDR_RAW_PUBKEY.to_vec(),
+        lock_duration,
+    }));
     assert!(validate_taker_fee_res.is_ok());
 
     let wrong_keypair = key_pair_from_secret(random_secp256k1_secret().as_slice()).unwrap();
-    let error = taker_coin
-        .watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
-            taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
-            sender_pubkey: wrong_keypair.public().to_vec(),
-            min_block_number: 0,
-            fee_addr: DEX_FEE_ADDR_RAW_PUBKEY.to_vec(),
-            lock_duration,
-        })
-        .wait()
-        .unwrap_err()
-        .into_inner();
+    let error = block_on_f01(taker_coin.watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
+        taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
+        sender_pubkey: wrong_keypair.public().to_vec(),
+        min_block_number: 0,
+        fee_addr: DEX_FEE_ADDR_RAW_PUBKEY.to_vec(),
+        lock_duration,
+    }))
+    .unwrap_err()
+    .into_inner();
 
     log!("error: {:?}", error);
     match error {
@@ -1492,17 +1463,15 @@ fn test_watcher_validate_taker_fee_erc20() {
         _ => panic!("Expected `WrongPaymentTx` invalid public key, found {:?}", error),
     }
 
-    let error = taker_coin
-        .watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
-            taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
-            sender_pubkey: taker_pubkey.to_vec(),
-            min_block_number: std::u64::MAX,
-            fee_addr: DEX_FEE_ADDR_RAW_PUBKEY.to_vec(),
-            lock_duration,
-        })
-        .wait()
-        .unwrap_err()
-        .into_inner();
+    let error = block_on_f01(taker_coin.watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
+        taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
+        sender_pubkey: taker_pubkey.to_vec(),
+        min_block_number: std::u64::MAX,
+        fee_addr: DEX_FEE_ADDR_RAW_PUBKEY.to_vec(),
+        lock_duration,
+    }))
+    .unwrap_err()
+    .into_inner();
     log!("error: {:?}", error);
     match error {
         ValidatePaymentError::WrongPaymentTx(err) => {
@@ -1514,17 +1483,15 @@ fn test_watcher_validate_taker_fee_erc20() {
         ),
     }
 
-    let error = taker_coin
-        .watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
-            taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
-            sender_pubkey: taker_pubkey.to_vec(),
-            min_block_number: 0,
-            fee_addr: taker_pubkey.to_vec(),
-            lock_duration,
-        })
-        .wait()
-        .unwrap_err()
-        .into_inner();
+    let error = block_on_f01(taker_coin.watcher_validate_taker_fee(WatcherValidateTakerFeeInput {
+        taker_fee_hash: taker_fee.tx_hash_as_bytes().into_vec(),
+        sender_pubkey: taker_pubkey.to_vec(),
+        min_block_number: 0,
+        fee_addr: taker_pubkey.to_vec(),
+        lock_duration,
+    }))
+    .unwrap_err()
+    .into_inner();
     log!("error: {:?}", error);
     match error {
         ValidatePaymentError::WrongPaymentTx(err) => {
@@ -1552,21 +1519,19 @@ fn test_watcher_validate_taker_payment_utxo() {
 
     let secret_hash = dhash160(&generate_secret().unwrap());
 
-    let taker_payment = taker_coin
-        .send_taker_payment(SendPaymentArgs {
-            time_lock_duration,
-            time_lock,
-            other_pubkey: maker_pubkey,
-            secret_hash: secret_hash.as_slice(),
-            amount: BigDecimal::from(10),
-            swap_contract_address: &None,
-            swap_unique_data: &[],
-            payment_instructions: &None,
-            watcher_reward: None,
-            wait_for_confirmation_until,
-        })
-        .wait()
-        .unwrap();
+    let taker_payment = block_on_f01(taker_coin.send_taker_payment(SendPaymentArgs {
+        time_lock_duration,
+        time_lock,
+        other_pubkey: maker_pubkey,
+        secret_hash: secret_hash.as_slice(),
+        amount: BigDecimal::from(10),
+        swap_contract_address: &None,
+        swap_unique_data: &[],
+        payment_instructions: &None,
+        watcher_reward: None,
+        wait_for_confirmation_until,
+    }))
+    .unwrap();
 
     let confirm_payment_input = ConfirmPaymentInput {
         payment_tx: taker_payment.tx_hex(),
@@ -1575,21 +1540,19 @@ fn test_watcher_validate_taker_payment_utxo() {
         wait_until: timeout,
         check_every: 1,
     };
-    taker_coin.wait_for_confirmations(confirm_payment_input).wait().unwrap();
+    block_on_f01(taker_coin.wait_for_confirmations(confirm_payment_input)).unwrap();
 
-    let taker_payment_refund_preimage = taker_coin
-        .create_taker_payment_refund_preimage(
-            &taker_payment.tx_hex(),
-            time_lock,
-            maker_pubkey,
-            secret_hash.as_slice(),
-            &None,
-            &[],
-        )
-        .wait()
-        .unwrap();
-    let validate_taker_payment_res = taker_coin
-        .watcher_validate_taker_payment(WatcherValidatePaymentInput {
+    let taker_payment_refund_preimage = block_on_f01(taker_coin.create_taker_payment_refund_preimage(
+        &taker_payment.tx_hex(),
+        time_lock,
+        maker_pubkey,
+        secret_hash.as_slice(),
+        &None,
+        &[],
+    ))
+    .unwrap();
+    let validate_taker_payment_res =
+        block_on_f01(taker_coin.watcher_validate_taker_payment(WatcherValidatePaymentInput {
             payment_tx: taker_payment.tx_hex(),
             taker_payment_refund_preimage: taker_payment_refund_preimage.tx_hex(),
             time_lock,
@@ -1599,25 +1562,22 @@ fn test_watcher_validate_taker_payment_utxo() {
             wait_until: timeout,
             confirmations: 1,
             maker_coin: MmCoinEnum::UtxoCoin(maker_coin.clone()),
-        })
-        .wait();
+        }));
     assert!(validate_taker_payment_res.is_ok());
 
-    let error = taker_coin
-        .watcher_validate_taker_payment(WatcherValidatePaymentInput {
-            payment_tx: taker_payment.tx_hex(),
-            taker_payment_refund_preimage: taker_payment_refund_preimage.tx_hex(),
-            time_lock,
-            taker_pub: maker_pubkey.to_vec(),
-            maker_pub: maker_pubkey.to_vec(),
-            secret_hash: secret_hash.to_vec(),
-            wait_until: timeout,
-            confirmations: 1,
-            maker_coin: MmCoinEnum::UtxoCoin(maker_coin.clone()),
-        })
-        .wait()
-        .unwrap_err()
-        .into_inner();
+    let error = block_on_f01(taker_coin.watcher_validate_taker_payment(WatcherValidatePaymentInput {
+        payment_tx: taker_payment.tx_hex(),
+        taker_payment_refund_preimage: taker_payment_refund_preimage.tx_hex(),
+        time_lock,
+        taker_pub: maker_pubkey.to_vec(),
+        maker_pub: maker_pubkey.to_vec(),
+        secret_hash: secret_hash.to_vec(),
+        wait_until: timeout,
+        confirmations: 1,
+        maker_coin: MmCoinEnum::UtxoCoin(maker_coin.clone()),
+    }))
+    .unwrap_err()
+    .into_inner();
 
     log!("error: {:?}", error);
     match error {
@@ -1629,21 +1589,19 @@ fn test_watcher_validate_taker_payment_utxo() {
 
     // Used to get wrong swap id
     let wrong_secret_hash = dhash160(&generate_secret().unwrap());
-    let error = taker_coin
-        .watcher_validate_taker_payment(WatcherValidatePaymentInput {
-            payment_tx: taker_payment.tx_hex(),
-            taker_payment_refund_preimage: taker_payment_refund_preimage.tx_hex(),
-            time_lock,
-            taker_pub: taker_pubkey.to_vec(),
-            maker_pub: maker_pubkey.to_vec(),
-            secret_hash: wrong_secret_hash.to_vec(),
-            wait_until: timeout,
-            confirmations: 1,
-            maker_coin: MmCoinEnum::UtxoCoin(maker_coin.clone()),
-        })
-        .wait()
-        .unwrap_err()
-        .into_inner();
+    let error = block_on_f01(taker_coin.watcher_validate_taker_payment(WatcherValidatePaymentInput {
+        payment_tx: taker_payment.tx_hex(),
+        taker_payment_refund_preimage: taker_payment_refund_preimage.tx_hex(),
+        time_lock,
+        taker_pub: taker_pubkey.to_vec(),
+        maker_pub: maker_pubkey.to_vec(),
+        secret_hash: wrong_secret_hash.to_vec(),
+        wait_until: timeout,
+        confirmations: 1,
+        maker_coin: MmCoinEnum::UtxoCoin(maker_coin.clone()),
+    }))
+    .unwrap_err()
+    .into_inner();
 
     log!("error: {:?}", error);
     match error {
@@ -1656,21 +1614,19 @@ fn test_watcher_validate_taker_payment_utxo() {
         ),
     }
 
-    let taker_payment_wrong_secret = taker_coin
-        .send_taker_payment(SendPaymentArgs {
-            time_lock_duration,
-            time_lock,
-            other_pubkey: maker_pubkey,
-            secret_hash: wrong_secret_hash.as_slice(),
-            amount: BigDecimal::from(10),
-            swap_contract_address: &taker_coin.swap_contract_address(),
-            swap_unique_data: &[],
-            payment_instructions: &None,
-            watcher_reward: None,
-            wait_for_confirmation_until,
-        })
-        .wait()
-        .unwrap();
+    let taker_payment_wrong_secret = block_on_f01(taker_coin.send_taker_payment(SendPaymentArgs {
+        time_lock_duration,
+        time_lock,
+        other_pubkey: maker_pubkey,
+        secret_hash: wrong_secret_hash.as_slice(),
+        amount: BigDecimal::from(10),
+        swap_contract_address: &taker_coin.swap_contract_address(),
+        swap_unique_data: &[],
+        payment_instructions: &None,
+        watcher_reward: None,
+        wait_for_confirmation_until,
+    }))
+    .unwrap();
 
     let confirm_payment_input = ConfirmPaymentInput {
         payment_tx: taker_payment_wrong_secret.tx_hex(),
@@ -1679,23 +1635,21 @@ fn test_watcher_validate_taker_payment_utxo() {
         wait_until: timeout,
         check_every: 1,
     };
-    taker_coin.wait_for_confirmations(confirm_payment_input).wait().unwrap();
+    block_on_f01(taker_coin.wait_for_confirmations(confirm_payment_input)).unwrap();
 
-    let error = taker_coin
-        .watcher_validate_taker_payment(WatcherValidatePaymentInput {
-            payment_tx: taker_payment.tx_hex(),
-            taker_payment_refund_preimage: taker_payment_refund_preimage.tx_hex(),
-            time_lock: 500,
-            taker_pub: taker_pubkey.to_vec(),
-            maker_pub: maker_pubkey.to_vec(),
-            secret_hash: wrong_secret_hash.to_vec(),
-            wait_until: timeout,
-            confirmations: 1,
-            maker_coin: MmCoinEnum::UtxoCoin(maker_coin.clone()),
-        })
-        .wait()
-        .unwrap_err()
-        .into_inner();
+    let error = block_on_f01(taker_coin.watcher_validate_taker_payment(WatcherValidatePaymentInput {
+        payment_tx: taker_payment.tx_hex(),
+        taker_payment_refund_preimage: taker_payment_refund_preimage.tx_hex(),
+        time_lock: 500,
+        taker_pub: taker_pubkey.to_vec(),
+        maker_pub: maker_pubkey.to_vec(),
+        secret_hash: wrong_secret_hash.to_vec(),
+        wait_until: timeout,
+        confirmations: 1,
+        maker_coin: MmCoinEnum::UtxoCoin(maker_coin.clone()),
+    }))
+    .unwrap_err()
+    .into_inner();
 
     log!("error: {:?}", error);
     match error {
@@ -1708,33 +1662,29 @@ fn test_watcher_validate_taker_payment_utxo() {
         ),
     }
 
-    let wrong_taker_payment_refund_preimage = taker_coin
-        .create_taker_payment_refund_preimage(
-            &taker_payment.tx_hex(),
-            time_lock,
-            maker_pubkey,
-            wrong_secret_hash.as_slice(),
-            &None,
-            &[],
-        )
-        .wait()
-        .unwrap();
+    let wrong_taker_payment_refund_preimage = block_on_f01(taker_coin.create_taker_payment_refund_preimage(
+        &taker_payment.tx_hex(),
+        time_lock,
+        maker_pubkey,
+        wrong_secret_hash.as_slice(),
+        &None,
+        &[],
+    ))
+    .unwrap();
 
-    let error = taker_coin
-        .watcher_validate_taker_payment(WatcherValidatePaymentInput {
-            payment_tx: taker_payment.tx_hex(),
-            taker_payment_refund_preimage: wrong_taker_payment_refund_preimage.tx_hex(),
-            time_lock,
-            taker_pub: taker_pubkey.to_vec(),
-            maker_pub: maker_pubkey.to_vec(),
-            secret_hash: secret_hash.to_vec(),
-            wait_until: timeout,
-            confirmations: 1,
-            maker_coin: MmCoinEnum::UtxoCoin(maker_coin.clone()),
-        })
-        .wait()
-        .unwrap_err()
-        .into_inner();
+    let error = block_on_f01(taker_coin.watcher_validate_taker_payment(WatcherValidatePaymentInput {
+        payment_tx: taker_payment.tx_hex(),
+        taker_payment_refund_preimage: wrong_taker_payment_refund_preimage.tx_hex(),
+        time_lock,
+        taker_pub: taker_pubkey.to_vec(),
+        maker_pub: maker_pubkey.to_vec(),
+        secret_hash: secret_hash.to_vec(),
+        wait_until: timeout,
+        confirmations: 1,
+        maker_coin: MmCoinEnum::UtxoCoin(maker_coin.clone()),
+    }))
+    .unwrap_err()
+    .into_inner();
 
     log!("error: {:?}", error);
     match error {
@@ -1777,21 +1727,19 @@ fn test_watcher_validate_taker_payment_eth() {
         .unwrap(),
     );
 
-    let taker_payment = taker_coin
-        .send_taker_payment(SendPaymentArgs {
-            time_lock_duration,
-            time_lock,
-            other_pubkey: maker_pub,
-            secret_hash: secret_hash.as_slice(),
-            amount: taker_amount.clone(),
-            swap_contract_address: &taker_coin.swap_contract_address(),
-            swap_unique_data: &[],
-            payment_instructions: &None,
-            watcher_reward: watcher_reward.clone(),
-            wait_for_confirmation_until,
-        })
-        .wait()
-        .unwrap();
+    let taker_payment = block_on_f01(taker_coin.send_taker_payment(SendPaymentArgs {
+        time_lock_duration,
+        time_lock,
+        other_pubkey: maker_pub,
+        secret_hash: secret_hash.as_slice(),
+        amount: taker_amount.clone(),
+        swap_contract_address: &taker_coin.swap_contract_address(),
+        swap_unique_data: &[],
+        payment_instructions: &None,
+        watcher_reward: watcher_reward.clone(),
+        wait_for_confirmation_until,
+    }))
+    .unwrap();
 
     let confirm_payment_input = ConfirmPaymentInput {
         payment_tx: taker_payment.tx_hex(),
@@ -1800,10 +1748,10 @@ fn test_watcher_validate_taker_payment_eth() {
         wait_until: timeout,
         check_every: 1,
     };
-    taker_coin.wait_for_confirmations(confirm_payment_input).wait().unwrap();
+    block_on_f01(taker_coin.wait_for_confirmations(confirm_payment_input)).unwrap();
 
-    let validate_taker_payment_res = taker_coin
-        .watcher_validate_taker_payment(coins::WatcherValidatePaymentInput {
+    let validate_taker_payment_res = block_on_f01(taker_coin.watcher_validate_taker_payment(
+        coins::WatcherValidatePaymentInput {
             payment_tx: taker_payment.tx_hex(),
             taker_payment_refund_preimage: Vec::new(),
             time_lock,
@@ -1813,12 +1761,12 @@ fn test_watcher_validate_taker_payment_eth() {
             wait_until: timeout,
             confirmations: 1,
             maker_coin: MmCoinEnum::EthCoin(taker_coin.clone()),
-        })
-        .wait();
+        },
+    ));
     assert!(validate_taker_payment_res.is_ok());
 
-    let error = taker_coin
-        .watcher_validate_taker_payment(coins::WatcherValidatePaymentInput {
+    let error = block_on_f01(
+        taker_coin.watcher_validate_taker_payment(coins::WatcherValidatePaymentInput {
             payment_tx: taker_payment.tx_hex(),
             taker_payment_refund_preimage: Vec::new(),
             time_lock,
@@ -1828,10 +1776,10 @@ fn test_watcher_validate_taker_payment_eth() {
             wait_until: timeout,
             confirmations: 1,
             maker_coin: MmCoinEnum::EthCoin(taker_coin.clone()),
-        })
-        .wait()
-        .unwrap_err()
-        .into_inner();
+        }),
+    )
+    .unwrap_err()
+    .into_inner();
     log!("error: {:?}", error);
     match error {
         ValidatePaymentError::WrongPaymentTx(err) => {
@@ -1843,24 +1791,22 @@ fn test_watcher_validate_taker_payment_eth() {
         ),
     }
 
-    let taker_payment_wrong_contract = taker_coin
-        .send_taker_payment(SendPaymentArgs {
-            time_lock_duration,
-            time_lock,
-            other_pubkey: maker_pub,
-            secret_hash: secret_hash.as_slice(),
-            amount: taker_amount.clone(),
-            swap_contract_address: &Some("9130b257d37a52e52f21054c4da3450c72f595ce".into()),
-            swap_unique_data: &[],
-            payment_instructions: &None,
-            watcher_reward: watcher_reward.clone(),
-            wait_for_confirmation_until,
-        })
-        .wait()
-        .unwrap();
+    let taker_payment_wrong_contract = block_on_f01(taker_coin.send_taker_payment(SendPaymentArgs {
+        time_lock_duration,
+        time_lock,
+        other_pubkey: maker_pub,
+        secret_hash: secret_hash.as_slice(),
+        amount: taker_amount.clone(),
+        swap_contract_address: &Some("9130b257d37a52e52f21054c4da3450c72f595ce".into()),
+        swap_unique_data: &[],
+        payment_instructions: &None,
+        watcher_reward: watcher_reward.clone(),
+        wait_for_confirmation_until,
+    }))
+    .unwrap();
 
-    let error = taker_coin
-        .watcher_validate_taker_payment(coins::WatcherValidatePaymentInput {
+    let error = block_on_f01(
+        taker_coin.watcher_validate_taker_payment(coins::WatcherValidatePaymentInput {
             payment_tx: taker_payment_wrong_contract.tx_hex(),
             taker_payment_refund_preimage: Vec::new(),
             time_lock,
@@ -1870,10 +1816,10 @@ fn test_watcher_validate_taker_payment_eth() {
             wait_until: timeout,
             confirmations: 1,
             maker_coin: MmCoinEnum::EthCoin(taker_coin.clone()),
-        })
-        .wait()
-        .unwrap_err()
-        .into_inner();
+        }),
+    )
+    .unwrap_err()
+    .into_inner();
     log!("error: {:?}", error);
     match error {
         ValidatePaymentError::WrongPaymentTx(err) => {
@@ -1887,8 +1833,8 @@ fn test_watcher_validate_taker_payment_eth() {
 
     // Used to get wrong swap id
     let wrong_secret_hash = dhash160(&generate_secret().unwrap());
-    let error = taker_coin
-        .watcher_validate_taker_payment(coins::WatcherValidatePaymentInput {
+    let error = block_on_f01(
+        taker_coin.watcher_validate_taker_payment(coins::WatcherValidatePaymentInput {
             payment_tx: taker_payment.tx_hex(),
             taker_payment_refund_preimage: Vec::new(),
             time_lock,
@@ -1898,10 +1844,10 @@ fn test_watcher_validate_taker_payment_eth() {
             wait_until: timeout,
             confirmations: 1,
             maker_coin: MmCoinEnum::EthCoin(taker_coin.clone()),
-        })
-        .wait()
-        .unwrap_err()
-        .into_inner();
+        }),
+    )
+    .unwrap_err()
+    .into_inner();
     log!("error: {:?}", error);
     match error {
         ValidatePaymentError::UnexpectedPaymentState(err) => {
@@ -1913,21 +1859,19 @@ fn test_watcher_validate_taker_payment_eth() {
         ),
     }
 
-    let taker_payment_wrong_secret = taker_coin
-        .send_taker_payment(SendPaymentArgs {
-            time_lock_duration,
-            time_lock,
-            other_pubkey: maker_pub,
-            secret_hash: wrong_secret_hash.as_slice(),
-            amount: taker_amount,
-            swap_contract_address: &taker_coin.swap_contract_address(),
-            swap_unique_data: &[],
-            payment_instructions: &None,
-            watcher_reward,
-            wait_for_confirmation_until,
-        })
-        .wait()
-        .unwrap();
+    let taker_payment_wrong_secret = block_on_f01(taker_coin.send_taker_payment(SendPaymentArgs {
+        time_lock_duration,
+        time_lock,
+        other_pubkey: maker_pub,
+        secret_hash: wrong_secret_hash.as_slice(),
+        amount: taker_amount,
+        swap_contract_address: &taker_coin.swap_contract_address(),
+        swap_unique_data: &[],
+        payment_instructions: &None,
+        watcher_reward,
+        wait_for_confirmation_until,
+    }))
+    .unwrap();
 
     let confirm_payment_input = ConfirmPaymentInput {
         payment_tx: taker_payment_wrong_secret.tx_hex(),
@@ -1936,23 +1880,21 @@ fn test_watcher_validate_taker_payment_eth() {
         wait_until: timeout,
         check_every: 1,
     };
-    taker_coin.wait_for_confirmations(confirm_payment_input).wait().unwrap();
+    block_on_f01(taker_coin.wait_for_confirmations(confirm_payment_input)).unwrap();
 
-    let error = taker_coin
-        .watcher_validate_taker_payment(WatcherValidatePaymentInput {
-            payment_tx: taker_payment.tx_hex(),
-            taker_payment_refund_preimage: Vec::new(),
-            time_lock,
-            taker_pub: taker_pub.to_vec(),
-            maker_pub: maker_pub.to_vec(),
-            secret_hash: wrong_secret_hash.to_vec(),
-            wait_until: timeout,
-            confirmations: 1,
-            maker_coin: MmCoinEnum::EthCoin(taker_coin.clone()),
-        })
-        .wait()
-        .unwrap_err()
-        .into_inner();
+    let error = block_on_f01(taker_coin.watcher_validate_taker_payment(WatcherValidatePaymentInput {
+        payment_tx: taker_payment.tx_hex(),
+        taker_payment_refund_preimage: Vec::new(),
+        time_lock,
+        taker_pub: taker_pub.to_vec(),
+        maker_pub: maker_pub.to_vec(),
+        secret_hash: wrong_secret_hash.to_vec(),
+        wait_until: timeout,
+        confirmations: 1,
+        maker_coin: MmCoinEnum::EthCoin(taker_coin.clone()),
+    }))
+    .unwrap_err()
+    .into_inner();
     log!("error: {:?}", error);
     match error {
         ValidatePaymentError::WrongPaymentTx(err) => {
@@ -1964,21 +1906,19 @@ fn test_watcher_validate_taker_payment_eth() {
         ),
     }
 
-    let error = taker_coin
-        .watcher_validate_taker_payment(WatcherValidatePaymentInput {
-            payment_tx: taker_payment.tx_hex(),
-            taker_payment_refund_preimage: Vec::new(),
-            time_lock,
-            taker_pub: taker_pub.to_vec(),
-            maker_pub: taker_pub.to_vec(),
-            secret_hash: secret_hash.to_vec(),
-            wait_until: timeout,
-            confirmations: 1,
-            maker_coin: MmCoinEnum::EthCoin(taker_coin.clone()),
-        })
-        .wait()
-        .unwrap_err()
-        .into_inner();
+    let error = block_on_f01(taker_coin.watcher_validate_taker_payment(WatcherValidatePaymentInput {
+        payment_tx: taker_payment.tx_hex(),
+        taker_payment_refund_preimage: Vec::new(),
+        time_lock,
+        taker_pub: taker_pub.to_vec(),
+        maker_pub: taker_pub.to_vec(),
+        secret_hash: secret_hash.to_vec(),
+        wait_until: timeout,
+        confirmations: 1,
+        maker_coin: MmCoinEnum::EthCoin(taker_coin.clone()),
+    }))
+    .unwrap_err()
+    .into_inner();
     log!("error: {:?}", error);
     match error {
         ValidatePaymentError::WrongPaymentTx(err) => {
@@ -2023,21 +1963,19 @@ fn test_watcher_validate_taker_payment_erc20() {
         .unwrap(),
     );
 
-    let taker_payment = taker_coin
-        .send_taker_payment(SendPaymentArgs {
-            time_lock_duration,
-            time_lock,
-            other_pubkey: maker_pub,
-            secret_hash: secret_hash.as_slice(),
-            amount: taker_amount.clone(),
-            swap_contract_address: &taker_coin.swap_contract_address(),
-            swap_unique_data: &[],
-            payment_instructions: &None,
-            watcher_reward: watcher_reward.clone(),
-            wait_for_confirmation_until,
-        })
-        .wait()
-        .unwrap();
+    let taker_payment = block_on_f01(taker_coin.send_taker_payment(SendPaymentArgs {
+        time_lock_duration,
+        time_lock,
+        other_pubkey: maker_pub,
+        secret_hash: secret_hash.as_slice(),
+        amount: taker_amount.clone(),
+        swap_contract_address: &taker_coin.swap_contract_address(),
+        swap_unique_data: &[],
+        payment_instructions: &None,
+        watcher_reward: watcher_reward.clone(),
+        wait_for_confirmation_until,
+    }))
+    .unwrap();
 
     let confirm_payment_input = ConfirmPaymentInput {
         payment_tx: taker_payment.tx_hex(),
@@ -2046,10 +1984,10 @@ fn test_watcher_validate_taker_payment_erc20() {
         wait_until: timeout,
         check_every: 1,
     };
-    taker_coin.wait_for_confirmations(confirm_payment_input).wait().unwrap();
+    block_on_f01(taker_coin.wait_for_confirmations(confirm_payment_input)).unwrap();
 
-    let validate_taker_payment_res = taker_coin
-        .watcher_validate_taker_payment(WatcherValidatePaymentInput {
+    let validate_taker_payment_res =
+        block_on_f01(taker_coin.watcher_validate_taker_payment(WatcherValidatePaymentInput {
             payment_tx: taker_payment.tx_hex(),
             taker_payment_refund_preimage: Vec::new(),
             time_lock,
@@ -2059,25 +1997,22 @@ fn test_watcher_validate_taker_payment_erc20() {
             wait_until: timeout,
             confirmations: 1,
             maker_coin: MmCoinEnum::EthCoin(taker_coin.clone()),
-        })
-        .wait();
+        }));
     assert!(validate_taker_payment_res.is_ok());
 
-    let error = taker_coin
-        .watcher_validate_taker_payment(WatcherValidatePaymentInput {
-            payment_tx: taker_payment.tx_hex(),
-            taker_payment_refund_preimage: Vec::new(),
-            time_lock,
-            taker_pub: maker_pub.to_vec(),
-            maker_pub: maker_pub.to_vec(),
-            secret_hash: secret_hash.to_vec(),
-            wait_until: timeout,
-            confirmations: 1,
-            maker_coin: MmCoinEnum::EthCoin(taker_coin.clone()),
-        })
-        .wait()
-        .unwrap_err()
-        .into_inner();
+    let error = block_on_f01(taker_coin.watcher_validate_taker_payment(WatcherValidatePaymentInput {
+        payment_tx: taker_payment.tx_hex(),
+        taker_payment_refund_preimage: Vec::new(),
+        time_lock,
+        taker_pub: maker_pub.to_vec(),
+        maker_pub: maker_pub.to_vec(),
+        secret_hash: secret_hash.to_vec(),
+        wait_until: timeout,
+        confirmations: 1,
+        maker_coin: MmCoinEnum::EthCoin(taker_coin.clone()),
+    }))
+    .unwrap_err()
+    .into_inner();
     log!("error: {:?}", error);
     match error {
         ValidatePaymentError::WrongPaymentTx(err) => {
@@ -2089,37 +2024,33 @@ fn test_watcher_validate_taker_payment_erc20() {
         ),
     }
 
-    let taker_payment_wrong_contract = taker_coin
-        .send_taker_payment(SendPaymentArgs {
-            time_lock_duration,
-            time_lock,
-            other_pubkey: maker_pub,
-            secret_hash: secret_hash.as_slice(),
-            amount: taker_amount.clone(),
-            swap_contract_address: &Some("9130b257d37a52e52f21054c4da3450c72f595ce".into()),
-            swap_unique_data: &[],
-            payment_instructions: &None,
-            watcher_reward: watcher_reward.clone(),
-            wait_for_confirmation_until,
-        })
-        .wait()
-        .unwrap();
+    let taker_payment_wrong_contract = block_on_f01(taker_coin.send_taker_payment(SendPaymentArgs {
+        time_lock_duration,
+        time_lock,
+        other_pubkey: maker_pub,
+        secret_hash: secret_hash.as_slice(),
+        amount: taker_amount.clone(),
+        swap_contract_address: &Some("9130b257d37a52e52f21054c4da3450c72f595ce".into()),
+        swap_unique_data: &[],
+        payment_instructions: &None,
+        watcher_reward: watcher_reward.clone(),
+        wait_for_confirmation_until,
+    }))
+    .unwrap();
 
-    let error = taker_coin
-        .watcher_validate_taker_payment(WatcherValidatePaymentInput {
-            payment_tx: taker_payment_wrong_contract.tx_hex(),
-            taker_payment_refund_preimage: Vec::new(),
-            time_lock,
-            taker_pub: taker_pub.to_vec(),
-            maker_pub: maker_pub.to_vec(),
-            secret_hash: secret_hash.to_vec(),
-            wait_until: timeout,
-            confirmations: 1,
-            maker_coin: MmCoinEnum::EthCoin(taker_coin.clone()),
-        })
-        .wait()
-        .unwrap_err()
-        .into_inner();
+    let error = block_on_f01(taker_coin.watcher_validate_taker_payment(WatcherValidatePaymentInput {
+        payment_tx: taker_payment_wrong_contract.tx_hex(),
+        taker_payment_refund_preimage: Vec::new(),
+        time_lock,
+        taker_pub: taker_pub.to_vec(),
+        maker_pub: maker_pub.to_vec(),
+        secret_hash: secret_hash.to_vec(),
+        wait_until: timeout,
+        confirmations: 1,
+        maker_coin: MmCoinEnum::EthCoin(taker_coin.clone()),
+    }))
+    .unwrap_err()
+    .into_inner();
     log!("error: {:?}", error);
     match error {
         ValidatePaymentError::WrongPaymentTx(err) => {
@@ -2133,21 +2064,19 @@ fn test_watcher_validate_taker_payment_erc20() {
 
     // Used to get wrong swap id
     let wrong_secret_hash = dhash160(&generate_secret().unwrap());
-    let error = taker_coin
-        .watcher_validate_taker_payment(WatcherValidatePaymentInput {
-            payment_tx: taker_payment.tx_hex(),
-            taker_payment_refund_preimage: Vec::new(),
-            time_lock,
-            taker_pub: taker_pub.to_vec(),
-            maker_pub: maker_pub.to_vec(),
-            secret_hash: wrong_secret_hash.to_vec(),
-            wait_until: timeout,
-            confirmations: 1,
-            maker_coin: MmCoinEnum::EthCoin(taker_coin.clone()),
-        })
-        .wait()
-        .unwrap_err()
-        .into_inner();
+    let error = block_on_f01(taker_coin.watcher_validate_taker_payment(WatcherValidatePaymentInput {
+        payment_tx: taker_payment.tx_hex(),
+        taker_payment_refund_preimage: Vec::new(),
+        time_lock,
+        taker_pub: taker_pub.to_vec(),
+        maker_pub: maker_pub.to_vec(),
+        secret_hash: wrong_secret_hash.to_vec(),
+        wait_until: timeout,
+        confirmations: 1,
+        maker_coin: MmCoinEnum::EthCoin(taker_coin.clone()),
+    }))
+    .unwrap_err()
+    .into_inner();
     log!("error: {:?}", error);
     match error {
         ValidatePaymentError::UnexpectedPaymentState(err) => {
@@ -2159,21 +2088,19 @@ fn test_watcher_validate_taker_payment_erc20() {
         ),
     }
 
-    let taker_payment_wrong_secret = taker_coin
-        .send_taker_payment(SendPaymentArgs {
-            time_lock_duration,
-            time_lock,
-            other_pubkey: maker_pub,
-            secret_hash: wrong_secret_hash.as_slice(),
-            amount: taker_amount,
-            swap_contract_address: &taker_coin.swap_contract_address(),
-            swap_unique_data: &[],
-            payment_instructions: &None,
-            watcher_reward,
-            wait_for_confirmation_until,
-        })
-        .wait()
-        .unwrap();
+    let taker_payment_wrong_secret = block_on_f01(taker_coin.send_taker_payment(SendPaymentArgs {
+        time_lock_duration,
+        time_lock,
+        other_pubkey: maker_pub,
+        secret_hash: wrong_secret_hash.as_slice(),
+        amount: taker_amount,
+        swap_contract_address: &taker_coin.swap_contract_address(),
+        swap_unique_data: &[],
+        payment_instructions: &None,
+        watcher_reward,
+        wait_for_confirmation_until,
+    }))
+    .unwrap();
 
     let confirm_payment_input = ConfirmPaymentInput {
         payment_tx: taker_payment_wrong_secret.tx_hex(),
@@ -2182,23 +2109,21 @@ fn test_watcher_validate_taker_payment_erc20() {
         wait_until: timeout,
         check_every: 1,
     };
-    taker_coin.wait_for_confirmations(confirm_payment_input).wait().unwrap();
+    block_on_f01(taker_coin.wait_for_confirmations(confirm_payment_input)).unwrap();
 
-    let error = taker_coin
-        .watcher_validate_taker_payment(WatcherValidatePaymentInput {
-            payment_tx: taker_payment.tx_hex(),
-            taker_payment_refund_preimage: Vec::new(),
-            time_lock,
-            taker_pub: taker_pub.to_vec(),
-            maker_pub: maker_pub.to_vec(),
-            secret_hash: wrong_secret_hash.to_vec(),
-            wait_until: timeout,
-            confirmations: 1,
-            maker_coin: MmCoinEnum::EthCoin(taker_coin.clone()),
-        })
-        .wait()
-        .unwrap_err()
-        .into_inner();
+    let error = block_on_f01(taker_coin.watcher_validate_taker_payment(WatcherValidatePaymentInput {
+        payment_tx: taker_payment.tx_hex(),
+        taker_payment_refund_preimage: Vec::new(),
+        time_lock,
+        taker_pub: taker_pub.to_vec(),
+        maker_pub: maker_pub.to_vec(),
+        secret_hash: wrong_secret_hash.to_vec(),
+        wait_until: timeout,
+        confirmations: 1,
+        maker_coin: MmCoinEnum::EthCoin(taker_coin.clone()),
+    }))
+    .unwrap_err()
+    .into_inner();
     log!("error: {:?}", error);
     match error {
         ValidatePaymentError::WrongPaymentTx(err) => {
@@ -2210,21 +2135,19 @@ fn test_watcher_validate_taker_payment_erc20() {
         ),
     }
 
-    let error = taker_coin
-        .watcher_validate_taker_payment(WatcherValidatePaymentInput {
-            payment_tx: taker_payment.tx_hex(),
-            taker_payment_refund_preimage: Vec::new(),
-            time_lock,
-            taker_pub: taker_pub.to_vec(),
-            maker_pub: taker_pub.to_vec(),
-            secret_hash: secret_hash.to_vec(),
-            wait_until: timeout,
-            confirmations: 1,
-            maker_coin: MmCoinEnum::EthCoin(taker_coin.clone()),
-        })
-        .wait()
-        .unwrap_err()
-        .into_inner();
+    let error = block_on_f01(taker_coin.watcher_validate_taker_payment(WatcherValidatePaymentInput {
+        payment_tx: taker_payment.tx_hex(),
+        taker_payment_refund_preimage: Vec::new(),
+        time_lock,
+        taker_pub: taker_pub.to_vec(),
+        maker_pub: taker_pub.to_vec(),
+        secret_hash: secret_hash.to_vec(),
+        wait_until: timeout,
+        confirmations: 1,
+        maker_coin: MmCoinEnum::EthCoin(taker_coin.clone()),
+    }))
+    .unwrap_err()
+    .into_inner();
     log!("error: {:?}", error);
     match error {
         ValidatePaymentError::WrongPaymentTx(err) => {
@@ -2250,21 +2173,19 @@ fn test_taker_validates_taker_payment_refund_utxo() {
 
     let secret_hash = dhash160(&generate_secret().unwrap());
 
-    let taker_payment = taker_coin
-        .send_taker_payment(SendPaymentArgs {
-            time_lock_duration,
-            time_lock,
-            other_pubkey: maker_pubkey,
-            secret_hash: secret_hash.as_slice(),
-            amount: BigDecimal::from(10),
-            swap_contract_address: &None,
-            swap_unique_data: &[],
-            payment_instructions: &None,
-            watcher_reward: None,
-            wait_for_confirmation_until,
-        })
-        .wait()
-        .unwrap();
+    let taker_payment = block_on_f01(taker_coin.send_taker_payment(SendPaymentArgs {
+        time_lock_duration,
+        time_lock,
+        other_pubkey: maker_pubkey,
+        secret_hash: secret_hash.as_slice(),
+        amount: BigDecimal::from(10),
+        swap_contract_address: &None,
+        swap_unique_data: &[],
+        payment_instructions: &None,
+        watcher_reward: None,
+        wait_for_confirmation_until,
+    }))
+    .unwrap();
 
     let confirm_payment_input = ConfirmPaymentInput {
         payment_tx: taker_payment.tx_hex(),
@@ -2273,34 +2194,30 @@ fn test_taker_validates_taker_payment_refund_utxo() {
         wait_until: timeout,
         check_every: 1,
     };
-    taker_coin.wait_for_confirmations(confirm_payment_input).wait().unwrap();
+    block_on_f01(taker_coin.wait_for_confirmations(confirm_payment_input)).unwrap();
 
-    let taker_payment_refund_preimage = taker_coin
-        .create_taker_payment_refund_preimage(
-            &taker_payment.tx_hex(),
-            time_lock,
-            maker_pubkey,
-            secret_hash.as_slice(),
-            &None,
-            &[],
-        )
-        .wait()
-        .unwrap();
+    let taker_payment_refund_preimage = block_on_f01(taker_coin.create_taker_payment_refund_preimage(
+        &taker_payment.tx_hex(),
+        time_lock,
+        maker_pubkey,
+        secret_hash.as_slice(),
+        &None,
+        &[],
+    ))
+    .unwrap();
 
-    let taker_payment_refund = taker_coin
-        .send_taker_payment_refund_preimage(RefundPaymentArgs {
-            payment_tx: &taker_payment_refund_preimage.tx_hex(),
-            other_pubkey: maker_pubkey,
-            tx_type_with_secret_hash: SwapTxTypeWithSecretHash::TakerOrMakerPayment {
-                maker_secret_hash: secret_hash.as_slice(),
-            },
-            time_lock,
-            swap_contract_address: &None,
-            swap_unique_data: &[],
-            watcher_reward: false,
-        })
-        .wait()
-        .unwrap();
+    let taker_payment_refund = block_on_f01(taker_coin.send_taker_payment_refund_preimage(RefundPaymentArgs {
+        payment_tx: &taker_payment_refund_preimage.tx_hex(),
+        other_pubkey: maker_pubkey,
+        tx_type_with_secret_hash: SwapTxTypeWithSecretHash::TakerOrMakerPayment {
+            maker_secret_hash: secret_hash.as_slice(),
+        },
+        time_lock,
+        swap_contract_address: &None,
+        swap_unique_data: &[],
+        watcher_reward: false,
+    }))
+    .unwrap();
 
     let validate_input = ValidateWatcherSpendInput {
         payment_tx: taker_payment_refund.tx_hex(),
@@ -2313,9 +2230,7 @@ fn test_taker_validates_taker_payment_refund_utxo() {
         spend_type: WatcherSpendType::TakerPaymentRefund,
     };
 
-    let validate_watcher_refund = taker_coin
-        .taker_validates_payment_spend_or_refund(validate_input)
-        .wait();
+    let validate_watcher_refund = block_on_f01(taker_coin.taker_validates_payment_spend_or_refund(validate_input));
     assert!(validate_watcher_refund.is_ok());
 }
 
@@ -2347,21 +2262,19 @@ fn test_taker_validates_taker_payment_refund_eth() {
     ))
     .unwrap();
 
-    let taker_payment = taker_coin
-        .send_taker_payment(SendPaymentArgs {
-            time_lock_duration,
-            time_lock,
-            other_pubkey: maker_pub,
-            secret_hash: secret_hash.as_slice(),
-            amount: taker_amount.clone(),
-            swap_contract_address: &taker_coin.swap_contract_address(),
-            swap_unique_data: &[],
-            payment_instructions: &None,
-            watcher_reward: Some(watcher_reward.clone()),
-            wait_for_confirmation_until,
-        })
-        .wait()
-        .unwrap();
+    let taker_payment = block_on_f01(taker_coin.send_taker_payment(SendPaymentArgs {
+        time_lock_duration,
+        time_lock,
+        other_pubkey: maker_pub,
+        secret_hash: secret_hash.as_slice(),
+        amount: taker_amount.clone(),
+        swap_contract_address: &taker_coin.swap_contract_address(),
+        swap_unique_data: &[],
+        payment_instructions: &None,
+        watcher_reward: Some(watcher_reward.clone()),
+        wait_for_confirmation_until,
+    }))
+    .unwrap();
 
     let confirm_payment_input = ConfirmPaymentInput {
         payment_tx: taker_payment.tx_hex(),
@@ -2370,19 +2283,17 @@ fn test_taker_validates_taker_payment_refund_eth() {
         wait_until: timeout,
         check_every: 1,
     };
-    taker_coin.wait_for_confirmations(confirm_payment_input).wait().unwrap();
+    block_on_f01(taker_coin.wait_for_confirmations(confirm_payment_input)).unwrap();
 
-    let taker_payment_refund_preimage = taker_coin
-        .create_taker_payment_refund_preimage(
-            &taker_payment.tx_hex(),
-            time_lock,
-            taker_pub,
-            secret_hash.as_slice(),
-            &taker_coin.swap_contract_address(),
-            &[],
-        )
-        .wait()
-        .unwrap();
+    let taker_payment_refund_preimage = block_on_f01(taker_coin.create_taker_payment_refund_preimage(
+        &taker_payment.tx_hex(),
+        time_lock,
+        taker_pub,
+        secret_hash.as_slice(),
+        &taker_coin.swap_contract_address(),
+        &[],
+    ))
+    .unwrap();
 
     let validate_input = ValidateWatcherSpendInput {
         payment_tx: taker_payment_refund_preimage.tx_hex(),
@@ -2395,9 +2306,7 @@ fn test_taker_validates_taker_payment_refund_eth() {
         spend_type: WatcherSpendType::TakerPaymentRefund,
     };
 
-    let error = taker_coin
-        .taker_validates_payment_spend_or_refund(validate_input)
-        .wait()
+    let error = block_on_f01(taker_coin.taker_validates_payment_spend_or_refund(validate_input))
         .unwrap_err()
         .into_inner();
     log!("error: {:?}", error);
@@ -2411,20 +2320,18 @@ fn test_taker_validates_taker_payment_refund_eth() {
         ),
     }
 
-    let taker_payment_refund = taker_coin
-        .send_taker_payment_refund_preimage(RefundPaymentArgs {
-            payment_tx: &taker_payment_refund_preimage.tx_hex(),
-            other_pubkey: taker_pub,
-            tx_type_with_secret_hash: SwapTxTypeWithSecretHash::TakerOrMakerPayment {
-                maker_secret_hash: secret_hash.as_slice(),
-            },
-            time_lock,
-            swap_contract_address: &taker_coin.swap_contract_address(),
-            swap_unique_data: &[],
-            watcher_reward: true,
-        })
-        .wait()
-        .unwrap();
+    let taker_payment_refund = block_on_f01(taker_coin.send_taker_payment_refund_preimage(RefundPaymentArgs {
+        payment_tx: &taker_payment_refund_preimage.tx_hex(),
+        other_pubkey: taker_pub,
+        tx_type_with_secret_hash: SwapTxTypeWithSecretHash::TakerOrMakerPayment {
+            maker_secret_hash: secret_hash.as_slice(),
+        },
+        time_lock,
+        swap_contract_address: &taker_coin.swap_contract_address(),
+        swap_unique_data: &[],
+        watcher_reward: true,
+    }))
+    .unwrap();
 
     let validate_input = ValidateWatcherSpendInput {
         payment_tx: taker_payment_refund.tx_hex(),
@@ -2437,9 +2344,7 @@ fn test_taker_validates_taker_payment_refund_eth() {
         spend_type: WatcherSpendType::TakerPaymentRefund,
     };
 
-    let validate_watcher_refund = taker_coin
-        .taker_validates_payment_spend_or_refund(validate_input)
-        .wait();
+    let validate_watcher_refund = block_on_f01(taker_coin.taker_validates_payment_spend_or_refund(validate_input));
     assert!(validate_watcher_refund.is_ok());
 
     let validate_input = ValidateWatcherSpendInput {
@@ -2452,9 +2357,7 @@ fn test_taker_validates_taker_payment_refund_eth() {
         watcher_reward: Some(watcher_reward.clone()),
         spend_type: WatcherSpendType::TakerPaymentRefund,
     };
-    let error = taker_coin
-        .taker_validates_payment_spend_or_refund(validate_input)
-        .wait()
+    let error = block_on_f01(taker_coin.taker_validates_payment_spend_or_refund(validate_input))
         .unwrap_err()
         .into_inner();
     log!("error: {:?}", error);
@@ -2479,9 +2382,7 @@ fn test_taker_validates_taker_payment_refund_eth() {
         spend_type: WatcherSpendType::TakerPaymentRefund,
     };
 
-    let error = maker_coin
-        .taker_validates_payment_spend_or_refund(validate_input)
-        .wait()
+    let error = block_on_f01(maker_coin.taker_validates_payment_spend_or_refund(validate_input))
         .unwrap_err()
         .into_inner();
     log!("error: {:?}", error);
@@ -2506,9 +2407,7 @@ fn test_taker_validates_taker_payment_refund_eth() {
         spend_type: WatcherSpendType::TakerPaymentRefund,
     };
 
-    let error = taker_coin
-        .taker_validates_payment_spend_or_refund(validate_input)
-        .wait()
+    let error = block_on_f01(taker_coin.taker_validates_payment_spend_or_refund(validate_input))
         .unwrap_err()
         .into_inner();
     log!("error: {:?}", error);
@@ -2536,9 +2435,7 @@ fn test_taker_validates_taker_payment_refund_eth() {
         spend_type: WatcherSpendType::TakerPaymentRefund,
     };
 
-    let error = taker_coin
-        .taker_validates_payment_spend_or_refund(validate_input)
-        .wait()
+    let error = block_on_f01(taker_coin.taker_validates_payment_spend_or_refund(validate_input))
         .unwrap_err()
         .into_inner();
     log!("error: {:?}", error);
@@ -2566,9 +2463,7 @@ fn test_taker_validates_taker_payment_refund_eth() {
         spend_type: WatcherSpendType::TakerPaymentRefund,
     };
 
-    let error = taker_coin
-        .taker_validates_payment_spend_or_refund(validate_input)
-        .wait()
+    let error = block_on_f01(taker_coin.taker_validates_payment_spend_or_refund(validate_input))
         .unwrap_err()
         .into_inner();
     log!("error: {:?}", error);
@@ -2596,9 +2491,7 @@ fn test_taker_validates_taker_payment_refund_eth() {
         spend_type: WatcherSpendType::TakerPaymentRefund,
     };
 
-    let error = taker_coin
-        .taker_validates_payment_spend_or_refund(validate_input)
-        .wait()
+    let error = block_on_f01(taker_coin.taker_validates_payment_spend_or_refund(validate_input))
         .unwrap_err()
         .into_inner();
     log!("error: {:?}", error);
@@ -2623,9 +2516,7 @@ fn test_taker_validates_taker_payment_refund_eth() {
         spend_type: WatcherSpendType::TakerPaymentRefund,
     };
 
-    let error = taker_coin
-        .taker_validates_payment_spend_or_refund(validate_input)
-        .wait()
+    let error = block_on_f01(taker_coin.taker_validates_payment_spend_or_refund(validate_input))
         .unwrap_err()
         .into_inner();
     log!("error: {:?}", error);
@@ -2672,21 +2563,19 @@ fn test_taker_validates_taker_payment_refund_erc20() {
         .unwrap(),
     );
 
-    let taker_payment = taker_coin
-        .send_taker_payment(SendPaymentArgs {
-            time_lock_duration,
-            time_lock,
-            other_pubkey: maker_pub,
-            secret_hash: secret_hash.as_slice(),
-            amount: taker_amount.clone(),
-            swap_contract_address: &taker_coin.swap_contract_address(),
-            swap_unique_data: &[],
-            payment_instructions: &None,
-            watcher_reward: watcher_reward.clone(),
-            wait_for_confirmation_until,
-        })
-        .wait()
-        .unwrap();
+    let taker_payment = block_on_f01(taker_coin.send_taker_payment(SendPaymentArgs {
+        time_lock_duration,
+        time_lock,
+        other_pubkey: maker_pub,
+        secret_hash: secret_hash.as_slice(),
+        amount: taker_amount.clone(),
+        swap_contract_address: &taker_coin.swap_contract_address(),
+        swap_unique_data: &[],
+        payment_instructions: &None,
+        watcher_reward: watcher_reward.clone(),
+        wait_for_confirmation_until,
+    }))
+    .unwrap();
 
     let confirm_payment_input = ConfirmPaymentInput {
         payment_tx: taker_payment.tx_hex(),
@@ -2695,34 +2584,30 @@ fn test_taker_validates_taker_payment_refund_erc20() {
         wait_until: timeout,
         check_every: 1,
     };
-    taker_coin.wait_for_confirmations(confirm_payment_input).wait().unwrap();
+    block_on_f01(taker_coin.wait_for_confirmations(confirm_payment_input)).unwrap();
 
-    let taker_payment_refund_preimage = taker_coin
-        .create_taker_payment_refund_preimage(
-            &taker_payment.tx_hex(),
-            time_lock,
-            taker_pub,
-            secret_hash.as_slice(),
-            &taker_coin.swap_contract_address(),
-            &[],
-        )
-        .wait()
-        .unwrap();
+    let taker_payment_refund_preimage = block_on_f01(taker_coin.create_taker_payment_refund_preimage(
+        &taker_payment.tx_hex(),
+        time_lock,
+        taker_pub,
+        secret_hash.as_slice(),
+        &taker_coin.swap_contract_address(),
+        &[],
+    ))
+    .unwrap();
 
-    let taker_payment_refund = taker_coin
-        .send_taker_payment_refund_preimage(RefundPaymentArgs {
-            payment_tx: &taker_payment_refund_preimage.tx_hex(),
-            other_pubkey: taker_pub,
-            tx_type_with_secret_hash: SwapTxTypeWithSecretHash::TakerOrMakerPayment {
-                maker_secret_hash: secret_hash.as_slice(),
-            },
-            time_lock,
-            swap_contract_address: &taker_coin.swap_contract_address(),
-            swap_unique_data: &[],
-            watcher_reward: true,
-        })
-        .wait()
-        .unwrap();
+    let taker_payment_refund = block_on_f01(taker_coin.send_taker_payment_refund_preimage(RefundPaymentArgs {
+        payment_tx: &taker_payment_refund_preimage.tx_hex(),
+        other_pubkey: taker_pub,
+        tx_type_with_secret_hash: SwapTxTypeWithSecretHash::TakerOrMakerPayment {
+            maker_secret_hash: secret_hash.as_slice(),
+        },
+        time_lock,
+        swap_contract_address: &taker_coin.swap_contract_address(),
+        swap_unique_data: &[],
+        watcher_reward: true,
+    }))
+    .unwrap();
 
     let validate_input = ValidateWatcherSpendInput {
         payment_tx: taker_payment_refund.tx_hex(),
@@ -2735,9 +2620,7 @@ fn test_taker_validates_taker_payment_refund_erc20() {
         spend_type: WatcherSpendType::TakerPaymentRefund,
     };
 
-    let validate_watcher_refund = taker_coin
-        .taker_validates_payment_spend_or_refund(validate_input)
-        .wait();
+    let validate_watcher_refund = block_on_f01(taker_coin.taker_validates_payment_spend_or_refund(validate_input));
     assert!(validate_watcher_refund.is_ok());
 
     let validate_input = ValidateWatcherSpendInput {
@@ -2751,9 +2634,7 @@ fn test_taker_validates_taker_payment_refund_erc20() {
         spend_type: WatcherSpendType::TakerPaymentRefund,
     };
 
-    let error = taker_coin
-        .taker_validates_payment_spend_or_refund(validate_input)
-        .wait()
+    let error = block_on_f01(taker_coin.taker_validates_payment_spend_or_refund(validate_input))
         .unwrap_err()
         .into_inner();
     log!("error: {:?}", error);
@@ -2783,54 +2664,48 @@ fn test_taker_validates_maker_payment_spend_utxo() {
     let secret = generate_secret().unwrap();
     let secret_hash = dhash160(&secret);
 
-    let maker_payment = maker_coin
-        .send_maker_payment(SendPaymentArgs {
-            time_lock_duration,
-            time_lock,
-            other_pubkey: taker_pubkey,
-            secret_hash: secret_hash.as_slice(),
-            amount: BigDecimal::from(10),
-            swap_contract_address: &None,
-            swap_unique_data: &[],
-            payment_instructions: &None,
-            watcher_reward: None,
-            wait_for_confirmation_until,
-        })
-        .wait()
-        .unwrap();
+    let maker_payment = block_on_f01(maker_coin.send_maker_payment(SendPaymentArgs {
+        time_lock_duration,
+        time_lock,
+        other_pubkey: taker_pubkey,
+        secret_hash: secret_hash.as_slice(),
+        amount: BigDecimal::from(10),
+        swap_contract_address: &None,
+        swap_unique_data: &[],
+        payment_instructions: &None,
+        watcher_reward: None,
+        wait_for_confirmation_until,
+    }))
+    .unwrap();
 
-    maker_coin
-        .wait_for_confirmations(ConfirmPaymentInput {
-            payment_tx: maker_payment.tx_hex(),
-            confirmations: 1,
-            requires_nota: false,
-            wait_until: timeout,
-            check_every: 1,
-        })
-        .wait()
-        .unwrap();
+    block_on_f01(maker_coin.wait_for_confirmations(ConfirmPaymentInput {
+        payment_tx: maker_payment.tx_hex(),
+        confirmations: 1,
+        requires_nota: false,
+        wait_until: timeout,
+        check_every: 1,
+    }))
+    .unwrap();
 
-    let maker_payment_spend_preimage = taker_coin
-        .create_maker_payment_spend_preimage(
-            &maker_payment.tx_hex(),
-            time_lock,
-            maker_pubkey,
-            secret_hash.as_slice(),
-            &[],
-        )
-        .wait()
-        .unwrap();
+    let maker_payment_spend_preimage = block_on_f01(taker_coin.create_maker_payment_spend_preimage(
+        &maker_payment.tx_hex(),
+        time_lock,
+        maker_pubkey,
+        secret_hash.as_slice(),
+        &[],
+    ))
+    .unwrap();
 
-    let maker_payment_spend = taker_coin
-        .send_maker_payment_spend_preimage(SendMakerPaymentSpendPreimageInput {
+    let maker_payment_spend = block_on_f01(taker_coin.send_maker_payment_spend_preimage(
+        SendMakerPaymentSpendPreimageInput {
             preimage: &maker_payment_spend_preimage.tx_hex(),
             secret_hash: secret_hash.as_slice(),
             secret: secret.as_slice(),
             taker_pub: taker_pubkey,
             watcher_reward: false,
-        })
-        .wait()
-        .unwrap();
+        },
+    ))
+    .unwrap();
 
     let validate_input = ValidateWatcherSpendInput {
         payment_tx: maker_payment_spend.tx_hex(),
@@ -2843,9 +2718,7 @@ fn test_taker_validates_maker_payment_spend_utxo() {
         spend_type: WatcherSpendType::TakerPaymentRefund,
     };
 
-    let validate_watcher_spend = taker_coin
-        .taker_validates_payment_spend_or_refund(validate_input)
-        .wait();
+    let validate_watcher_spend = block_on_f01(taker_coin.taker_validates_payment_spend_or_refund(validate_input));
     assert!(validate_watcher_spend.is_ok());
 }
 
@@ -2877,43 +2750,37 @@ fn test_taker_validates_maker_payment_spend_eth() {
     .unwrap()
     .unwrap();
 
-    let maker_payment = maker_coin
-        .send_maker_payment(SendPaymentArgs {
-            time_lock_duration,
-            time_lock,
-            other_pubkey: taker_pub,
-            secret_hash: secret_hash.as_slice(),
-            amount: maker_amount.clone(),
-            swap_contract_address: &maker_coin.swap_contract_address(),
-            swap_unique_data: &[],
-            payment_instructions: &None,
-            watcher_reward: Some(watcher_reward.clone()),
-            wait_for_confirmation_until,
-        })
-        .wait()
-        .unwrap();
+    let maker_payment = block_on_f01(maker_coin.send_maker_payment(SendPaymentArgs {
+        time_lock_duration,
+        time_lock,
+        other_pubkey: taker_pub,
+        secret_hash: secret_hash.as_slice(),
+        amount: maker_amount.clone(),
+        swap_contract_address: &maker_coin.swap_contract_address(),
+        swap_unique_data: &[],
+        payment_instructions: &None,
+        watcher_reward: Some(watcher_reward.clone()),
+        wait_for_confirmation_until,
+    }))
+    .unwrap();
 
-    maker_coin
-        .wait_for_confirmations(ConfirmPaymentInput {
-            payment_tx: maker_payment.tx_hex(),
-            confirmations: 1,
-            requires_nota: false,
-            wait_until: timeout,
-            check_every: 1,
-        })
-        .wait()
-        .unwrap();
+    block_on_f01(maker_coin.wait_for_confirmations(ConfirmPaymentInput {
+        payment_tx: maker_payment.tx_hex(),
+        confirmations: 1,
+        requires_nota: false,
+        wait_until: timeout,
+        check_every: 1,
+    }))
+    .unwrap();
 
-    let maker_payment_spend_preimage = taker_coin
-        .create_maker_payment_spend_preimage(
-            &maker_payment.tx_hex(),
-            time_lock,
-            maker_pub,
-            secret_hash.as_slice(),
-            &[],
-        )
-        .wait()
-        .unwrap();
+    let maker_payment_spend_preimage = block_on_f01(taker_coin.create_maker_payment_spend_preimage(
+        &maker_payment.tx_hex(),
+        time_lock,
+        maker_pub,
+        secret_hash.as_slice(),
+        &[],
+    ))
+    .unwrap();
 
     let validate_input = ValidateWatcherSpendInput {
         payment_tx: maker_payment_spend_preimage.tx_hex(),
@@ -2926,9 +2793,7 @@ fn test_taker_validates_maker_payment_spend_eth() {
         spend_type: WatcherSpendType::MakerPaymentSpend,
     };
 
-    let error = taker_coin
-        .taker_validates_payment_spend_or_refund(validate_input)
-        .wait()
+    let error = block_on_f01(taker_coin.taker_validates_payment_spend_or_refund(validate_input))
         .unwrap_err()
         .into_inner();
     log!("error: {:?}", error);
@@ -2942,27 +2807,25 @@ fn test_taker_validates_maker_payment_spend_eth() {
         ),
     }
 
-    let maker_payment_spend = taker_coin
-        .send_maker_payment_spend_preimage(SendMakerPaymentSpendPreimageInput {
+    let maker_payment_spend = block_on_f01(taker_coin.send_maker_payment_spend_preimage(
+        SendMakerPaymentSpendPreimageInput {
             preimage: &maker_payment_spend_preimage.tx_hex(),
             secret_hash: secret_hash.as_slice(),
             secret: secret.as_slice(),
             taker_pub,
             watcher_reward: true,
-        })
-        .wait()
-        .unwrap();
+        },
+    ))
+    .unwrap();
 
-    maker_coin
-        .wait_for_confirmations(ConfirmPaymentInput {
-            payment_tx: maker_payment_spend.tx_hex(),
-            confirmations: 1,
-            requires_nota: false,
-            wait_until: timeout,
-            check_every: 1,
-        })
-        .wait()
-        .unwrap();
+    block_on_f01(maker_coin.wait_for_confirmations(ConfirmPaymentInput {
+        payment_tx: maker_payment_spend.tx_hex(),
+        confirmations: 1,
+        requires_nota: false,
+        wait_until: timeout,
+        check_every: 1,
+    }))
+    .unwrap();
 
     let validate_input = ValidateWatcherSpendInput {
         payment_tx: maker_payment_spend.tx_hex(),
@@ -2975,10 +2838,7 @@ fn test_taker_validates_maker_payment_spend_eth() {
         spend_type: WatcherSpendType::MakerPaymentSpend,
     };
 
-    taker_coin
-        .taker_validates_payment_spend_or_refund(validate_input)
-        .wait()
-        .unwrap();
+    block_on_f01(taker_coin.taker_validates_payment_spend_or_refund(validate_input)).unwrap();
 
     let validate_input = ValidateWatcherSpendInput {
         payment_tx: maker_payment_spend.tx_hex(),
@@ -2991,9 +2851,7 @@ fn test_taker_validates_maker_payment_spend_eth() {
         spend_type: WatcherSpendType::MakerPaymentSpend,
     };
 
-    let error = taker_coin
-        .taker_validates_payment_spend_or_refund(validate_input)
-        .wait()
+    let error = block_on_f01(taker_coin.taker_validates_payment_spend_or_refund(validate_input))
         .unwrap_err()
         .into_inner();
     log!("error: {:?}", error);
@@ -3018,9 +2876,7 @@ fn test_taker_validates_maker_payment_spend_eth() {
         spend_type: WatcherSpendType::MakerPaymentSpend,
     };
 
-    let error = taker_coin
-        .taker_validates_payment_spend_or_refund(validate_input)
-        .wait()
+    let error = block_on_f01(taker_coin.taker_validates_payment_spend_or_refund(validate_input))
         .unwrap_err()
         .into_inner();
     log!("error: {:?}", error);
@@ -3045,9 +2901,7 @@ fn test_taker_validates_maker_payment_spend_eth() {
         spend_type: WatcherSpendType::MakerPaymentSpend,
     };
 
-    let error = maker_coin
-        .taker_validates_payment_spend_or_refund(validate_input)
-        .wait()
+    let error = block_on_f01(maker_coin.taker_validates_payment_spend_or_refund(validate_input))
         .unwrap_err()
         .into_inner();
     log!("error: {:?}", error);
@@ -3075,9 +2929,7 @@ fn test_taker_validates_maker_payment_spend_eth() {
         spend_type: WatcherSpendType::MakerPaymentSpend,
     };
 
-    let error = taker_coin
-        .taker_validates_payment_spend_or_refund(validate_input)
-        .wait()
+    let error = block_on_f01(taker_coin.taker_validates_payment_spend_or_refund(validate_input))
         .unwrap_err()
         .into_inner();
     log!("error: {:?}", error);
@@ -3105,9 +2957,7 @@ fn test_taker_validates_maker_payment_spend_eth() {
         spend_type: WatcherSpendType::MakerPaymentSpend,
     };
 
-    let error = taker_coin
-        .taker_validates_payment_spend_or_refund(validate_input)
-        .wait()
+    let error = block_on_f01(taker_coin.taker_validates_payment_spend_or_refund(validate_input))
         .unwrap_err()
         .into_inner();
     log!("error: {:?}", error);
@@ -3135,9 +2985,7 @@ fn test_taker_validates_maker_payment_spend_eth() {
         spend_type: WatcherSpendType::MakerPaymentSpend,
     };
 
-    let error = taker_coin
-        .taker_validates_payment_spend_or_refund(validate_input)
-        .wait()
+    let error = block_on_f01(taker_coin.taker_validates_payment_spend_or_refund(validate_input))
         .unwrap_err()
         .into_inner();
     log!("error: {:?}", error);
@@ -3162,9 +3010,7 @@ fn test_taker_validates_maker_payment_spend_eth() {
         spend_type: WatcherSpendType::MakerPaymentSpend,
     };
 
-    let error = taker_coin
-        .taker_validates_payment_spend_or_refund(validate_input)
-        .wait()
+    let error = block_on_f01(taker_coin.taker_validates_payment_spend_or_refund(validate_input))
         .unwrap_err()
         .into_inner();
     log!("error: {:?}", error);
@@ -3206,65 +3052,57 @@ fn test_taker_validates_maker_payment_spend_erc20() {
     ))
     .unwrap();
 
-    let maker_payment = maker_coin
-        .send_maker_payment(SendPaymentArgs {
-            time_lock_duration,
-            time_lock,
-            other_pubkey: taker_pub,
-            secret_hash: secret_hash.as_slice(),
-            amount: maker_amount.clone(),
-            swap_contract_address: &maker_coin.swap_contract_address(),
-            swap_unique_data: &[],
-            payment_instructions: &None,
-            watcher_reward: watcher_reward.clone(),
-            wait_for_confirmation_until,
-        })
-        .wait()
-        .unwrap();
+    let maker_payment = block_on_f01(maker_coin.send_maker_payment(SendPaymentArgs {
+        time_lock_duration,
+        time_lock,
+        other_pubkey: taker_pub,
+        secret_hash: secret_hash.as_slice(),
+        amount: maker_amount.clone(),
+        swap_contract_address: &maker_coin.swap_contract_address(),
+        swap_unique_data: &[],
+        payment_instructions: &None,
+        watcher_reward: watcher_reward.clone(),
+        wait_for_confirmation_until,
+    }))
+    .unwrap();
 
-    maker_coin
-        .wait_for_confirmations(ConfirmPaymentInput {
-            payment_tx: maker_payment.tx_hex(),
-            confirmations: 1,
-            requires_nota: false,
-            wait_until: timeout,
-            check_every: 1,
-        })
-        .wait()
-        .unwrap();
+    block_on_f01(maker_coin.wait_for_confirmations(ConfirmPaymentInput {
+        payment_tx: maker_payment.tx_hex(),
+        confirmations: 1,
+        requires_nota: false,
+        wait_until: timeout,
+        check_every: 1,
+    }))
+    .unwrap();
 
-    let maker_payment_spend_preimage = taker_coin
-        .create_maker_payment_spend_preimage(
-            &maker_payment.tx_hex(),
-            time_lock,
-            maker_pub,
-            secret_hash.as_slice(),
-            &[],
-        )
-        .wait()
-        .unwrap();
+    let maker_payment_spend_preimage = block_on_f01(taker_coin.create_maker_payment_spend_preimage(
+        &maker_payment.tx_hex(),
+        time_lock,
+        maker_pub,
+        secret_hash.as_slice(),
+        &[],
+    ))
+    .unwrap();
 
-    let maker_payment_spend = taker_coin
-        .send_maker_payment_spend_preimage(SendMakerPaymentSpendPreimageInput {
+    let maker_payment_spend = block_on_f01(taker_coin.send_maker_payment_spend_preimage(
+        SendMakerPaymentSpendPreimageInput {
             preimage: &maker_payment_spend_preimage.tx_hex(),
             secret_hash: secret_hash.as_slice(),
             secret: secret.as_slice(),
             taker_pub,
             watcher_reward: true,
-        })
-        .wait()
-        .unwrap();
+        },
+    ))
+    .unwrap();
 
-    maker_coin
-        .wait_for_confirmations(ConfirmPaymentInput {
-            payment_tx: maker_payment_spend.tx_hex(),
-            confirmations: 1,
-            requires_nota: false,
-            wait_until: timeout,
-            check_every: 1,
-        })
-        .wait()
-        .unwrap();
+    block_on_f01(maker_coin.wait_for_confirmations(ConfirmPaymentInput {
+        payment_tx: maker_payment_spend.tx_hex(),
+        confirmations: 1,
+        requires_nota: false,
+        wait_until: timeout,
+        check_every: 1,
+    }))
+    .unwrap();
 
     let validate_input = ValidateWatcherSpendInput {
         payment_tx: maker_payment_spend.tx_hex(),
@@ -3277,10 +3115,7 @@ fn test_taker_validates_maker_payment_spend_erc20() {
         spend_type: WatcherSpendType::MakerPaymentSpend,
     };
 
-    taker_coin
-        .taker_validates_payment_spend_or_refund(validate_input)
-        .wait()
-        .unwrap();
+    block_on_f01(taker_coin.taker_validates_payment_spend_or_refund(validate_input)).unwrap();
 
     let validate_input = ValidateWatcherSpendInput {
         payment_tx: maker_payment_spend.tx_hex(),
@@ -3293,9 +3128,7 @@ fn test_taker_validates_maker_payment_spend_erc20() {
         spend_type: WatcherSpendType::MakerPaymentSpend,
     };
 
-    let error = taker_coin
-        .taker_validates_payment_spend_or_refund(validate_input)
-        .wait()
+    let error = block_on_f01(taker_coin.taker_validates_payment_spend_or_refund(validate_input))
         .unwrap_err()
         .into_inner();
     log!("error: {:?}", error);
@@ -3329,7 +3162,7 @@ fn test_send_taker_payment_refund_preimage_utxo() {
         watcher_reward: None,
         wait_for_confirmation_until: 0,
     };
-    let tx = coin.send_taker_payment(taker_payment_args).wait().unwrap();
+    let tx = block_on_f01(coin.send_taker_payment(taker_payment_args)).unwrap();
 
     let confirm_payment_input = ConfirmPaymentInput {
         payment_tx: tx.tx_hex(),
@@ -3338,27 +3171,30 @@ fn test_send_taker_payment_refund_preimage_utxo() {
         wait_until: timeout,
         check_every: 1,
     };
-    coin.wait_for_confirmations(confirm_payment_input).wait().unwrap();
+    block_on_f01(coin.wait_for_confirmations(confirm_payment_input)).unwrap();
 
-    let refund_tx = coin
-        .create_taker_payment_refund_preimage(&tx.tx_hex(), time_lock, my_public_key, &[0; 20], &None, &[])
-        .wait()
-        .unwrap();
+    let refund_tx = block_on_f01(coin.create_taker_payment_refund_preimage(
+        &tx.tx_hex(),
+        time_lock,
+        my_public_key,
+        &[0; 20],
+        &None,
+        &[],
+    ))
+    .unwrap();
 
-    let refund_tx = coin
-        .send_taker_payment_refund_preimage(RefundPaymentArgs {
-            payment_tx: &refund_tx.tx_hex(),
-            swap_contract_address: &None,
-            tx_type_with_secret_hash: SwapTxTypeWithSecretHash::TakerOrMakerPayment {
-                maker_secret_hash: &[0; 20],
-            },
-            other_pubkey: my_public_key,
-            time_lock,
-            swap_unique_data: &[],
-            watcher_reward: false,
-        })
-        .wait()
-        .unwrap();
+    let refund_tx = block_on_f01(coin.send_taker_payment_refund_preimage(RefundPaymentArgs {
+        payment_tx: &refund_tx.tx_hex(),
+        swap_contract_address: &None,
+        tx_type_with_secret_hash: SwapTxTypeWithSecretHash::TakerOrMakerPayment {
+            maker_secret_hash: &[0; 20],
+        },
+        other_pubkey: my_public_key,
+        time_lock,
+        swap_unique_data: &[],
+        watcher_reward: false,
+    }))
+    .unwrap();
 
     let confirm_payment_input = ConfirmPaymentInput {
         payment_tx: refund_tx.tx_hex(),
@@ -3367,7 +3203,7 @@ fn test_send_taker_payment_refund_preimage_utxo() {
         wait_until: timeout,
         check_every: 1,
     };
-    coin.wait_for_confirmations(confirm_payment_input).wait().unwrap();
+    block_on_f01(coin.wait_for_confirmations(confirm_payment_input)).unwrap();
 
     let search_input = SearchForSwapTxSpendInput {
         time_lock,


### PR DESCRIPTION
Encountered an issue regarding a tokio tcp stream that breaks because it was spawned in a non-tokio runtime (in #1966).

These `.wait` methods used were using a different runtime - from `futures` - to run the future, but we could have instead did `block_on(fut.compat())` and run it on MM2's tokio runtime.

PRing this on its own to reduce the clutter in #1966 :)