### PR TITLE
fix(hd-wallet): use `CoinBalanceMap` for UTXO and QTUM

### DIFF
--- a/mm2src/coins/rpc_command/account_balance.rs
+++ b/mm2src/coins/rpc_command/account_balance.rs
@@ -63,10 +63,10 @@ pub async fn account_balance(
     req: HDAccountBalanceRequest,
 ) -> MmResult<HDAccountBalanceResponseEnum, HDAccountBalanceRpcError> {
     match lp_coinfind_or_err(&ctx, &req.coin).await? {
-        MmCoinEnum::UtxoCoin(utxo) => Ok(HDAccountBalanceResponseEnum::Single(
+        MmCoinEnum::UtxoCoin(utxo) => Ok(HDAccountBalanceResponseEnum::Map(
             utxo.account_balance_rpc(req.params).await?,
         )),
-        MmCoinEnum::QtumCoin(qtum) => Ok(HDAccountBalanceResponseEnum::Single(
+        MmCoinEnum::QtumCoin(qtum) => Ok(HDAccountBalanceResponseEnum::Map(
             qtum.account_balance_rpc(req.params).await?,
         )),
         MmCoinEnum::EthCoin(eth) => Ok(HDAccountBalanceResponseEnum::Map(

--- a/mm2src/coins/rpc_command/get_new_address.rs
+++ b/mm2src/coins/rpc_command/get_new_address.rs
@@ -320,7 +320,7 @@ impl RpcTask for InitGetNewAddressTask {
         }
 
         match self.coin {
-            MmCoinEnum::UtxoCoin(ref utxo) => Ok(GetNewAddressResponseEnum::Single(
+            MmCoinEnum::UtxoCoin(ref utxo) => Ok(GetNewAddressResponseEnum::Map(
                 get_new_address_helper(
                     &self.ctx,
                     utxo,
@@ -330,7 +330,7 @@ impl RpcTask for InitGetNewAddressTask {
                 )
                 .await?,
             )),
-            MmCoinEnum::QtumCoin(ref qtum) => Ok(GetNewAddressResponseEnum::Single(
+            MmCoinEnum::QtumCoin(ref qtum) => Ok(GetNewAddressResponseEnum::Map(
                 get_new_address_helper(
                     &self.ctx,
                     qtum,
@@ -362,10 +362,10 @@ pub async fn get_new_address(
 ) -> MmResult<GetNewAddressResponseEnum, GetNewAddressRpcError> {
     let coin = lp_coinfind_or_err(&ctx, &req.coin).await?;
     match coin {
-        MmCoinEnum::UtxoCoin(utxo) => Ok(GetNewAddressResponseEnum::Single(
+        MmCoinEnum::UtxoCoin(utxo) => Ok(GetNewAddressResponseEnum::Map(
             utxo.get_new_address_rpc_without_conf(req.params).await?,
         )),
-        MmCoinEnum::QtumCoin(qtum) => Ok(GetNewAddressResponseEnum::Single(
+        MmCoinEnum::QtumCoin(qtum) => Ok(GetNewAddressResponseEnum::Map(
             qtum.get_new_address_rpc_without_conf(req.params).await?,
         )),
         MmCoinEnum::EthCoin(eth) => Ok(GetNewAddressResponseEnum::Map(

--- a/mm2src/coins/rpc_command/init_account_balance.rs
+++ b/mm2src/coins/rpc_command/init_account_balance.rs
@@ -73,10 +73,10 @@ impl RpcTask for InitAccountBalanceTask {
         _task_handle: InitAccountBalanceTaskHandleShared,
     ) -> Result<Self::Item, MmError<Self::Error>> {
         match self.coin {
-            MmCoinEnum::UtxoCoin(ref utxo) => Ok(HDAccountBalanceEnum::Single(
+            MmCoinEnum::UtxoCoin(ref utxo) => Ok(HDAccountBalanceEnum::Map(
                 utxo.init_account_balance_rpc(self.req.params.clone()).await?,
             )),
-            MmCoinEnum::QtumCoin(ref qtum) => Ok(HDAccountBalanceEnum::Single(
+            MmCoinEnum::QtumCoin(ref qtum) => Ok(HDAccountBalanceEnum::Map(
                 qtum.init_account_balance_rpc(self.req.params.clone()).await?,
             )),
             MmCoinEnum::EthCoin(ref eth) => Ok(HDAccountBalanceEnum::Map(

--- a/mm2src/coins/rpc_command/init_create_account.rs
+++ b/mm2src/coins/rpc_command/init_create_account.rs
@@ -286,7 +286,7 @@ impl RpcTask for InitCreateAccountTask {
         }
 
         match self.coin {
-            MmCoinEnum::UtxoCoin(ref utxo) => Ok(HDAccountBalanceEnum::Single(
+            MmCoinEnum::UtxoCoin(ref utxo) => Ok(HDAccountBalanceEnum::Map(
                 create_new_account_helper(
                     &self.ctx,
                     utxo,
@@ -298,7 +298,7 @@ impl RpcTask for InitCreateAccountTask {
                 )
                 .await?,
             )),
-            MmCoinEnum::QtumCoin(ref qtum) => Ok(HDAccountBalanceEnum::Single(
+            MmCoinEnum::QtumCoin(ref qtum) => Ok(HDAccountBalanceEnum::Map(
                 create_new_account_helper(
                     &self.ctx,
                     qtum,

--- a/mm2src/coins/rpc_command/init_scan_for_new_addresses.rs
+++ b/mm2src/coins/rpc_command/init_scan_for_new_addresses.rs
@@ -92,10 +92,10 @@ impl RpcTask for InitScanAddressesTask {
 
     async fn run(&mut self, _task_handle: ScanAddressesTaskHandleShared) -> Result<Self::Item, MmError<Self::Error>> {
         match self.coin {
-            MmCoinEnum::UtxoCoin(ref utxo) => Ok(ScanAddressesResponseEnum::Single(
+            MmCoinEnum::UtxoCoin(ref utxo) => Ok(ScanAddressesResponseEnum::Map(
                 utxo.init_scan_for_new_addresses_rpc(self.req.params.clone()).await?,
             )),
-            MmCoinEnum::QtumCoin(ref qtum) => Ok(ScanAddressesResponseEnum::Single(
+            MmCoinEnum::QtumCoin(ref qtum) => Ok(ScanAddressesResponseEnum::Map(
                 qtum.init_scan_for_new_addresses_rpc(self.req.params.clone()).await?,
             )),
             MmCoinEnum::EthCoin(ref eth) => Ok(ScanAddressesResponseEnum::Map(

--- a/mm2src/coins/utxo/bch.rs
+++ b/mm2src/coins/utxo/bch.rs
@@ -13,18 +13,18 @@ use crate::utxo::utxo_common::{big_decimal_from_sat_unsigned, utxo_prepare_addre
 use crate::utxo::utxo_hd_wallet::{UtxoHDAccount, UtxoHDAddress};
 use crate::utxo::utxo_tx_history_v2::{UtxoMyAddressesHistoryError, UtxoTxDetailsError, UtxoTxDetailsParams,
                                       UtxoTxHistoryOps};
-use crate::{coin_balance, BlockHeightAndTime, CanRefundHtlc, CheckIfMyPaymentSentArgs, CoinBalance, CoinProtocol,
-            CoinWithDerivationMethod, CoinWithPrivKeyPolicy, ConfirmPaymentInput, DexFee, GetWithdrawSenderAddress,
-            IguanaBalanceOps, IguanaPrivKey, MakerSwapTakerCoin, MmCoinEnum, NegotiateSwapContractAddrErr,
-            PaymentInstructionArgs, PaymentInstructions, PaymentInstructionsErr, PrivKeyBuildPolicy,
-            RawTransactionFut, RawTransactionRequest, RawTransactionResult, RefundError, RefundPaymentArgs,
-            RefundResult, SearchForSwapTxSpendInput, SendMakerPaymentSpendPreimageInput, SendPaymentArgs,
-            SignRawTransactionRequest, SignatureResult, SpendPaymentArgs, SwapOps, TakerSwapMakerCoin,
-            TradePreimageValue, TransactionFut, TransactionResult, TransactionType, TxFeeDetails, TxMarshalingErr,
-            UnexpectedDerivationMethod, ValidateAddressResult, ValidateFeeArgs, ValidateInstructionsErr,
-            ValidateOtherPubKeyErr, ValidatePaymentError, ValidatePaymentFut, ValidatePaymentInput,
-            ValidateWatcherSpendInput, VerificationResult, WaitForHTLCTxSpendArgs, WatcherOps, WatcherReward,
-            WatcherRewardError, WatcherSearchForSwapTxSpendInput, WatcherValidatePaymentInput,
+use crate::{coin_balance, BlockHeightAndTime, CanRefundHtlc, CheckIfMyPaymentSentArgs, CoinBalance, CoinBalanceMap,
+            CoinProtocol, CoinWithDerivationMethod, CoinWithPrivKeyPolicy, ConfirmPaymentInput, DexFee,
+            GetWithdrawSenderAddress, IguanaBalanceOps, IguanaPrivKey, MakerSwapTakerCoin, MmCoinEnum,
+            NegotiateSwapContractAddrErr, PaymentInstructionArgs, PaymentInstructions, PaymentInstructionsErr,
+            PrivKeyBuildPolicy, RawTransactionFut, RawTransactionRequest, RawTransactionResult, RefundError,
+            RefundPaymentArgs, RefundResult, SearchForSwapTxSpendInput, SendMakerPaymentSpendPreimageInput,
+            SendPaymentArgs, SignRawTransactionRequest, SignatureResult, SpendPaymentArgs, SwapOps,
+            TakerSwapMakerCoin, TradePreimageValue, TransactionFut, TransactionResult, TransactionType, TxFeeDetails,
+            TxMarshalingErr, UnexpectedDerivationMethod, ValidateAddressResult, ValidateFeeArgs,
+            ValidateInstructionsErr, ValidateOtherPubKeyErr, ValidatePaymentError, ValidatePaymentFut,
+            ValidatePaymentInput, ValidateWatcherSpendInput, VerificationResult, WaitForHTLCTxSpendArgs, WatcherOps,
+            WatcherReward, WatcherRewardError, WatcherSearchForSwapTxSpendInput, WatcherValidatePaymentInput,
             WatcherValidateTakerFeeInput, WithdrawFut};
 use common::executor::{AbortableSystem, AbortedError};
 use common::log::warn;
@@ -1450,7 +1450,7 @@ impl HDCoinWithdrawOps for BchCoin {}
 #[async_trait]
 impl HDWalletBalanceOps for BchCoin {
     type HDAddressScanner = UtxoAddressScanner;
-    type BalanceObject = CoinBalance;
+    type BalanceObject = CoinBalanceMap;
 
     async fn produce_hd_address_scanner(&self) -> BalanceResult<Self::HDAddressScanner> {
         utxo_common::produce_hd_address_scanner(self).await
@@ -1487,7 +1487,8 @@ impl HDWalletBalanceOps for BchCoin {
     }
 
     async fn known_address_balance(&self, address: &Address) -> BalanceResult<Self::BalanceObject> {
-        utxo_common::address_balance(self, address).await
+        let balance = utxo_common::address_balance(self, address).await?;
+        Ok(HashMap::from([(self.ticker().to_string(), balance)]))
     }
 
     async fn known_addresses_balances(

--- a/mm2src/coins/utxo/bch.rs
+++ b/mm2src/coins/utxo/bch.rs
@@ -1495,7 +1495,17 @@ impl HDWalletBalanceOps for BchCoin {
         &self,
         addresses: Vec<Address>,
     ) -> BalanceResult<Vec<(Address, Self::BalanceObject)>> {
-        utxo_common::addresses_balances(self, addresses).await
+        let ticker = self.ticker().to_string();
+        let balances = utxo_common::addresses_balances(self, addresses).await?;
+
+        balances
+            .into_iter()
+            .map(|(address, balance)| {
+                let mut balance_by_ticker = HashMap::with_capacity(1);
+                balance_by_ticker.insert(ticker.clone(), balance);
+                Ok((address, balance_by_ticker))
+            })
+            .collect()
     }
 
     async fn prepare_addresses_for_balance_stream_if_enabled(

--- a/mm2src/coins/utxo/bch.rs
+++ b/mm2src/coins/utxo/bch.rs
@@ -1500,11 +1500,7 @@ impl HDWalletBalanceOps for BchCoin {
 
         balances
             .into_iter()
-            .map(|(address, balance)| {
-                let mut balance_by_ticker = HashMap::with_capacity(1);
-                balance_by_ticker.insert(ticker.clone(), balance);
-                Ok((address, balance_by_ticker))
-            })
+            .map(|(address, balance)| Ok((address, HashMap::from([(ticker.clone(), balance)]))))
             .collect()
     }
 

--- a/mm2src/coins/utxo/qtum.rs
+++ b/mm2src/coins/utxo/qtum.rs
@@ -23,7 +23,7 @@ use crate::utxo::utxo_builder::{MergeUtxoArcOps, UtxoCoinBuildError, UtxoCoinBui
 use crate::utxo::utxo_hd_wallet::{UtxoHDAccount, UtxoHDAddress};
 use crate::utxo::utxo_tx_history_v2::{UtxoMyAddressesHistoryError, UtxoTxDetailsError, UtxoTxDetailsParams,
                                       UtxoTxHistoryOps};
-use crate::{eth, CanRefundHtlc, CheckIfMyPaymentSentArgs, CoinBalance, CoinWithDerivationMethod,
+use crate::{eth, CanRefundHtlc, CheckIfMyPaymentSentArgs, CoinBalance, CoinBalanceMap, CoinWithDerivationMethod,
             CoinWithPrivKeyPolicy, ConfirmPaymentInput, DelegationError, DelegationFut, DexFee,
             GetWithdrawSenderAddress, IguanaBalanceOps, IguanaPrivKey, MakerSwapTakerCoin, MmCoinEnum,
             NegotiateSwapContractAddrErr, PaymentInstructionArgs, PaymentInstructions, PaymentInstructionsErr,
@@ -1062,9 +1062,12 @@ impl CoinWithDerivationMethod for QtumCoin {
 
 #[async_trait]
 impl IguanaBalanceOps for QtumCoin {
-    type BalanceObject = CoinBalance;
+    type BalanceObject = CoinBalanceMap;
 
-    async fn iguana_balances(&self) -> BalanceResult<Self::BalanceObject> { self.my_balance().compat().await }
+    async fn iguana_balances(&self) -> BalanceResult<Self::BalanceObject> {
+        let balance = self.my_balance().compat().await?;
+        Ok(HashMap::from([(self.ticker().to_string(), balance)]))
+    }
 }
 
 #[async_trait]
@@ -1103,7 +1106,7 @@ impl HDCoinWithdrawOps for QtumCoin {}
 #[async_trait]
 impl HDWalletBalanceOps for QtumCoin {
     type HDAddressScanner = UtxoAddressScanner;
-    type BalanceObject = CoinBalance;
+    type BalanceObject = CoinBalanceMap;
 
     async fn produce_hd_address_scanner(&self) -> BalanceResult<Self::HDAddressScanner> {
         utxo_common::produce_hd_address_scanner(self).await
@@ -1140,7 +1143,8 @@ impl HDWalletBalanceOps for QtumCoin {
     }
 
     async fn known_address_balance(&self, address: &Address) -> BalanceResult<Self::BalanceObject> {
-        utxo_common::address_balance(self, address).await
+        let balance = utxo_common::address_balance(self, address).await?;
+        Ok(HashMap::from([(self.ticker().to_string(), balance)]))
     }
 
     async fn known_addresses_balances(
@@ -1160,7 +1164,7 @@ impl HDWalletBalanceOps for QtumCoin {
 
 #[async_trait]
 impl GetNewAddressRpcOps for QtumCoin {
-    type BalanceObject = CoinBalance;
+    type BalanceObject = CoinBalanceMap;
 
     async fn get_new_address_rpc_without_conf(
         &self,
@@ -1183,7 +1187,7 @@ impl GetNewAddressRpcOps for QtumCoin {
 
 #[async_trait]
 impl AccountBalanceRpcOps for QtumCoin {
-    type BalanceObject = CoinBalance;
+    type BalanceObject = CoinBalanceMap;
 
     async fn account_balance_rpc(
         &self,
@@ -1195,7 +1199,7 @@ impl AccountBalanceRpcOps for QtumCoin {
 
 #[async_trait]
 impl InitAccountBalanceRpcOps for QtumCoin {
-    type BalanceObject = CoinBalance;
+    type BalanceObject = CoinBalanceMap;
 
     async fn init_account_balance_rpc(
         &self,
@@ -1207,7 +1211,7 @@ impl InitAccountBalanceRpcOps for QtumCoin {
 
 #[async_trait]
 impl InitScanAddressesRpcOps for QtumCoin {
-    type BalanceObject = CoinBalance;
+    type BalanceObject = CoinBalanceMap;
 
     async fn init_scan_for_new_addresses_rpc(
         &self,
@@ -1219,7 +1223,7 @@ impl InitScanAddressesRpcOps for QtumCoin {
 
 #[async_trait]
 impl InitCreateAccountRpcOps for QtumCoin {
-    type BalanceObject = CoinBalance;
+    type BalanceObject = CoinBalanceMap;
 
     async fn init_create_account_rpc<XPubExtractor>(
         &self,

--- a/mm2src/coins/utxo/qtum.rs
+++ b/mm2src/coins/utxo/qtum.rs
@@ -1151,7 +1151,17 @@ impl HDWalletBalanceOps for QtumCoin {
         &self,
         addresses: Vec<Address>,
     ) -> BalanceResult<Vec<(Address, Self::BalanceObject)>> {
-        utxo_common::addresses_balances(self, addresses).await
+        let ticker = self.ticker().to_string();
+        let balances = utxo_common::addresses_balances(self, addresses).await?;
+
+        balances
+            .into_iter()
+            .map(|(address, balance)| {
+                let mut balance_by_ticker = HashMap::with_capacity(1);
+                balance_by_ticker.insert(ticker.clone(), balance);
+                Ok((address, balance_by_ticker))
+            })
+            .collect()
     }
 
     async fn prepare_addresses_for_balance_stream_if_enabled(

--- a/mm2src/coins/utxo/qtum.rs
+++ b/mm2src/coins/utxo/qtum.rs
@@ -1156,11 +1156,7 @@ impl HDWalletBalanceOps for QtumCoin {
 
         balances
             .into_iter()
-            .map(|(address, balance)| {
-                let mut balance_by_ticker = HashMap::with_capacity(1);
-                balance_by_ticker.insert(ticker.clone(), balance);
-                Ok((address, balance_by_ticker))
-            })
+            .map(|(address, balance)| Ok((address, HashMap::from([(ticker.clone(), balance)]))))
             .collect()
     }
 

--- a/mm2src/coins/utxo/rpc_clients/electrum_rpc/connection.rs
+++ b/mm2src/coins/utxo/rpc_clients/electrum_rpc/connection.rs
@@ -386,11 +386,15 @@ impl ElectrumConnection {
                 };
 
                 let Some(dns_name) = uri.host().map(String::from) else {
-                    return Err(ElectrumConnectionErr::Irrecoverable("Couldn't retrieve host from address".to_string()));
+                    return Err(ElectrumConnectionErr::Irrecoverable(
+                        "Couldn't retrieve host from address".to_string(),
+                    ));
                 };
 
                 let Ok(dns) = server_name_from_domain(dns_name.as_str()) else {
-                    return Err(ElectrumConnectionErr::Irrecoverable("Address isn't a valid domain name".to_string()));
+                    return Err(ElectrumConnectionErr::Irrecoverable(
+                        "Address isn't a valid domain name".to_string(),
+                    ));
                 };
 
                 let tls_connector = if connection.settings.disable_cert_verification {

--- a/mm2src/coins/utxo/utxo_common.rs
+++ b/mm2src/coins/utxo/utxo_common.rs
@@ -12,14 +12,14 @@ use crate::utxo::tx_cache::TxCacheResult;
 use crate::utxo::utxo_hd_wallet::UtxoHDAddress;
 use crate::utxo::utxo_withdraw::{InitUtxoWithdraw, StandardUtxoWithdraw, UtxoWithdraw};
 use crate::watcher_common::validate_watcher_reward;
-use crate::{scan_for_new_addresses_impl, CanRefundHtlc, CoinBalance, CoinBalanceMap, CoinWithDerivationMethod,
-            ConfirmPaymentInput, DexFee, GenPreimageResult, GenTakerFundingSpendArgs, GenTakerPaymentSpendArgs,
-            GetWithdrawSenderAddress, RawTransactionError, RawTransactionRequest, RawTransactionRes,
-            RawTransactionResult, RefundFundingSecretArgs, RefundMakerPaymentSecretArgs, RefundPaymentArgs,
-            RewardTarget, SearchForSwapTxSpendInput, SendMakerPaymentArgs, SendMakerPaymentSpendPreimageInput,
-            SendPaymentArgs, SendTakerFundingArgs, SignRawTransactionEnum, SignRawTransactionRequest,
-            SignUtxoTransactionParams, SignatureError, SignatureResult, SpendMakerPaymentArgs, SpendPaymentArgs,
-            SwapOps, SwapTxTypeWithSecretHash, TradePreimageValue, TransactionData, TransactionFut, TransactionResult,
+use crate::{scan_for_new_addresses_impl, CanRefundHtlc, CoinBalance, CoinWithDerivationMethod, ConfirmPaymentInput,
+            DexFee, GenPreimageResult, GenTakerFundingSpendArgs, GenTakerPaymentSpendArgs, GetWithdrawSenderAddress,
+            RawTransactionError, RawTransactionRequest, RawTransactionRes, RawTransactionResult,
+            RefundFundingSecretArgs, RefundMakerPaymentSecretArgs, RefundPaymentArgs, RewardTarget,
+            SearchForSwapTxSpendInput, SendMakerPaymentArgs, SendMakerPaymentSpendPreimageInput, SendPaymentArgs,
+            SendTakerFundingArgs, SignRawTransactionEnum, SignRawTransactionRequest, SignUtxoTransactionParams,
+            SignatureError, SignatureResult, SpendMakerPaymentArgs, SpendPaymentArgs, SwapOps,
+            SwapTxTypeWithSecretHash, TradePreimageValue, TransactionData, TransactionFut, TransactionResult,
             TxFeeDetails, TxGenError, TxMarshalingErr, TxPreimageWithSig, ValidateAddressResult,
             ValidateOtherPubKeyErr, ValidatePaymentFut, ValidatePaymentInput, ValidateSwapV2TxError,
             ValidateSwapV2TxResult, ValidateTakerFundingArgs, ValidateTakerFundingSpendPreimageError,
@@ -230,7 +230,7 @@ where
 
 /// Requests balances of the given `addresses`.
 /// The pairs `(Address, CoinBalance)` are guaranteed to be in the same order in which they were requested.
-pub async fn addresses_balances<T>(coin: &T, addresses: Vec<Address>) -> BalanceResult<Vec<(Address, CoinBalanceMap)>>
+pub async fn addresses_balances<T>(coin: &T, addresses: Vec<Address>) -> BalanceResult<Vec<(Address, CoinBalance)>>
 where
     T: UtxoCommonOps + GetUtxoMapOps + MarketCoinOps,
 {
@@ -244,7 +244,7 @@ where
                     BalanceError::Internal(error)
                 })?;
                 let balance = unspents.to_coin_balance(coin.as_ref().decimals);
-                Ok((address, HashMap::from([(coin.ticker().to_string(), balance)])))
+                Ok((address, balance))
             })
             .collect()
     } else {
@@ -258,7 +258,7 @@ where
             .map(|(address, spendable)| {
                 let unspendable = BigDecimal::from(0);
                 let balance = CoinBalance { spendable, unspendable };
-                (address, HashMap::from([(coin.ticker().to_string(), balance)]))
+                (address, balance)
             })
             .collect())
     }

--- a/mm2src/coins/utxo/utxo_common.rs
+++ b/mm2src/coins/utxo/utxo_common.rs
@@ -12,14 +12,14 @@ use crate::utxo::tx_cache::TxCacheResult;
 use crate::utxo::utxo_hd_wallet::UtxoHDAddress;
 use crate::utxo::utxo_withdraw::{InitUtxoWithdraw, StandardUtxoWithdraw, UtxoWithdraw};
 use crate::watcher_common::validate_watcher_reward;
-use crate::{scan_for_new_addresses_impl, CanRefundHtlc, CoinBalance, CoinWithDerivationMethod, ConfirmPaymentInput,
-            DexFee, GenPreimageResult, GenTakerFundingSpendArgs, GenTakerPaymentSpendArgs, GetWithdrawSenderAddress,
-            RawTransactionError, RawTransactionRequest, RawTransactionRes, RawTransactionResult,
-            RefundFundingSecretArgs, RefundMakerPaymentSecretArgs, RefundPaymentArgs, RewardTarget,
-            SearchForSwapTxSpendInput, SendMakerPaymentArgs, SendMakerPaymentSpendPreimageInput, SendPaymentArgs,
-            SendTakerFundingArgs, SignRawTransactionEnum, SignRawTransactionRequest, SignUtxoTransactionParams,
-            SignatureError, SignatureResult, SpendMakerPaymentArgs, SpendPaymentArgs, SwapOps,
-            SwapTxTypeWithSecretHash, TradePreimageValue, TransactionData, TransactionFut, TransactionResult,
+use crate::{scan_for_new_addresses_impl, CanRefundHtlc, CoinBalance, CoinBalanceMap, CoinWithDerivationMethod,
+            ConfirmPaymentInput, DexFee, GenPreimageResult, GenTakerFundingSpendArgs, GenTakerPaymentSpendArgs,
+            GetWithdrawSenderAddress, RawTransactionError, RawTransactionRequest, RawTransactionRes,
+            RawTransactionResult, RefundFundingSecretArgs, RefundMakerPaymentSecretArgs, RefundPaymentArgs,
+            RewardTarget, SearchForSwapTxSpendInput, SendMakerPaymentArgs, SendMakerPaymentSpendPreimageInput,
+            SendPaymentArgs, SendTakerFundingArgs, SignRawTransactionEnum, SignRawTransactionRequest,
+            SignUtxoTransactionParams, SignatureError, SignatureResult, SpendMakerPaymentArgs, SpendPaymentArgs,
+            SwapOps, SwapTxTypeWithSecretHash, TradePreimageValue, TransactionData, TransactionFut, TransactionResult,
             TxFeeDetails, TxGenError, TxMarshalingErr, TxPreimageWithSig, ValidateAddressResult,
             ValidateOtherPubKeyErr, ValidatePaymentFut, ValidatePaymentInput, ValidateSwapV2TxError,
             ValidateSwapV2TxResult, ValidateTakerFundingArgs, ValidateTakerFundingSpendPreimageError,
@@ -230,7 +230,7 @@ where
 
 /// Requests balances of the given `addresses`.
 /// The pairs `(Address, CoinBalance)` are guaranteed to be in the same order in which they were requested.
-pub async fn addresses_balances<T>(coin: &T, addresses: Vec<Address>) -> BalanceResult<Vec<(Address, CoinBalance)>>
+pub async fn addresses_balances<T>(coin: &T, addresses: Vec<Address>) -> BalanceResult<Vec<(Address, CoinBalanceMap)>>
 where
     T: UtxoCommonOps + GetUtxoMapOps + MarketCoinOps,
 {
@@ -244,7 +244,7 @@ where
                     BalanceError::Internal(error)
                 })?;
                 let balance = unspents.to_coin_balance(coin.as_ref().decimals);
-                Ok((address, balance))
+                Ok((address, HashMap::from([(coin.ticker().to_string(), balance)])))
             })
             .collect()
     } else {
@@ -258,7 +258,7 @@ where
             .map(|(address, spendable)| {
                 let unspendable = BigDecimal::from(0);
                 let balance = CoinBalance { spendable, unspendable };
-                (address, balance)
+                (address, HashMap::from([(coin.ticker().to_string(), balance)]))
             })
             .collect())
     }

--- a/mm2src/coins/utxo/utxo_standard.rs
+++ b/mm2src/coins/utxo/utxo_standard.rs
@@ -1246,7 +1246,17 @@ impl HDWalletBalanceOps for UtxoStandardCoin {
         &self,
         addresses: Vec<Address>,
     ) -> BalanceResult<Vec<(Address, Self::BalanceObject)>> {
-        utxo_common::addresses_balances(self, addresses).await
+        let ticker = self.ticker().to_string();
+        let balances = utxo_common::addresses_balances(self, addresses).await?;
+
+        balances
+            .into_iter()
+            .map(|(address, balance)| {
+                let mut balance_by_ticker = HashMap::with_capacity(1);
+                balance_by_ticker.insert(ticker.clone(), balance);
+                Ok((address, balance_by_ticker))
+            })
+            .collect()
     }
 
     async fn prepare_addresses_for_balance_stream_if_enabled(

--- a/mm2src/coins/utxo/utxo_standard.rs
+++ b/mm2src/coins/utxo/utxo_standard.rs
@@ -22,23 +22,24 @@ use crate::utxo::utxo_builder::{UtxoArcBuilder, UtxoCoinBuilder};
 use crate::utxo::utxo_hd_wallet::{UtxoHDAccount, UtxoHDAddress};
 use crate::utxo::utxo_tx_history_v2::{UtxoMyAddressesHistoryError, UtxoTxDetailsError, UtxoTxDetailsParams,
                                       UtxoTxHistoryOps};
-use crate::{CanRefundHtlc, CheckIfMyPaymentSentArgs, CoinBalance, CoinWithDerivationMethod, CoinWithPrivKeyPolicy,
-            CommonSwapOpsV2, ConfirmPaymentInput, DexFee, FundingTxSpend, GenPreimageResult, GenTakerFundingSpendArgs,
-            GenTakerPaymentSpendArgs, GetWithdrawSenderAddress, IguanaBalanceOps, IguanaPrivKey, MakerCoinSwapOpsV2,
-            MakerSwapTakerCoin, MmCoinEnum, NegotiateSwapContractAddrErr, PaymentInstructionArgs, PaymentInstructions,
-            PaymentInstructionsErr, PrivKeyBuildPolicy, RawTransactionRequest, RawTransactionResult, RefundError,
-            RefundFundingSecretArgs, RefundMakerPaymentSecretArgs, RefundMakerPaymentTimelockArgs, RefundPaymentArgs,
-            RefundResult, RefundTakerPaymentArgs, SearchForFundingSpendErr, SearchForSwapTxSpendInput,
-            SendMakerPaymentArgs, SendMakerPaymentSpendPreimageInput, SendPaymentArgs, SendTakerFundingArgs,
-            SignRawTransactionRequest, SignatureResult, SpendMakerPaymentArgs, SpendPaymentArgs, SwapOps,
-            SwapTxTypeWithSecretHash, TakerCoinSwapOpsV2, TakerSwapMakerCoin, ToBytes, TradePreimageValue,
-            TransactionFut, TransactionResult, TxMarshalingErr, TxPreimageWithSig, ValidateAddressResult,
-            ValidateFeeArgs, ValidateInstructionsErr, ValidateMakerPaymentArgs, ValidateOtherPubKeyErr,
-            ValidatePaymentError, ValidatePaymentFut, ValidatePaymentInput, ValidateSwapV2TxResult,
-            ValidateTakerFundingArgs, ValidateTakerFundingSpendPreimageResult,
-            ValidateTakerPaymentSpendPreimageResult, ValidateWatcherSpendInput, VerificationResult,
-            WaitForHTLCTxSpendArgs, WaitForTakerPaymentSpendError, WatcherOps, WatcherReward, WatcherRewardError,
-            WatcherSearchForSwapTxSpendInput, WatcherValidatePaymentInput, WatcherValidateTakerFeeInput, WithdrawFut};
+use crate::{CanRefundHtlc, CheckIfMyPaymentSentArgs, CoinBalance, CoinBalanceMap, CoinWithDerivationMethod,
+            CoinWithPrivKeyPolicy, CommonSwapOpsV2, ConfirmPaymentInput, DexFee, FundingTxSpend, GenPreimageResult,
+            GenTakerFundingSpendArgs, GenTakerPaymentSpendArgs, GetWithdrawSenderAddress, IguanaBalanceOps,
+            IguanaPrivKey, MakerCoinSwapOpsV2, MakerSwapTakerCoin, MmCoinEnum, NegotiateSwapContractAddrErr,
+            PaymentInstructionArgs, PaymentInstructions, PaymentInstructionsErr, PrivKeyBuildPolicy,
+            RawTransactionRequest, RawTransactionResult, RefundError, RefundFundingSecretArgs,
+            RefundMakerPaymentSecretArgs, RefundMakerPaymentTimelockArgs, RefundPaymentArgs, RefundResult,
+            RefundTakerPaymentArgs, SearchForFundingSpendErr, SearchForSwapTxSpendInput, SendMakerPaymentArgs,
+            SendMakerPaymentSpendPreimageInput, SendPaymentArgs, SendTakerFundingArgs, SignRawTransactionRequest,
+            SignatureResult, SpendMakerPaymentArgs, SpendPaymentArgs, SwapOps, SwapTxTypeWithSecretHash,
+            TakerCoinSwapOpsV2, TakerSwapMakerCoin, ToBytes, TradePreimageValue, TransactionFut, TransactionResult,
+            TxMarshalingErr, TxPreimageWithSig, ValidateAddressResult, ValidateFeeArgs, ValidateInstructionsErr,
+            ValidateMakerPaymentArgs, ValidateOtherPubKeyErr, ValidatePaymentError, ValidatePaymentFut,
+            ValidatePaymentInput, ValidateSwapV2TxResult, ValidateTakerFundingArgs,
+            ValidateTakerFundingSpendPreimageResult, ValidateTakerPaymentSpendPreimageResult,
+            ValidateWatcherSpendInput, VerificationResult, WaitForHTLCTxSpendArgs, WaitForTakerPaymentSpendError,
+            WatcherOps, WatcherReward, WatcherRewardError, WatcherSearchForSwapTxSpendInput,
+            WatcherValidatePaymentInput, WatcherValidateTakerFeeInput, WithdrawFut};
 use common::executor::{AbortableSystem, AbortedError};
 use futures::{FutureExt, TryFutureExt};
 use mm2_metrics::MetricsArc;
@@ -1133,9 +1134,12 @@ impl CoinWithDerivationMethod for UtxoStandardCoin {
 
 #[async_trait]
 impl IguanaBalanceOps for UtxoStandardCoin {
-    type BalanceObject = CoinBalance;
+    type BalanceObject = CoinBalanceMap;
 
-    async fn iguana_balances(&self) -> BalanceResult<Self::BalanceObject> { self.my_balance().compat().await }
+    async fn iguana_balances(&self) -> BalanceResult<Self::BalanceObject> {
+        let balance = self.my_balance().compat().await?;
+        Ok(HashMap::from([(self.ticker().to_string(), balance)]))
+    }
 }
 
 #[async_trait]
@@ -1173,7 +1177,7 @@ impl HDCoinWithdrawOps for UtxoStandardCoin {}
 
 #[async_trait]
 impl GetNewAddressRpcOps for UtxoStandardCoin {
-    type BalanceObject = CoinBalance;
+    type BalanceObject = CoinBalanceMap;
 
     async fn get_new_address_rpc_without_conf(
         &self,
@@ -1197,7 +1201,7 @@ impl GetNewAddressRpcOps for UtxoStandardCoin {
 #[async_trait]
 impl HDWalletBalanceOps for UtxoStandardCoin {
     type HDAddressScanner = UtxoAddressScanner;
-    type BalanceObject = CoinBalance;
+    type BalanceObject = CoinBalanceMap;
 
     async fn produce_hd_address_scanner(&self) -> BalanceResult<Self::HDAddressScanner> {
         utxo_common::produce_hd_address_scanner(self).await
@@ -1234,7 +1238,8 @@ impl HDWalletBalanceOps for UtxoStandardCoin {
     }
 
     async fn known_address_balance(&self, address: &Address) -> BalanceResult<Self::BalanceObject> {
-        utxo_common::address_balance(self, address).await
+        let balance = utxo_common::address_balance(self, address).await?;
+        Ok(HashMap::from([(self.ticker().to_string(), balance)]))
     }
 
     async fn known_addresses_balances(
@@ -1254,7 +1259,7 @@ impl HDWalletBalanceOps for UtxoStandardCoin {
 
 #[async_trait]
 impl AccountBalanceRpcOps for UtxoStandardCoin {
-    type BalanceObject = CoinBalance;
+    type BalanceObject = CoinBalanceMap;
 
     async fn account_balance_rpc(
         &self,
@@ -1266,7 +1271,7 @@ impl AccountBalanceRpcOps for UtxoStandardCoin {
 
 #[async_trait]
 impl InitAccountBalanceRpcOps for UtxoStandardCoin {
-    type BalanceObject = CoinBalance;
+    type BalanceObject = CoinBalanceMap;
 
     async fn init_account_balance_rpc(
         &self,
@@ -1278,7 +1283,7 @@ impl InitAccountBalanceRpcOps for UtxoStandardCoin {
 
 #[async_trait]
 impl InitScanAddressesRpcOps for UtxoStandardCoin {
-    type BalanceObject = CoinBalance;
+    type BalanceObject = CoinBalanceMap;
 
     async fn init_scan_for_new_addresses_rpc(
         &self,
@@ -1290,7 +1295,7 @@ impl InitScanAddressesRpcOps for UtxoStandardCoin {
 
 #[async_trait]
 impl InitCreateAccountRpcOps for UtxoStandardCoin {
-    type BalanceObject = CoinBalance;
+    type BalanceObject = CoinBalanceMap;
 
     async fn init_create_account_rpc<XPubExtractor>(
         &self,

--- a/mm2src/coins/utxo/utxo_standard.rs
+++ b/mm2src/coins/utxo/utxo_standard.rs
@@ -1251,11 +1251,7 @@ impl HDWalletBalanceOps for UtxoStandardCoin {
 
         balances
             .into_iter()
-            .map(|(address, balance)| {
-                let mut balance_by_ticker = HashMap::with_capacity(1);
-                balance_by_ticker.insert(ticker.clone(), balance);
-                Ok((address, balance_by_ticker))
-            })
+            .map(|(address, balance)| Ok((address, HashMap::from([(ticker.clone(), balance)]))))
             .collect()
     }
 

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -27,9 +27,9 @@ use crate::utxo::utxo_common_tests::{self, utxo_coin_fields_for_test, utxo_coin_
 use crate::utxo::utxo_hd_wallet::UtxoHDAccount;
 use crate::utxo::utxo_standard::{utxo_standard_coin_with_priv_key, UtxoStandardCoin};
 use crate::utxo::utxo_tx_history_v2::{UtxoTxDetailsParams, UtxoTxHistoryOps};
-use crate::{BlockHeightAndTime, CoinBalance, ConfirmPaymentInput, DexFee, IguanaPrivKey, PrivKeyBuildPolicy,
-            SearchForSwapTxSpendInput, SpendPaymentArgs, StakingInfosDetails, SwapOps, TradePreimageValue,
-            TxFeeDetails, TxMarshalingErr, ValidateFeeArgs, INVALID_SENDER_ERR_LOG};
+use crate::{BlockHeightAndTime, CoinBalance, CoinBalanceMap, ConfirmPaymentInput, DexFee, IguanaPrivKey,
+            PrivKeyBuildPolicy, SearchForSwapTxSpendInput, SpendPaymentArgs, StakingInfosDetails, SwapOps,
+            TradePreimageValue, TxFeeDetails, TxMarshalingErr, ValidateFeeArgs, INVALID_SENDER_ERR_LOG};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::{WaitForHTLCTxSpendArgs, WithdrawFee};
 use chain::{BlockHeader, BlockHeaderBits, OutPoint};
@@ -3689,7 +3689,7 @@ fn test_qtum_with_check_utxo_maturity_false() {
 #[test]
 fn test_account_balance_rpc() {
     let mut addresses_map: HashMap<String, u64> = HashMap::new();
-    let mut balances_by_der_path: HashMap<String, HDAddressBalance<CoinBalance>> = HashMap::new();
+    let mut balances_by_der_path: HashMap<String, HDAddressBalance<CoinBalanceMap>> = HashMap::new();
 
     macro_rules! known_address {
         ($der_path:literal, $address:literal, $chain:expr, balance = $balance:literal) => {
@@ -3698,7 +3698,10 @@ fn test_account_balance_rpc() {
                 address: $address.to_string(),
                 derivation_path: RpcDerivationPath(DerivationPath::from_str($der_path).unwrap()),
                 chain: $chain,
-                balance: CoinBalance::new(BigDecimal::from($balance)),
+                balance: HashMap::from([(
+                    TEST_COIN_NAME.to_string(),
+                    CoinBalance::new(BigDecimal::from($balance)),
+                )]),
             })
         };
     }
@@ -3788,7 +3791,7 @@ fn test_account_balance_rpc() {
         account_index: 0,
         derivation_path: DerivationPath::from_str("m/44'/141'/0'").unwrap().into(),
         addresses: get_balances!("m/44'/141'/0'/0/0", "m/44'/141'/0'/0/1", "m/44'/141'/0'/0/2"),
-        page_balance: CoinBalance::new(BigDecimal::from(0)),
+        page_balance: HashMap::from([(coin.ticker().to_string(), CoinBalance::new(BigDecimal::from(0)))]),
         limit: 3,
         skipped: 0,
         total: 7,
@@ -3810,7 +3813,7 @@ fn test_account_balance_rpc() {
         account_index: 0,
         derivation_path: DerivationPath::from_str("m/44'/141'/0'").unwrap().into(),
         addresses: get_balances!("m/44'/141'/0'/0/3", "m/44'/141'/0'/0/4", "m/44'/141'/0'/0/5"),
-        page_balance: CoinBalance::new(BigDecimal::from(99)),
+        page_balance: HashMap::from([(coin.ticker().to_string(), CoinBalance::new(BigDecimal::from(99)))]),
         limit: 3,
         skipped: 3,
         total: 7,
@@ -3832,7 +3835,7 @@ fn test_account_balance_rpc() {
         account_index: 0,
         derivation_path: DerivationPath::from_str("m/44'/141'/0'").unwrap().into(),
         addresses: get_balances!("m/44'/141'/0'/0/6"),
-        page_balance: CoinBalance::new(BigDecimal::from(32)),
+        page_balance: HashMap::from([(coin.ticker().to_string(), CoinBalance::new(BigDecimal::from(32)))]),
         limit: 3,
         skipped: 6,
         total: 7,
@@ -3854,7 +3857,7 @@ fn test_account_balance_rpc() {
         account_index: 0,
         derivation_path: DerivationPath::from_str("m/44'/141'/0'").unwrap().into(),
         addresses: Vec::new(),
-        page_balance: CoinBalance::default(),
+        page_balance: HashMap::from([(coin.ticker().to_string(), CoinBalance::default())]),
         limit: 3,
         skipped: 7,
         total: 7,
@@ -3876,7 +3879,7 @@ fn test_account_balance_rpc() {
         account_index: 0,
         derivation_path: DerivationPath::from_str("m/44'/141'/0'").unwrap().into(),
         addresses: get_balances!("m/44'/141'/0'/1/1", "m/44'/141'/0'/1/2"),
-        page_balance: CoinBalance::new(BigDecimal::from(54)),
+        page_balance: HashMap::from([(coin.ticker().to_string(), CoinBalance::new(BigDecimal::from(54)))]),
         limit: 3,
         skipped: 1,
         total: 3,
@@ -3898,7 +3901,7 @@ fn test_account_balance_rpc() {
         account_index: 1,
         derivation_path: DerivationPath::from_str("m/44'/141'/1'").unwrap().into(),
         addresses: Vec::new(),
-        page_balance: CoinBalance::default(),
+        page_balance: HashMap::from([(coin.ticker().to_string(), CoinBalance::default())]),
         limit: 3,
         skipped: 0,
         total: 0,
@@ -3920,7 +3923,7 @@ fn test_account_balance_rpc() {
         account_index: 1,
         derivation_path: DerivationPath::from_str("m/44'/141'/1'").unwrap().into(),
         addresses: get_balances!("m/44'/141'/1'/1/0"),
-        page_balance: CoinBalance::new(BigDecimal::from(0)),
+        page_balance: HashMap::from([(coin.ticker().to_string(), CoinBalance::new(BigDecimal::from(0)))]),
         limit: 3,
         skipped: 0,
         total: 1,
@@ -3942,7 +3945,7 @@ fn test_account_balance_rpc() {
         account_index: 1,
         derivation_path: DerivationPath::from_str("m/44'/141'/1'").unwrap().into(),
         addresses: Vec::new(),
-        page_balance: CoinBalance::default(),
+        page_balance: HashMap::from([(coin.ticker().to_string(), CoinBalance::default())]),
         limit: 3,
         skipped: 1,
         total: 1,
@@ -3984,7 +3987,7 @@ fn test_scan_for_new_addresses() {
     // The list of addresses with a non-empty transaction history.
     let mut non_empty_addresses: HashSet<String> = HashSet::new();
     // The map of results by the addresses.
-    let mut balances_by_der_path: HashMap<String, HDAddressBalance<CoinBalance>> = HashMap::new();
+    let mut balances_by_der_path: HashMap<String, HDAddressBalance<CoinBalanceMap>> = HashMap::new();
 
     macro_rules! new_address {
         ($der_path:literal, $address:literal, $chain:expr, balance = $balance:expr) => {{
@@ -3997,7 +4000,10 @@ fn test_scan_for_new_addresses() {
                 address: $address.to_string(),
                 derivation_path: RpcDerivationPath(DerivationPath::from_str($der_path).unwrap()),
                 chain: $chain,
-                balance: CoinBalance::new(BigDecimal::from($balance.unwrap_or(0i32))),
+                balance: HashMap::from([(
+                    TEST_COIN_NAME.to_string(),
+                    CoinBalance::new(BigDecimal::from($balance.unwrap_or(0i32))),
+                )]),
             });
         }};
     }

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -4000,12 +4000,9 @@ fn test_scan_for_new_addresses() {
                 address: $address.to_string(),
                 derivation_path: RpcDerivationPath(DerivationPath::from_str($der_path).unwrap()),
                 chain: $chain,
-                balance: match $balance {
-                    Some(balance) => {
-                        HashMap::from([(TEST_COIN_NAME.to_string(), CoinBalance::new(BigDecimal::from(balance)))])
-                    },
-                    None => HashMap::default(),
-                },
+                balance: $balance.map_or_else(HashMap::default, |balance| {
+                    HashMap::from([(TEST_COIN_NAME.to_string(), CoinBalance::new(BigDecimal::from(balance)))])
+                }),
             });
         }};
     }

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -3857,7 +3857,7 @@ fn test_account_balance_rpc() {
         account_index: 0,
         derivation_path: DerivationPath::from_str("m/44'/141'/0'").unwrap().into(),
         addresses: Vec::new(),
-        page_balance: HashMap::from([(coin.ticker().to_string(), CoinBalance::default())]),
+        page_balance: HashMap::default(),
         limit: 3,
         skipped: 7,
         total: 7,
@@ -3901,7 +3901,7 @@ fn test_account_balance_rpc() {
         account_index: 1,
         derivation_path: DerivationPath::from_str("m/44'/141'/1'").unwrap().into(),
         addresses: Vec::new(),
-        page_balance: HashMap::from([(coin.ticker().to_string(), CoinBalance::default())]),
+        page_balance: HashMap::default(),
         limit: 3,
         skipped: 0,
         total: 0,
@@ -3945,7 +3945,7 @@ fn test_account_balance_rpc() {
         account_index: 1,
         derivation_path: DerivationPath::from_str("m/44'/141'/1'").unwrap().into(),
         addresses: Vec::new(),
-        page_balance: HashMap::from([(coin.ticker().to_string(), CoinBalance::default())]),
+        page_balance: HashMap::default(),
         limit: 3,
         skipped: 1,
         total: 1,
@@ -4000,10 +4000,12 @@ fn test_scan_for_new_addresses() {
                 address: $address.to_string(),
                 derivation_path: RpcDerivationPath(DerivationPath::from_str($der_path).unwrap()),
                 chain: $chain,
-                balance: HashMap::from([(
-                    TEST_COIN_NAME.to_string(),
-                    CoinBalance::new(BigDecimal::from($balance.unwrap_or(0i32))),
-                )]),
+                balance: match $balance {
+                    Some(balance) => {
+                        HashMap::from([(TEST_COIN_NAME.to_string(), CoinBalance::new(BigDecimal::from(balance)))])
+                    },
+                    None => HashMap::default(),
+                },
             });
         }};
     }
@@ -4033,7 +4035,7 @@ fn test_scan_for_new_addresses() {
 
         // Account#0, internal addresses.
         new_address!("m/44'/141'/0'/1/1", "RPj9JXUVnewWwVpxZDeqGB25qVqz5qJzwP", Bip44Chain::Internal, balance = Some(98));
-        new_address!("m/44'/141'/0'/1/2", "RSYdSLRYWuzBson2GDbWBa632q2PmFnCaH", Bip44Chain::Internal, balance = None);
+        new_address!("m/44'/141'/0'/1/2", "RSYdSLRYWuzBson2GDbWBa632q2PmFnCaH", Bip44Chain::Internal, balance = None::<u64>);
         new_address!("m/44'/141'/0'/1/3", "RQstQeTUEZLh6c3YWJDkeVTTQoZUsfvNCr", Bip44Chain::Internal, balance = Some(14));
         unused_address!("m/44'/141'/0'/1/4", "RT54m6pfj9scqwSLmYdfbmPcrpxnWGAe9J");
         unused_address!("m/44'/141'/0'/1/5", "RYWfEFxqA6zya9c891Dj7vxiDojCmuWR9T");
@@ -4043,8 +4045,8 @@ fn test_scan_for_new_addresses() {
         // Account#1, external addresses.
         new_address!("m/44'/141'/1'/0/0", "RBQFLwJ88gVcnfkYvJETeTAB6AAYLow12K", Bip44Chain::External, balance = Some(9));
         new_address!("m/44'/141'/1'/0/1", "RCyy77sRWFa2oiFPpyimeTQfenM1aRoiZs", Bip44Chain::External, balance = Some(7));
-        new_address!("m/44'/141'/1'/0/2", "RDnNa3pQmisfi42KiTZrfYfuxkLC91PoTJ", Bip44Chain::External, balance = None);
-        new_address!("m/44'/141'/1'/0/3", "RQRGgXcGJz93CoAfQJoLgBz2r9HtJYMX3Z", Bip44Chain::External, balance = None);
+        new_address!("m/44'/141'/1'/0/2", "RDnNa3pQmisfi42KiTZrfYfuxkLC91PoTJ", Bip44Chain::External, balance = None::<u64>);
+        new_address!("m/44'/141'/1'/0/3", "RQRGgXcGJz93CoAfQJoLgBz2r9HtJYMX3Z", Bip44Chain::External, balance = None::<u64>);
         new_address!("m/44'/141'/1'/0/4", "RM6cqSFCFZ4J1LngLzqKkwo2ouipbDZUbm", Bip44Chain::External, balance = Some(11));
         unused_address!("m/44'/141'/1'/0/5", "RX2fGBZjNZMNdNcnc5QBRXvmsXTvadvTPN");
         unused_address!("m/44'/141'/1'/0/6", "RJJ7muUETyp59vxVXna9KAZ9uQ1QSqmcjE");

--- a/mm2src/coins_activation/src/utxo_activation/common_impl.rs
+++ b/mm2src/coins_activation/src/utxo_activation/common_impl.rs
@@ -8,7 +8,7 @@ use coins::hd_wallet::RpcTaskXPubExtractor;
 use coins::my_tx_history_v2::TxHistoryStorage;
 use coins::utxo::utxo_tx_history_v2::{utxo_history_loop, UtxoTxHistoryOps};
 use coins::utxo::{UtxoActivationParams, UtxoCoinFields};
-use coins::{CoinBalance, CoinFutSpawner, MarketCoinOps, PrivKeyActivationPolicy, PrivKeyBuildPolicy};
+use coins::{CoinBalanceMap, CoinFutSpawner, MarketCoinOps, PrivKeyActivationPolicy, PrivKeyBuildPolicy};
 use common::executor::{AbortSettings, SpawnAbortable};
 use crypto::hw_rpc_task::HwConnectStatuses;
 use crypto::{CryptoCtxError, HwRpcError};
@@ -31,7 +31,7 @@ where
             InProgressStatus = UtxoStandardInProgressStatus,
             AwaitingStatus = UtxoStandardAwaitingStatus,
             UserAction = UtxoStandardUserAction,
-        > + EnableCoinBalanceOps<BalanceObject = CoinBalance>
+        > + EnableCoinBalanceOps<BalanceObject = CoinBalanceMap>
         + MarketCoinOps,
 {
     let ticker = coin.ticker().to_owned();

--- a/mm2src/coins_activation/src/utxo_activation/utxo_standard_activation_result.rs
+++ b/mm2src/coins_activation/src/utxo_activation/utxo_standard_activation_result.rs
@@ -1,6 +1,6 @@
 use crate::prelude::{CurrentBlock, GetAddressesBalances};
 use coins::coin_balance::CoinBalanceReport;
-use coins::CoinBalance;
+use coins::CoinBalanceMap;
 use mm2_number::BigDecimal;
 use serde_derive::Serialize;
 use std::collections::HashMap;
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 pub struct UtxoStandardActivationResult {
     pub ticker: String,
     pub current_block: u64,
-    pub wallet_balance: CoinBalanceReport<CoinBalance>,
+    pub wallet_balance: CoinBalanceReport<CoinBalanceMap>,
 }
 
 impl CurrentBlock for UtxoStandardActivationResult {

--- a/mm2src/mm2_main/tests/integration_tests_common/mod.rs
+++ b/mm2src/mm2_main/tests/integration_tests_common/mod.rs
@@ -7,7 +7,7 @@ use mm2_rpc::data::legacy::CoinInitResponse;
 use mm2_test_helpers::electrums::{doc_electrums, marty_electrums};
 use mm2_test_helpers::for_tests::{create_new_account_status, enable_native as enable_native_impl,
                                   init_create_new_account, MarketMakerIt};
-use mm2_test_helpers::structs::{CreateNewAccountStatus, HDAccountAddressId, HDAccountBalance, InitTaskResult,
+use mm2_test_helpers::structs::{CreateNewAccountStatus, HDAccountAddressId, HDAccountBalanceMap, InitTaskResult,
                                 RpcV2Response};
 use serde_json::{self as json, Value as Json};
 use std::collections::HashMap;
@@ -99,7 +99,7 @@ pub async fn create_new_account(
     coin: &str,
     account_id: Option<u32>,
     timeout: u64,
-) -> HDAccountBalance {
+) -> HDAccountBalanceMap {
     let init = init_create_new_account(mm, coin, account_id).await;
     let init: RpcV2Response<InitTaskResult> = json::from_value(init).unwrap();
     let timeout = wait_until_ms(timeout * 1000);

--- a/mm2src/mm2_main/tests/mm2_tests/mm2_tests_inner.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/mm2_tests_inner.rs
@@ -5671,7 +5671,7 @@ fn test_enable_utxo_with_enable_hd() {
         None,
     ));
     let balance = match rick.wallet_balance {
-        EnableCoinBalance::HD(hd) => hd,
+        EnableCoinBalanceMap::HD(hd) => hd,
         _ => panic!("Expected EnableCoinBalance::HD"),
     };
     let account = balance.accounts.get(0).expect("Expected account at index 0");
@@ -5689,7 +5689,7 @@ fn test_enable_utxo_with_enable_hd() {
         None,
     ));
     let balance = match btc_segwit.wallet_balance {
-        EnableCoinBalance::HD(hd) => hd,
+        EnableCoinBalanceMap::HD(hd) => hd,
         _ => panic!("Expected EnableCoinBalance::HD"),
     };
     let account = balance.accounts.get(0).expect("Expected account at index 0");

--- a/mm2src/mm2_test_helpers/src/structs.rs
+++ b/mm2src/mm2_test_helpers/src/structs.rs
@@ -621,7 +621,7 @@ pub struct ZCoinActivationResult {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct GetNewAddressResponse {
-    pub new_address: HDAddressBalance,
+    pub new_address: HDAddressBalanceMap,
 }
 
 #[derive(Debug, Deserialize)]
@@ -629,8 +629,8 @@ pub struct GetNewAddressResponse {
 pub struct HDAccountBalanceResponse {
     pub account_index: u32,
     pub derivation_path: String,
-    pub addresses: Vec<HDAddressBalance>,
-    pub page_balance: CoinBalance,
+    pub addresses: Vec<HDAddressBalanceMap>,
+    pub page_balance: HashMap<String, CoinBalance>,
     pub limit: usize,
     pub skipped: u32,
     pub total: u32,
@@ -651,7 +651,7 @@ pub struct CoinActivationResult {
 pub struct UtxoStandardActivationResult {
     pub ticker: String,
     pub current_block: u64,
-    pub wallet_balance: EnableCoinBalance,
+    pub wallet_balance: EnableCoinBalanceMap,
 }
 
 #[derive(Debug, Deserialize)]
@@ -726,7 +726,7 @@ pub enum InitLightningStatus {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields, tag = "status", content = "details")]
 pub enum CreateNewAccountStatus {
-    Ok(HDAccountBalance),
+    Ok(HDAccountBalanceMap),
     Error(Json),
     InProgress(Json),
     UserActionRequired(Json),


### PR DESCRIPTION
This is to return the same type/json across all coins for GUI since EVM uses `CoinBalanceMap`, the balance for UTXO will show as
```json
"balance":{
   "KMD":{
      "spendable":"0",
      "unspendable":"0"
   }
}
```
instead of
```json
"balance":{
   "spendable":"0",
   "unspendable":"0"
}
```

**To Test:**
Already tested by @CharlVS