### PR TITLE
feat(cosmos-offline-tests): prepare IBC channels inside the container 

### DIFF
--- a/mm2src/mm2_main/tests/docker_tests/docker_tests_common.rs
+++ b/mm2src/mm2_main/tests/docker_tests/docker_tests_common.rs
@@ -110,8 +110,8 @@ pub const SIA_DOCKER_IMAGE: &str = "docker.io/alrighttt/walletd-komodo";
 pub const SIA_DOCKER_IMAGE_WITH_TAG: &str = "docker.io/alrighttt/walletd-komodo:latest";
 
 pub const NUCLEUS_IMAGE: &str = "docker.io/komodoofficial/nucleusd";
-pub const ATOM_IMAGE: &str = "docker.io/komodoofficial/gaiad";
-pub const IBC_RELAYER_IMAGE: &str = "docker.io/komodoofficial/ibc-relayer";
+pub const ATOM_IMAGE_WITH_TAG: &str = "docker.io/komodoofficial/gaiad:kdf-ci";
+pub const IBC_RELAYER_IMAGE_WITH_TAG: &str = "docker.io/komodoofficial/ibc-relayer:kdf-ci";
 
 pub const QTUM_ADDRESS_LABEL: &str = "MM2_ADDRESS_LABEL";
 
@@ -409,8 +409,8 @@ pub fn atom_node(docker: &'_ Cli, runtime_dir: PathBuf) -> DockerNode<'_> {
     let atom_node_runtime_dir = runtime_dir.join("atom-testnet-data");
     assert!(atom_node_runtime_dir.exists());
 
-    let image =
-        GenericImage::new(ATOM_IMAGE, "latest").with_volume(atom_node_runtime_dir.to_str().unwrap(), "/root/.gaia");
+    let (image, tag) = ATOM_IMAGE_WITH_TAG.rsplit_once(':').unwrap();
+    let image = GenericImage::new(image, tag).with_volume(atom_node_runtime_dir.to_str().unwrap(), "/root/.gaia");
     let image = RunnableImage::from((image, vec![])).with_network("host");
     let container = docker.run(image);
 
@@ -421,13 +421,12 @@ pub fn atom_node(docker: &'_ Cli, runtime_dir: PathBuf) -> DockerNode<'_> {
     }
 }
 
-#[allow(dead_code)]
 pub fn ibc_relayer_node(docker: &'_ Cli, runtime_dir: PathBuf) -> DockerNode<'_> {
     let relayer_node_runtime_dir = runtime_dir.join("ibc-relayer-data");
     assert!(relayer_node_runtime_dir.exists());
 
-    let image = GenericImage::new(IBC_RELAYER_IMAGE, "latest")
-        .with_volume(relayer_node_runtime_dir.to_str().unwrap(), "/home/relayer/.relayer");
+    let (image, tag) = IBC_RELAYER_IMAGE_WITH_TAG.rsplit_once(':').unwrap();
+    let image = GenericImage::new(image, tag).with_volume(relayer_node_runtime_dir.to_str().unwrap(), "/root/.relayer");
     let image = RunnableImage::from((image, vec![])).with_network("host");
     let container = docker.run(image);
 
@@ -1128,7 +1127,27 @@ async fn get_current_gas_limit(web3: &Web3<Http>) {
     }
 }
 
-#[allow(dead_code)]
+pub fn prepare_ibc_channels(container_id: &str) {
+    let mut docker = Command::new("docker");
+    docker
+        .arg("exec")
+        .arg(container_id)
+        .args(["rly", "transact", "clients", "nucleus-atom", "--override"])
+        .output()
+        .unwrap();
+
+    // It takes couple seconds for nodes to get into the right state after updating clients.
+    thread::sleep(Duration::from_secs(5));
+
+    let mut docker = Command::new("docker");
+    docker
+        .arg("exec")
+        .arg(container_id)
+        .args(["rly", "transact", "link", "nucleus-atom"])
+        .output()
+        .unwrap();
+}
+
 pub fn wait_until_relayer_container_is_ready(container_id: &str) {
     const Q_RESULT: &str = "0: nucleus-atom         -> chns(✔) clnts(✔) conn(✔) (nucleus-testnet<>cosmoshub-testnet)";
 

--- a/mm2src/mm2_main/tests/docker_tests/docker_tests_common.rs
+++ b/mm2src/mm2_main/tests/docker_tests/docker_tests_common.rs
@@ -1128,24 +1128,20 @@ async fn get_current_gas_limit(web3: &Web3<Http>) {
 }
 
 pub fn prepare_ibc_channels(container_id: &str) {
-    let mut docker = Command::new("docker");
-    docker
-        .arg("exec")
-        .arg(container_id)
-        .args(["rly", "transact", "clients", "nucleus-atom", "--override"])
-        .output()
-        .unwrap();
+    let exec = |args: &[&str]| {
+        Command::new("docker")
+            .args(["exec", container_id])
+            .args(args)
+            .output()
+            .unwrap();
+    };
 
-    // It takes couple seconds for nodes to get into the right state after updating clients.
+    exec(&["rly", "transact", "clients", "nucleus-atom", "--override"]);
+    // It takes a couple of seconds for nodes to get into the right state after updating clients.
+    // Wait for 5 just to make sure.
     thread::sleep(Duration::from_secs(5));
 
-    let mut docker = Command::new("docker");
-    docker
-        .arg("exec")
-        .arg(container_id)
-        .args(["rly", "transact", "link", "nucleus-atom"])
-        .output()
-        .unwrap();
+    exec(&["rly", "transact", "link", "nucleus-atom"]);
 }
 
 pub fn wait_until_relayer_container_is_ready(container_id: &str) {

--- a/mm2src/mm2_main/tests/docker_tests/tendermint_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/tendermint_tests.rs
@@ -312,10 +312,9 @@ fn test_custom_gas_limit_on_tendermint_withdraw() {
 }
 
 #[test]
-#[ignore]
 fn test_tendermint_ibc_withdraw() {
     // visit `{swagger_address}/ibc/core/channel/v1/channels?pagination.limit=10000` to see the full list of ibc channels
-    const IBC_SOURCE_CHANNEL: &str = "channel-1";
+    const IBC_SOURCE_CHANNEL: &str = "channel-2";
 
     const IBC_TARGET_ADDRESS: &str = "cosmos1r5v5srda7xfth3hn2s26txvrcrntldjumt8mhl";
     const MY_ADDRESS: &str = "nuc150evuj4j7k9kgu38e453jdv9m3u0ft2n4fgzfr";
@@ -359,10 +358,9 @@ fn test_tendermint_ibc_withdraw() {
 }
 
 #[test]
-#[ignore]
 fn test_tendermint_ibc_withdraw_hd() {
     // visit `{swagger_address}/ibc/core/channel/v1/channels?pagination.limit=10000` to see the full list of ibc channels
-    const IBC_SOURCE_CHANNEL: &str = "channel-1";
+    const IBC_SOURCE_CHANNEL: &str = "channel-2";
 
     const IBC_TARGET_ADDRESS: &str = "nuc150evuj4j7k9kgu38e453jdv9m3u0ft2n4fgzfr";
     const MY_ADDRESS: &str = "cosmos134h9tv7866jcuw708w5w76lcfx7s3x2ysyalxy";

--- a/mm2src/mm2_main/tests/docker_tests_main.rs
+++ b/mm2src/mm2_main/tests/docker_tests_main.rs
@@ -56,8 +56,8 @@ pub fn docker_tests_runner(tests: &[&TestDescAndFn]) {
             QTUM_REGTEST_DOCKER_IMAGE_WITH_TAG,
             GETH_DOCKER_IMAGE_WITH_TAG,
             NUCLEUS_IMAGE,
-            ATOM_IMAGE,
-            IBC_RELAYER_IMAGE,
+            ATOM_IMAGE_WITH_TAG,
+            IBC_RELAYER_IMAGE_WITH_TAG,
         ];
 
         for image in IMAGES {
@@ -68,8 +68,8 @@ pub fn docker_tests_runner(tests: &[&TestDescAndFn]) {
         let runtime_dir = prepare_runtime_dir().unwrap();
 
         let nucleus_node = nucleus_node(&docker, runtime_dir.clone());
-        let atom_node = atom_node(&docker, runtime_dir);
-        // let ibc_relayer_node = ibc_relayer_node(&docker, runtime_dir);
+        let atom_node = atom_node(&docker, runtime_dir.clone());
+        let ibc_relayer_node = ibc_relayer_node(&docker, runtime_dir);
         let utxo_node = utxo_asset_docker_node(&docker, "MYCOIN", 7000);
         let utxo_node1 = utxo_asset_docker_node(&docker, "MYCOIN1", 8000);
         let qtum_node = qtum_docker_node(&docker, 9000);
@@ -90,8 +90,10 @@ pub fn docker_tests_runner(tests: &[&TestDescAndFn]) {
 
         wait_for_geth_node_ready();
         init_geth_node();
+        prepare_ibc_channels(ibc_relayer_node.container.id());
+
         thread::sleep(Duration::from_secs(10));
-        // wait_until_relayer_container_is_ready(ibc_relayer_node.container.id());
+        wait_until_relayer_container_is_ready(ibc_relayer_node.container.id());
 
         containers.push(utxo_node);
         containers.push(utxo_node1);
@@ -100,7 +102,7 @@ pub fn docker_tests_runner(tests: &[&TestDescAndFn]) {
         containers.push(geth_node);
         containers.push(nucleus_node);
         containers.push(atom_node);
-        // containers.push(ibc_relayer_node);
+        containers.push(ibc_relayer_node);
     }
     // detect if docker is installed
     // skip the tests that use docker if not installed


### PR DESCRIPTION
Fixes the weird "expired channel" bug and re-enables [ignored IBC tests](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2185).

Blocker on https://github.com/KomodoPlatform/komodo-defi-framework/pull/2245.