### PR TITLE
fix(evm): correctly display eth addr in iguana v2 activation result

### DIFF
--- a/mm2src/coins_activation/src/eth_with_token_activation.rs
+++ b/mm2src/coins_activation/src/eth_with_token_activation.rs
@@ -12,7 +12,7 @@ use coins::coin_balance::{CoinBalanceReport, EnableCoinBalanceOps};
 use coins::eth::v2_activation::{eth_coin_from_conf_and_request_v2, Erc20Protocol, Erc20TokenActivationRequest,
                                 EthActivationV2Error, EthActivationV2Request, EthPrivKeyActivationPolicy};
 use coins::eth::v2_activation::{EthTokenActivationError, NftActivationRequest, NftProviderEnum};
-use coins::eth::{Erc20TokenInfo, EthCoin, EthCoinType, EthPrivKeyBuildPolicy};
+use coins::eth::{display_eth_address, Erc20TokenInfo, EthCoin, EthCoinType, EthPrivKeyBuildPolicy};
 use coins::hd_wallet::RpcTaskXPubExtractor;
 use coins::my_tx_history_v2::TxHistoryStorage;
 use coins::nft::nft_structs::NftInfo;
@@ -360,8 +360,11 @@ impl PlatformCoinWithTokensActivationOps for EthCoin {
                     return Ok(EthWithTokensActivationResult::Iguana(
                         IguanaEthWithTokensActivationResult {
                             current_block,
-                            eth_addresses_infos: HashMap::from([(my_address.to_string(), eth_address_info)]),
-                            erc20_addresses_infos: HashMap::from([(my_address.to_string(), erc20_address_info)]),
+                            eth_addresses_infos: HashMap::from([(display_eth_address(my_address), eth_address_info)]),
+                            erc20_addresses_infos: HashMap::from([(
+                                display_eth_address(my_address),
+                                erc20_address_info,
+                            )]),
                             nfts_infos: nfts_map,
                         },
                     ));
@@ -385,8 +388,8 @@ impl PlatformCoinWithTokensActivationOps for EthCoin {
                 Ok(EthWithTokensActivationResult::Iguana(
                     IguanaEthWithTokensActivationResult {
                         current_block,
-                        eth_addresses_infos: HashMap::from([(my_address.to_string(), eth_address_info)]),
-                        erc20_addresses_infos: HashMap::from([(my_address.to_string(), erc20_address_info)]),
+                        eth_addresses_infos: HashMap::from([(display_eth_address(my_address), eth_address_info)]),
+                        erc20_addresses_infos: HashMap::from([(display_eth_address(my_address), erc20_address_info)]),
                         nfts_infos: nfts_map,
                     },
                 ))


### PR DESCRIPTION
without `display_eth_address`
```log
0xAA36D...38cc4
```

with `display_eth_address`
```log
0xAA36D90C59aB32C743C5570476b7676385838cc4
```