### PR TITLE
fix(hd-wallet): correctly display evm addr in `get_new_address` response

### DIFF
--- a/mm2src/coins/rpc_command/get_new_address.rs
+++ b/mm2src/coins/rpc_command/get_new_address.rs
@@ -472,7 +472,7 @@ pub(crate) mod common_impl {
 
         Ok(GetNewAddressResponse {
             new_address: HDAddressBalance {
-                address: address.to_string(),
+                address: coin.address_formatter()(&address),
                 derivation_path: RpcDerivationPath(hd_address.derivation_path().clone()),
                 chain,
                 balance,
@@ -510,13 +510,14 @@ pub(crate) mod common_impl {
         let address = hd_address.address();
         let balance = coin.known_address_balance(&address).await?;
 
-        coin.prepare_addresses_for_balance_stream_if_enabled(HashSet::from([address.to_string()]))
+        let formatted_address = coin.address_formatter()(&address);
+        coin.prepare_addresses_for_balance_stream_if_enabled(HashSet::from([formatted_address.clone()]))
             .await
             .map_err(|e| GetNewAddressRpcError::FailedScripthashSubscription(e.to_string()))?;
 
         Ok(GetNewAddressResponse {
             new_address: HDAddressBalance {
-                address: address.to_string(),
+                address: formatted_address,
                 derivation_path: RpcDerivationPath(hd_address.derivation_path().clone()),
                 chain,
                 balance,

--- a/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
+++ b/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
@@ -17,11 +17,11 @@ use crypto::privkey::key_pair_from_seed;
 use crypto::{CryptoCtx, DerivationPath, KeyPairPolicy};
 use http::StatusCode;
 use mm2_number::{BigDecimal, BigRational, MmNumber};
-use mm2_test_helpers::for_tests::{check_my_swap_status_amounts, disable_coin, disable_coin_err, enable_eth_coin,
-                                  enable_eth_with_tokens_v2, erc20_dev_conf, eth_dev_conf, get_locked_amount,
-                                  kmd_conf, max_maker_vol, mm_dump, mycoin1_conf, mycoin_conf, set_price, start_swaps,
-                                  wait_for_swap_contract_negotiation, wait_for_swap_negotiation_failure,
-                                  MarketMakerIt, Mm2TestConf};
+use mm2_test_helpers::for_tests::{account_balance, check_my_swap_status_amounts, disable_coin, disable_coin_err,
+                                  enable_eth_coin, enable_eth_with_tokens_v2, erc20_dev_conf, eth_dev_conf,
+                                  get_locked_amount, get_new_address, kmd_conf, max_maker_vol, mm_dump, mycoin1_conf,
+                                  mycoin_conf, set_price, start_swaps, wait_for_swap_contract_negotiation,
+                                  wait_for_swap_negotiation_failure, MarketMakerIt, Mm2TestConf};
 use mm2_test_helpers::{get_passphrase, structs::*};
 use serde_json::Value as Json;
 use std::collections::{HashMap, HashSet};
@@ -5258,7 +5258,7 @@ fn test_sell_min_volume_dust() {
 }
 
 #[test]
-fn test_enable_eth_erc20_coins_with_enable_hd() {
+fn test_eth_erc20_hd() {
     const PASSPHRASE: &str = "tank abandon bind salon remove wisdom net size aspect direct source fossil";
 
     let coins = json!([eth_dev_conf(), erc20_dev_conf(&erc20_contract_checksum())]);
@@ -5335,6 +5335,21 @@ fn test_enable_eth_erc20_coins_with_enable_hd() {
     assert_eq!(account.addresses[0].balance.len(), 2);
     assert!(account.addresses[0].balance.contains_key("ETH"));
     assert!(account.addresses[0].balance.contains_key("ERC20DEV"));
+
+    let get_new_address = block_on(get_new_address(&mm_hd, "ETH", 0, Some(Bip44Chain::External)));
+    assert!(get_new_address.new_address.balance.contains_key("ETH"));
+    // Make sure balance is returned for any token enabled with ETH as platform coin
+    assert!(get_new_address.new_address.balance.contains_key("ERC20DEV"));
+    assert_eq!(
+        get_new_address.new_address.address,
+        "0x4249E165a68E4FF9C41B1C3C3b4245c30ecB43CC"
+    );
+    // Make sure that the address is also added to tokens
+    let account_balance = block_on(account_balance(&mm_hd, "ERC20DEV", 0, Bip44Chain::External));
+    assert_eq!(
+        account_balance.addresses[2].address,
+        "0x4249E165a68E4FF9C41B1C3C3b4245c30ecB43CC"
+    );
 
     block_on(mm_hd.stop()).unwrap();
 


### PR DESCRIPTION
**To Test:**
Nothing as it already tested by @CharlVS. No docs updates as well as the docs show the full address in response.