### PR TITLE
fix(merge): remove duplicated `db_root` function

### DIFF
--- a/mm2src/mm2_core/src/mm_ctx.rs
+++ b/mm2src/mm2_core/src/mm_ctx.rs
@@ -290,10 +290,6 @@ impl MmCtx {
     /// Returns the path to the MM databases root.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn db_root(&self) -> PathBuf { path_to_db_root(self.conf["dbdir"].as_str()) }
-
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn db_root(&self) -> PathBuf { path_to_db_root(self.conf["dbdir"].as_str()) }
-
     #[cfg(not(target_arch = "wasm32"))]
     pub fn wallet_file_path(&self, wallet_name: &str) -> PathBuf {
         self.db_root().join(wallet_name.to_string() + ".dat")


### PR DESCRIPTION
`db_root` function was duplicated due to it being created in 2 branches that were merged to dev. This PR fixes this.