### PR TITLE
refactor(SwapOps): make `send_maker_payment` async

### DIFF
--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -1117,11 +1117,11 @@ impl SwapOps for EthCoin {
         )
     }
 
-    fn send_maker_payment(&self, maker_payment: SendPaymentArgs) -> TransactionFut {
-        Box::new(
-            self.send_hash_time_locked_payment(maker_payment)
-                .map(TransactionEnum::from),
-        )
+    async fn send_maker_payment(&self, maker_payment_args: SendPaymentArgs<'_>) -> TransactionResult {
+        self.send_hash_time_locked_payment(maker_payment_args)
+            .compat()
+            .await
+            .map(TransactionEnum::from)
     }
 
     fn send_taker_payment(&self, taker_payment: SendPaymentArgs) -> TransactionFut {

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -1071,7 +1071,7 @@ pub enum WatcherRewardError {
 pub trait SwapOps {
     fn send_taker_fee(&self, fee_addr: &[u8], dex_fee: DexFee, uuid: &[u8], expire_at: u64) -> TransactionFut;
 
-    fn send_maker_payment(&self, maker_payment_args: SendPaymentArgs<'_>) -> TransactionFut;
+    async fn send_maker_payment(&self, maker_payment_args: SendPaymentArgs<'_>) -> TransactionResult;
 
     fn send_taker_payment(&self, taker_payment_args: SendPaymentArgs<'_>) -> TransactionFut;
 

--- a/mm2src/coins/siacoin.rs
+++ b/mm2src/coins/siacoin.rs
@@ -403,7 +403,9 @@ impl SwapOps for SiaCoin {
         unimplemented!()
     }
 
-    fn send_maker_payment(&self, _maker_payment_args: SendPaymentArgs) -> TransactionFut { unimplemented!() }
+    async fn send_maker_payment(&self, _maker_payment_args: SendPaymentArgs<'_>) -> TransactionResult {
+        unimplemented!()
+    }
 
     fn send_taker_payment(&self, _taker_payment_args: SendPaymentArgs) -> TransactionFut { unimplemented!() }
 

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -2702,7 +2702,7 @@ impl SwapOps for TendermintCoin {
         )
     }
 
-    fn send_maker_payment(&self, maker_payment_args: SendPaymentArgs) -> TransactionFut {
+    async fn send_maker_payment(&self, maker_payment_args: SendPaymentArgs<'_>) -> TransactionResult {
         self.send_htlc_for_denom(
             maker_payment_args.time_lock_duration,
             maker_payment_args.other_pubkey,
@@ -2711,6 +2711,8 @@ impl SwapOps for TendermintCoin {
             self.denom.clone(),
             self.decimals,
         )
+        .compat()
+        .await
     }
 
     fn send_taker_payment(&self, taker_payment_args: SendPaymentArgs) -> TransactionFut {

--- a/mm2src/coins/tendermint/tendermint_token.rs
+++ b/mm2src/coins/tendermint/tendermint_token.rs
@@ -115,15 +115,18 @@ impl SwapOps for TendermintToken {
         )
     }
 
-    fn send_maker_payment(&self, maker_payment_args: SendPaymentArgs) -> TransactionFut {
-        self.platform_coin.send_htlc_for_denom(
-            maker_payment_args.time_lock_duration,
-            maker_payment_args.other_pubkey,
-            maker_payment_args.secret_hash,
-            maker_payment_args.amount,
-            self.denom.clone(),
-            self.decimals,
-        )
+    async fn send_maker_payment(&self, maker_payment_args: SendPaymentArgs<'_>) -> TransactionResult {
+        self.platform_coin
+            .send_htlc_for_denom(
+                maker_payment_args.time_lock_duration,
+                maker_payment_args.other_pubkey,
+                maker_payment_args.secret_hash,
+                maker_payment_args.amount,
+                self.denom.clone(),
+                self.decimals,
+            )
+            .compat()
+            .await
     }
 
     fn send_taker_payment(&self, taker_payment_args: SendPaymentArgs) -> TransactionFut {

--- a/mm2src/coins/test_coin.rs
+++ b/mm2src/coins/test_coin.rs
@@ -118,7 +118,9 @@ impl SwapOps for TestCoin {
         unimplemented!()
     }
 
-    fn send_maker_payment(&self, _maker_payment_args: SendPaymentArgs) -> TransactionFut { unimplemented!() }
+    async fn send_maker_payment(&self, maker_payment_args: SendPaymentArgs<'_>) -> TransactionResult {
+        unimplemented!()
+    }
 
     fn send_taker_payment(&self, _taker_payment_args: SendPaymentArgs) -> TransactionFut { unimplemented!() }
 

--- a/mm2src/coins/utxo/bch.rs
+++ b/mm2src/coins/utxo/bch.rs
@@ -875,8 +875,10 @@ impl SwapOps for BchCoin {
     }
 
     #[inline]
-    fn send_maker_payment(&self, maker_payment_args: SendPaymentArgs) -> TransactionFut {
+    async fn send_maker_payment(&self, maker_payment_args: SendPaymentArgs<'_>) -> TransactionResult {
         utxo_common::send_maker_payment(self.clone(), maker_payment_args)
+            .compat()
+            .await
     }
 
     #[inline]

--- a/mm2src/coins/utxo/qtum.rs
+++ b/mm2src/coins/utxo/qtum.rs
@@ -515,8 +515,10 @@ impl SwapOps for QtumCoin {
     }
 
     #[inline]
-    fn send_maker_payment(&self, maker_payment_args: SendPaymentArgs) -> TransactionFut {
+    async fn send_maker_payment(&self, maker_payment_args: SendPaymentArgs<'_>) -> TransactionResult {
         utxo_common::send_maker_payment(self.clone(), maker_payment_args)
+            .compat()
+            .await
     }
 
     #[inline]

--- a/mm2src/coins/utxo/utxo_standard.rs
+++ b/mm2src/coins/utxo/utxo_standard.rs
@@ -307,8 +307,10 @@ impl SwapOps for UtxoStandardCoin {
     }
 
     #[inline]
-    fn send_maker_payment(&self, maker_payment_args: SendPaymentArgs) -> TransactionFut {
+    async fn send_maker_payment(&self, maker_payment_args: SendPaymentArgs<'_>) -> TransactionResult {
         utxo_common::send_maker_payment(self.clone(), maker_payment_args)
+            .compat()
+            .await
     }
 
     #[inline]

--- a/mm2src/coins/z_coin/z_coin_native_tests.rs
+++ b/mm2src/coins/z_coin/z_coin_native_tests.rs
@@ -54,7 +54,7 @@ fn zombie_coin_send_and_refund_maker_payment() {
         watcher_reward: None,
         wait_for_confirmation_until: 0,
     };
-    let tx = block_on_f01(coin.send_maker_payment(args)).unwrap();
+    let tx = block_on(coin.send_maker_payment(args)).unwrap();
     log!("swap tx {}", hex::encode(tx.tx_hash_as_bytes().0));
 
     let refund_args = RefundPaymentArgs {
@@ -115,7 +115,7 @@ fn zombie_coin_send_and_spend_maker_payment() {
         wait_for_confirmation_until: 0,
     };
 
-    let tx = block_on_f01(coin.send_maker_payment(maker_payment_args)).unwrap();
+    let tx = block_on(coin.send_maker_payment(maker_payment_args)).unwrap();
     log!("swap tx {}", hex::encode(tx.tx_hash_as_bytes().0));
 
     let maker_pub = taker_pub;

--- a/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
+++ b/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
@@ -139,7 +139,7 @@ fn test_search_for_swap_tx_spend_native_was_refunded_maker() {
         watcher_reward: None,
         wait_for_confirmation_until: 0,
     };
-    let tx = block_on_f01(coin.send_maker_payment(maker_payment_args)).unwrap();
+    let tx = block_on(coin.send_maker_payment(maker_payment_args)).unwrap();
 
     let confirm_payment_input = ConfirmPaymentInput {
         payment_tx: tx.tx_hex(),
@@ -276,7 +276,7 @@ fn test_search_for_maker_swap_tx_spend_native_was_spent_by_taker() {
         watcher_reward: None,
         wait_for_confirmation_until: 0,
     };
-    let tx = block_on_f01(coin.send_maker_payment(maker_payment_args)).unwrap();
+    let tx = block_on(coin.send_maker_payment(maker_payment_args)).unwrap();
 
     let confirm_payment_input = ConfirmPaymentInput {
         payment_tx: tx.tx_hex(),
@@ -347,7 +347,7 @@ fn test_one_hundred_maker_payments_in_a_row_native() {
             watcher_reward: None,
             wait_for_confirmation_until: 0,
         };
-        let tx = block_on_f01(coin.send_maker_payment(maker_payment_args)).unwrap();
+        let tx = block_on(coin.send_maker_payment(maker_payment_args)).unwrap();
         if let TransactionEnum::UtxoTx(tx) = tx {
             unspents.push(UnspentInfo {
                 outpoint: OutPoint {

--- a/mm2src/mm2_main/tests/docker_tests/eth_docker_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/eth_docker_tests.rs
@@ -539,7 +539,7 @@ fn send_and_refund_eth_maker_payment_impl(swap_txfee_policy: SwapTxFeePolicy) {
         watcher_reward: None,
         wait_for_confirmation_until: 0,
     };
-    let eth_maker_payment = block_on_f01(eth_coin.send_maker_payment(send_payment_args)).unwrap();
+    let eth_maker_payment = block_on(eth_coin.send_maker_payment(send_payment_args)).unwrap();
 
     let confirm_input = ConfirmPaymentInput {
         payment_tx: eth_maker_payment.tx_hex(),
@@ -625,7 +625,7 @@ fn send_and_spend_eth_maker_payment_impl(swap_txfee_policy: SwapTxFeePolicy) {
         watcher_reward: None,
         wait_for_confirmation_until: 0,
     };
-    let eth_maker_payment = block_on_f01(maker_eth_coin.send_maker_payment(send_payment_args)).unwrap();
+    let eth_maker_payment = block_on(maker_eth_coin.send_maker_payment(send_payment_args)).unwrap();
 
     let confirm_input = ConfirmPaymentInput {
         payment_tx: eth_maker_payment.tx_hex(),
@@ -708,7 +708,7 @@ fn send_and_refund_erc20_maker_payment_impl(swap_txfee_policy: SwapTxFeePolicy) 
         watcher_reward: None,
         wait_for_confirmation_until: now_sec() + 60,
     };
-    let eth_maker_payment = block_on_f01(erc20_coin.send_maker_payment(send_payment_args)).unwrap();
+    let eth_maker_payment = block_on(erc20_coin.send_maker_payment(send_payment_args)).unwrap();
 
     let confirm_input = ConfirmPaymentInput {
         payment_tx: eth_maker_payment.tx_hex(),
@@ -797,7 +797,7 @@ fn send_and_spend_erc20_maker_payment_impl(swap_txfee_policy: SwapTxFeePolicy) {
         watcher_reward: None,
         wait_for_confirmation_until: now_sec() + 60,
     };
-    let eth_maker_payment = block_on_f01(maker_erc20_coin.send_maker_payment(send_payment_args)).unwrap();
+    let eth_maker_payment = block_on(maker_erc20_coin.send_maker_payment(send_payment_args)).unwrap();
 
     let confirm_input = ConfirmPaymentInput {
         payment_tx: eth_maker_payment.tx_hex(),

--- a/mm2src/mm2_main/tests/docker_tests/qrc20_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/qrc20_tests.rs
@@ -185,7 +185,7 @@ fn test_taker_spends_maker_payment() {
         watcher_reward: None,
         wait_for_confirmation_until: 0,
     };
-    let payment = block_on_f01(maker_coin.send_maker_payment(maker_payment_args)).unwrap();
+    let payment = block_on(maker_coin.send_maker_payment(maker_payment_args)).unwrap();
     let payment_tx_hash = payment.tx_hash_as_bytes();
     let payment_tx_hex = payment.tx_hex();
     log!("Maker payment: {:?}", payment_tx_hash);
@@ -360,7 +360,7 @@ fn test_maker_refunds_payment() {
         watcher_reward: None,
         wait_for_confirmation_until: 0,
     };
-    let payment = block_on_f01(coin.send_maker_payment(maker_payment)).unwrap();
+    let payment = block_on(coin.send_maker_payment(maker_payment)).unwrap();
     let payment_tx_hash = payment.tx_hash_as_bytes();
     let payment_tx_hex = payment.tx_hex();
     log!("Maker payment: {:?}", payment_tx_hash);
@@ -501,7 +501,7 @@ fn test_check_if_my_payment_sent() {
         watcher_reward: None,
         wait_for_confirmation_until: 0,
     };
-    let payment = block_on_f01(coin.send_maker_payment(maker_payment_args)).unwrap();
+    let payment = block_on(coin.send_maker_payment(maker_payment_args)).unwrap();
     let payment_tx_hash = payment.tx_hash_as_bytes();
     let payment_tx_hex = payment.tx_hex();
     log!("Maker payment: {:?}", payment_tx_hash);
@@ -558,7 +558,7 @@ fn test_search_for_swap_tx_spend_taker_spent() {
         watcher_reward: None,
         wait_for_confirmation_until: 0,
     };
-    let payment = block_on_f01(maker_coin.send_maker_payment(maker_payment_args)).unwrap();
+    let payment = block_on(maker_coin.send_maker_payment(maker_payment_args)).unwrap();
     let payment_tx_hash = payment.tx_hash_as_bytes();
     let payment_tx_hex = payment.tx_hex();
     log!("Maker payment: {:?}", payment_tx_hash);
@@ -637,7 +637,7 @@ fn test_search_for_swap_tx_spend_maker_refunded() {
         watcher_reward: None,
         wait_for_confirmation_until: 0,
     };
-    let payment = block_on_f01(maker_coin.send_maker_payment(maker_payment_args)).unwrap();
+    let payment = block_on(maker_coin.send_maker_payment(maker_payment_args)).unwrap();
     let payment_tx_hash = payment.tx_hash_as_bytes();
     let payment_tx_hex = payment.tx_hex();
     log!("Maker payment: {:?}", payment_tx_hash);
@@ -717,7 +717,7 @@ fn test_search_for_swap_tx_spend_not_spent() {
         watcher_reward: None,
         wait_for_confirmation_until: 0,
     };
-    let payment = block_on_f01(maker_coin.send_maker_payment(maker_payment_args)).unwrap();
+    let payment = block_on(maker_coin.send_maker_payment(maker_payment_args)).unwrap();
     let payment_tx_hash = payment.tx_hash_as_bytes();
     let payment_tx_hex = payment.tx_hex();
     log!("Maker payment: {:?}", payment_tx_hash);
@@ -774,7 +774,7 @@ fn test_wait_for_tx_spend() {
         watcher_reward: None,
         wait_for_confirmation_until: 0,
     };
-    let payment = block_on_f01(maker_coin.send_maker_payment(maker_payment_args)).unwrap();
+    let payment = block_on(maker_coin.send_maker_payment(maker_payment_args)).unwrap();
     let payment_tx_hash = payment.tx_hash_as_bytes();
     let payment_tx_hex = payment.tx_hex();
     log!("Maker payment: {:?}", payment_tx_hash);
@@ -1483,7 +1483,7 @@ fn test_search_for_segwit_swap_tx_spend_native_was_refunded_maker() {
         watcher_reward: None,
         wait_for_confirmation_until: 0,
     };
-    let tx = block_on_f01(coin.send_maker_payment(maker_payment)).unwrap();
+    let tx = block_on(coin.send_maker_payment(maker_payment)).unwrap();
 
     let confirm_payment_input = ConfirmPaymentInput {
         payment_tx: tx.tx_hex(),

--- a/mm2src/mm2_main/tests/docker_tests/swap_watcher_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/swap_watcher_tests.rs
@@ -2666,7 +2666,7 @@ fn test_taker_validates_maker_payment_spend_utxo() {
     let secret = generate_secret().unwrap();
     let secret_hash = dhash160(&secret);
 
-    let maker_payment = block_on_f01(maker_coin.send_maker_payment(SendPaymentArgs {
+    let maker_payment = block_on(maker_coin.send_maker_payment(SendPaymentArgs {
         time_lock_duration,
         time_lock,
         other_pubkey: taker_pubkey,
@@ -2752,7 +2752,7 @@ fn test_taker_validates_maker_payment_spend_eth() {
     .unwrap()
     .unwrap();
 
-    let maker_payment = block_on_f01(maker_coin.send_maker_payment(SendPaymentArgs {
+    let maker_payment = block_on(maker_coin.send_maker_payment(SendPaymentArgs {
         time_lock_duration,
         time_lock,
         other_pubkey: taker_pub,
@@ -3054,7 +3054,7 @@ fn test_taker_validates_maker_payment_spend_erc20() {
     ))
     .unwrap();
 
-    let maker_payment = block_on_f01(maker_coin.send_maker_payment(SendPaymentArgs {
+    let maker_payment = block_on(maker_coin.send_maker_payment(SendPaymentArgs {
         time_lock_duration,
         time_lock,
         other_pubkey: taker_pub,


### PR DESCRIPTION
This is needed for SIA. Will convert all other SwapOps trait methods to async in another PR after this is merged.