### PR TITLE
fix(legacy-swap): remove the need for takers to confirm their payment

### DIFF
--- a/mm2src/coins/qrc20/swap.rs
+++ b/mm2src/coins/qrc20/swap.rs
@@ -356,8 +356,8 @@ impl Qrc20Coin {
                     move |e| {
                         error!(
                             "Failed to retrieve QRC20 payment details from transaction {} \
-                            after waiting until {}. Error: {:?}",
-                            tx_hash, wait_until, e
+                            will retry in {} seconds. Error: {:?}",
+                            tx_hash, check_every, e
                         )
                     }
                 })

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -1715,28 +1715,6 @@ impl TakerSwap {
             self.p2p_privkey,
         );
 
-        let confirm_taker_payment_input = ConfirmPaymentInput {
-            payment_tx: self.r().taker_payment.clone().unwrap().tx_hex.0,
-            confirmations: self.r().data.taker_payment_confirmations,
-            requires_nota: self.r().data.taker_payment_requires_nota.unwrap_or(false),
-            wait_until: self.r().data.taker_payment_lock,
-            check_every: WAIT_CONFIRM_INTERVAL_SEC,
-        };
-        let wait_f = self
-            .taker_coin
-            .wait_for_confirmations(confirm_taker_payment_input)
-            .compat();
-        if let Err(err) = wait_f.await {
-            return Ok((Some(TakerSwapCommand::PrepareForTakerPaymentRefund), vec![
-                TakerSwapEvent::TakerPaymentWaitConfirmFailed(
-                    ERRL!("!taker_coin.wait_for_confirmations: {}", err).into(),
-                ),
-                TakerSwapEvent::TakerPaymentWaitRefundStarted {
-                    wait_until: self.wait_refund_until(),
-                },
-            ]));
-        }
-
         #[cfg(any(test, feature = "run-docker-tests"))]
         if self.fail_at == Some(FailAt::WaitForTakerPaymentSpendPanic) {
             panic!("Taker panicked unexpectedly at wait for taker payment spend");

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -1717,10 +1717,12 @@ impl TakerSwap {
 
         #[cfg(any(test, feature = "run-docker-tests"))]
         if self.fail_at == Some(FailAt::WaitForTakerPaymentSpendPanic) {
+            // Wait for 5 seconds before panicking to ensure the message is sent
+            Timer::sleep(5.).await;
             panic!("Taker panicked unexpectedly at wait for taker payment spend");
         }
 
-        info!("Taker payment confirmed");
+        info!("Waiting for maker to spend taker payment!");
 
         let wait_until = match std::env::var("USE_TEST_LOCKTIME") {
             Ok(_) => self.r().data.started_at,

--- a/mm2src/mm2_main/tests/docker_tests/swap_watcher_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/swap_watcher_tests.rs
@@ -686,11 +686,8 @@ fn test_taker_completes_swap_after_taker_payment_spent_while_offline() {
     // stop taker after taker payment sent
     let taker_payment_msg = "Taker payment tx hash ";
     block_on(mm_alice.wait_for_log(120., |log| log.contains(taker_payment_msg))).unwrap();
-    let alice_log = mm_alice.log_as_utf8().unwrap();
-    let tx_hash_start = alice_log.find(taker_payment_msg).unwrap() + taker_payment_msg.len();
-    let payment_tx_hash = alice_log[tx_hash_start..tx_hash_start + 64].to_string();
     // ensure p2p message is sent to the maker, this happens before this message:
-    block_on(mm_alice.wait_for_log(120., |log| log.contains(&format!("Waiting for tx {}", payment_tx_hash)))).unwrap();
+    block_on(mm_alice.wait_for_log(120., |log| log.contains("Waiting for maker to spend taker payment!"))).unwrap();
     alice_conf.conf["dbdir"] = mm_alice.folder.join("DB").to_str().unwrap().into();
     block_on(mm_alice.stop()).unwrap();
 


### PR DESCRIPTION
To Test:
Nothing as swaps should work as normal after this. This invalidates the fix of this issue https://github.com/KomodoPlatform/komodo-defi-framework/issues/1442 and I will work on a better solution for this where taker rebroadcast thier transaction if it's not on chain. 