### PR TITLE
fix(tests): add more sepolia endpoints in tests

### DIFF
--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -241,7 +241,7 @@ pub const ETH_MAINNET_NODE: &str = "https://mainnet.infura.io/v3/c01c1b4cf666425
 pub const ETH_MAINNET_CHAIN_ID: u64 = 1;
 pub const ETH_MAINNET_SWAP_CONTRACT: &str = "0x24abe4c71fc658c91313b6552cd40cd808b3ea80";
 
-pub const ETH_SEPOLIA_NODES: &[&str] = &["https://rpc2.sepolia.org"];
+pub const ETH_SEPOLIA_NODES: &[&str] = &["https://ethereum-sepolia-rpc.publicnode.com","https://rpc2.sepolia.org","https://1rpc.io/sepolia"];
 pub const ETH_SEPOLIA_CHAIN_ID: u64 = 11155111;
 pub const ETH_SEPOLIA_SWAP_CONTRACT: &str = "0xeA6D65434A15377081495a9E7C5893543E7c32cB";
 pub const ETH_SEPOLIA_TOKEN_CONTRACT: &str = "0x09d0d71FBC00D7CCF9CFf132f5E6825C88293F19";


### PR DESCRIPTION
In current dev we use only one url in sepolia endpoints, which is experiencing issues right now:
`Failed to get client version for all urls`
```
failures:

---- mm2_tests::eth_tests::test_sign_eth_transaction stdout ----
04 10:22:29, for_tests:1547] sending rpc request {"userpass":"pass","method":"enable","coin":"ETH","urls":["https://rpc2.sepolia.org/"],"swap_contract_address":"0xeA6D65434A15377081495a9E7C5893543E7c32cB","mm2":1} to http://127.0.0.150:7783/
thread 'mm2_tests::eth_tests::test_sign_eth_transaction' panicked at 'assertion failed: `(left == right)`
  left: `500`,
 right: `200`: 'enable "ETH"' failed: {"error":"rpc:184] dispatcher_legacy:141] lp_commands_legacy:169] lp_coins:4463] eth:6530] Failed to get client version for all urls"}', mm2src/mm2_main/tests/mm2_tests/eth_tests.rs:75:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- mm2_tests::eth_tests::test_sign_eth_transaction_eip1559 stdout ----
04 10:22:30, for_tests:1547] sending rpc request {"userpass":"pass","method":"enable","coin":"ETH","urls":["https://rpc2.sepolia.org/"],"swap_contract_address":"0xeA6D65434A15377081495a9E7C5893543E7c32cB","mm2":1} to http://127.0.0.195:7783/
thread 'mm2_tests::eth_tests::test_sign_eth_transaction_eip1559' panicked at 'assertion failed: `(left == right)`
  left: `500`,
 right: `200`: 'enable "ETH"' failed: {"error":"rpc:184] dispatcher_legacy:141] lp_commands_legacy:169] lp_coins:4463] eth:6530] Failed to get client version for all urls"}', mm2src/mm2_main/tests/mm2_tests/eth_tests.rs:75:5

---- mm2_tests::mm2_tests_inner::test_convert_eth_address stdout ----
04 10:23:05, mm2_tests_inner:2682] log path: /var/folders/g6/rgtlsw6n123b0gt5483s5_cm0000gn/T/mm2_2024-11-04_10-23-05-131_127.0.0.84/mm2.log
04 10:23:05, for_tests:1547] sending rpc request {"userpass":"pass","method":"enable","coin":"ETH","urls":["https://rpc2.sepolia.org/"],"swap_contract_address":"0xeA6D65434A15377081495a9E7C5893543E7c32cB","path_to_address":{"account_id":0,"chain":"External","address_id":0},"mm2":1} to http://127.0.0.84:7783/
thread 'mm2_tests::mm2_tests_inner::test_convert_eth_address' panicked at 'assertion failed: `(left == right)`
  left: `500`,
 right: `200`: 'enable' failed: {"error":"rpc:184] dispatcher_legacy:141] lp_commands_legacy:169] lp_coins:4463] eth:6530] Failed to get client version for all urls"}', /Users/runner/work/komodo-defi-framework/komodo-defi-framework/mm2src/mm2_test_helpers/src/for_tests.rs:2003:5
```


This pr provides more urls.