### PR TITLE
optimization(legacy-swap): support going the spending path on refund

### DIFF
--- a/mm2src/mm2_main/src/lp_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap.rs
@@ -475,7 +475,7 @@ pub struct RecoveredSwap {
     transaction: TransactionEnum,
 }
 
-#[derive(Display)]
+#[derive(Display, Debug, PartialEq)]
 pub enum RecoverSwapError {
     // We might not find the original payment tx on chain (e.g. re-orged). This doesn't mean though that nobody has it.
     // TODO: These coins should be spent ASAP to avoid them getting locked (or stolen).

--- a/mm2src/mm2_main/src/lp_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap.rs
@@ -475,6 +475,22 @@ pub struct RecoveredSwap {
     transaction: TransactionEnum,
 }
 
+#[derive(Display)]
+pub enum RecoverSwapError {
+    // We might not find the original payment tx on chain (e.g. re-orged). This doesn't mean though that nobody has it.
+    // TODO: These coins should be spent ASAP to avoid them getting locked (or stolen).
+    #[display(fmt = "The payment tx is not on-chain. Nothing to recover.")]
+    PaymentTxNotFound,
+    #[display(fmt = "An unknown error occurred. Retrying might fix it: {}", _0)]
+    Temporary(String),
+    #[display(fmt = "The swap is not recoverable: {}", _0)]
+    Irrecoverable(String),
+    #[display(fmt = "Wait {}s and try to recover again.", _0)]
+    WaitAndRetry(u64),
+    #[display(fmt = "The funds will be automatically recovered after lock-time: {}", _0)]
+    AutoRecoverableAfter(u64),
+}
+
 /// Represents the amount of a coin locked by ongoing swap
 #[derive(Debug)]
 pub struct LockedAmount {

--- a/mm2src/mm2_main/src/lp_swap/maker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap.rs
@@ -1187,7 +1187,6 @@ impl MakerSwap {
         ]))
     }
 
-    // fixme: turn this into a recover (forever lived, unless maker payment isn't on chain)
     async fn refund_maker_payment(&self) -> Result<(Option<MakerSwapCommand>, Vec<MakerSwapEvent>), String> {
         #[cfg(test)]
         if self.fail_at == Some(FailAt::MakerPaymentRefund) {
@@ -1196,91 +1195,88 @@ impl MakerSwap {
             ]));
         }
 
-        let maker_payment = self.r().maker_payment.clone().unwrap().tx_hex;
-        let locktime = self.r().data.maker_payment_lock;
-        if self.maker_coin.is_auto_refundable() {
-            return match self.maker_coin.wait_for_htlc_refund(&maker_payment, locktime).await {
-                Ok(()) => Ok((Some(MakerSwapCommand::FinalizeMakerPaymentRefund), vec![
-                    MakerSwapEvent::MakerPaymentRefunded(None),
-                ])),
-                Err(err) => Ok((Some(MakerSwapCommand::Finish), vec![
-                    MakerSwapEvent::MakerPaymentRefundFailed(
-                        ERRL!("!maker_coin.wait_for_htlc_refund: {}", err.to_string()).into(),
-                    ),
-                ])),
-            };
-        }
-
+        // Keep trying to recover funds (by refunding the maker payment or spending the taker payment) until successful or face an irrecoverable error.
         loop {
-            match self.maker_coin.can_refund_htlc(locktime).await {
-                Ok(CanRefundHtlc::CanRefundNow) => break,
-                Ok(CanRefundHtlc::HaveToWait(to_sleep)) => Timer::sleep(to_sleep as f64).await,
-                Err(e) => {
-                    error!("Error {} on can_refund_htlc, retrying in 30 seconds", e);
-                    Timer::sleep(30.).await;
+            match self.recover_funds().await {
+                // We recovered the swap successfully.
+                Ok(recovered_swap) => match recovered_swap {
+                    // We recovered the swap by refunding the maker payment.
+                    RecoveredSwap {
+                        action: RecoveredSwapAction::RefundedMyPayment,
+                        coin: _,
+                        transaction,
+                    } => {
+                        let tx_ident = TransactionIdentifier {
+                            tx_hex: transaction.tx_hex().into(),
+                            tx_hash: transaction.tx_hash_as_bytes(),
+                        };
+                        info!("Maker payment refund tx {:02x}", tx_ident.tx_hash);
+                        return Ok((Some(MakerSwapCommand::FinalizeMakerPaymentRefund), vec![
+                            MakerSwapEvent::MakerPaymentRefunded(Some(tx_ident)),
+                        ]));
+                    },
+                    // We recovered the swap by proceeding forward and spending the taker payment. The swap wasn't actually a failure.
+                    // Roll back to confirming the taker payment spend.
+                    RecoveredSwap {
+                        action: RecoveredSwapAction::SpentOtherPayment,
+                        coin: _,
+                        transaction,
+                    } => {
+                        let tx_ident = TransactionIdentifier {
+                            tx_hex: transaction.tx_hex().into(),
+                            tx_hash: transaction.tx_hash_as_bytes(),
+                        };
+                        info!("Refund canceled. Taker payment spend tx {:02x}", tx_ident.tx_hash);
+                        // TODO: We prepared for refund but didn't finalize refund. This must be breaking something for lightning.
+                        return Ok((Some(MakerSwapCommand::ConfirmTakerPaymentSpend), vec![
+                            MakerSwapEvent::TakerPaymentSpent(tx_ident),
+                            MakerSwapEvent::TakerPaymentSpendConfirmStarted,
+                        ]));
+                    },
+                },
+
+                // Encountered an error during swap recover.
+                Err(err) => match err {
+                    // The payment tx we want to refund isn't even on-chain. There is nothing to refund/spend.
+                    RecoverSwapError::PaymentTxNotFound => {
+                        return Ok((Some(MakerSwapCommand::Finish), vec![
+                            MakerSwapEvent::MakerPaymentRefundFailed(
+                                "MakerPayment isn't even on-chain to refund it.".into(),
+                            ),
+                        ]));
+                    },
+                    // The error is unrecoverable, retrying will not fix the issue.
+                    RecoverSwapError::Irrecoverable(e) => {
+                        return Ok((Some(MakerSwapCommand::Finish), vec![
+                            MakerSwapEvent::MakerPaymentRefundFailed(ERRL!("!maker_coin.recover_funds: {}", e).into()),
+                        ]));
+                    },
+                    // The error is temporary, retrying may fix the issue.
+                    RecoverSwapError::Temporary(e) => {
+                        error!("Error {} on recover_funds, retrying in 30 seconds", e);
+                        Timer::sleep(30.).await;
+                    },
+                    // We should wait for this many seconds and try again.
+                    RecoverSwapError::WaitAndRetry(secs) => {
+                        Timer::sleep(secs as f64).await;
+                    },
+                    // The swap will be automatically recovered after the specified locktime.
+                    RecoverSwapError::AutoRecoverableAfter(locktime) => {
+                        let maker_payment = self.r().maker_payment.clone().unwrap().tx_hex;
+                        return match self.maker_coin.wait_for_htlc_refund(&maker_payment, locktime).await {
+                            Ok(()) => Ok((Some(MakerSwapCommand::FinalizeMakerPaymentRefund), vec![
+                                MakerSwapEvent::MakerPaymentRefunded(None),
+                            ])),
+                            Err(e) => Ok((Some(MakerSwapCommand::Finish), vec![
+                                MakerSwapEvent::MakerPaymentRefundFailed(
+                                    ERRL!("!maker_coin.wait_for_htlc_refund: {}", e.to_string()).into(),
+                                ),
+                            ])),
+                        };
+                    },
                 },
             }
         }
-
-        let other_maker_coin_htlc_pub = self.r().other_maker_coin_htlc_pub;
-        let maker_coin_swap_contract_address = self.r().data.maker_coin_swap_contract_address.clone();
-        let watcher_reward = self.r().watcher_reward;
-        let spend_result = self
-            .maker_coin
-            .send_maker_refunds_payment(RefundPaymentArgs {
-                payment_tx: &maker_payment,
-                time_lock: locktime,
-                other_pubkey: other_maker_coin_htlc_pub.as_slice(),
-                tx_type_with_secret_hash: SwapTxTypeWithSecretHash::TakerOrMakerPayment {
-                    maker_secret_hash: self.secret_hash().as_slice(),
-                },
-                swap_contract_address: &maker_coin_swap_contract_address,
-                swap_unique_data: &self.unique_swap_data(),
-                watcher_reward,
-            })
-            .await;
-
-        let transaction = match spend_result {
-            Ok(t) => t,
-            Err(err) => {
-                if let Some(tx) = err.get_tx() {
-                    broadcast_p2p_tx_msg(
-                        &self.ctx,
-                        tx_helper_topic(self.maker_coin.ticker()),
-                        &tx,
-                        &self.p2p_privkey,
-                    );
-                }
-
-                return Ok((Some(MakerSwapCommand::Finish), vec![
-                    MakerSwapEvent::MakerPaymentRefundFailed(
-                        ERRL!(
-                            "!maker_coin.send_maker_refunds_payment: {}",
-                            err.get_plain_text_format()
-                        )
-                        .into(),
-                    ),
-                ]));
-            },
-        };
-
-        broadcast_p2p_tx_msg(
-            &self.ctx,
-            tx_helper_topic(self.maker_coin.ticker()),
-            &transaction,
-            &self.p2p_privkey,
-        );
-
-        let tx_hash = transaction.tx_hash_as_bytes();
-        info!("Maker payment refund tx {:02x}", tx_hash);
-        let tx_ident = TransactionIdentifier {
-            tx_hex: BytesJson::from(transaction.tx_hex()),
-            tx_hash,
-        };
-
-        Ok((Some(MakerSwapCommand::FinalizeMakerPaymentRefund), vec![
-            MakerSwapEvent::MakerPaymentRefunded(Some(tx_ident)),
-        ]))
     }
 
     async fn finalize_maker_payment_refund(&self) -> Result<(Option<MakerSwapCommand>, Vec<MakerSwapEvent>), String> {

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -2921,7 +2921,7 @@ mod taker_swap_tests {
         ))
         .unwrap();
         let error = block_on(taker_swap.recover_funds()).unwrap_err();
-        assert!(error.contains("Too early to refund"));
+        assert!(matches!(error, RecoverSwapError::WaitAndRetry(_)));
         assert!(unsafe { SEARCH_TX_SPEND_CALLED });
     }
 
@@ -2969,28 +2969,6 @@ mod taker_swap_tests {
         assert_eq!(expected, actual);
         assert!(unsafe { SEARCH_TX_SPEND_CALLED });
         assert!(unsafe { MAKER_PAYMENT_SPEND_CALLED });
-    }
-
-    #[test]
-    fn test_recover_funds_taker_swap_not_finished() {
-        let ctx = mm_ctx_with_iguana(PASSPHRASE);
-
-        // the json doesn't have Finished event at the end
-        let taker_saved_json = r#"{"error_events":["StartFailed","NegotiateFailed","TakerFeeSendFailed","MakerPaymentValidateFailed","TakerPaymentTransactionFailed","TakerPaymentDataSendFailed","TakerPaymentWaitForSpendFailed","MakerPaymentSpendFailed","MakerPaymentSpendConfirmFailed","TakerPaymentRefunded","TakerPaymentRefundedByWatcher","TakerPaymentRefundFailed"],"events":[{"event":{"data":{"lock_duration":7800,"maker":"1bb83b58ec130e28e0a6d5d2acf2eb01b0d3f1670e021d47d31db8a858219da8","maker_amount":"0.12596566232185483","maker_coin":"KMD","maker_coin_start_block":1458035,"maker_payment_confirmations":1,"maker_payment_wait":1564053079,"my_persistent_pub":"0326846707a52a233cfc49a61ef51b1698bbe6aa78fa8b8d411c02743c09688f0a","started_at":1564050479,"taker_amount":"50.000000000000001504212457800000","taker_coin":"DOGE","taker_coin_start_block":2823448,"taker_payment_confirmations":1,"taker_payment_lock":1564058279,"uuid":"41383f43-46a5-478c-9386-3b2cce0aca20"},"type":"Started"},"timestamp":1564050480269},{"event":{"data":{"maker_payment_locktime":1564066080,"maker_pubkey":"031bb83b58ec130e28e0a6d5d2acf2eb01b0d3f1670e021d47d31db8a858219da8","secret_hash":"3669eb83a007a3c507448d79f45a9f06ec2f36a8"},"type":"Negotiated"},"timestamp":1564050540991},{"event":{"data":{"tx_hash":"bdde828b492d6d1cc25cd2322fd592dafd722fcc7d8b0fedce4d3bb4a1a8c8ff","tx_hex":"0100000002c7efa995c8b7be0a8b6c2d526c6c444c1634d65584e9ee89904e9d8675eac88c010000006a473044022051f34d5e3b7d0b9098d5e35333f3550f9cb9e57df83d5e4635b7a8d2986d6d5602200288c98da05de6950e01229a637110a1800ba643e75cfec59d4eb1021ad9b40801210326846707a52a233cfc49a61ef51b1698bbe6aa78fa8b8d411c02743c09688f0affffffffae6c233989efa7c7d2aa6534adc96078917ff395b7f09f734a147b2f44ade164000000006a4730440220393a784c2da74d0e2a28ec4f7df6c8f9d8b2af6ae6957f1e68346d744223a8fd02201b7a96954ac06815a43a6c7668d829ae9cbb5de76fa77189ddfd9e3038df662c01210326846707a52a233cfc49a61ef51b1698bbe6aa78fa8b8d411c02743c09688f0affffffff02115f5800000000001976a914ca1e04745e8ca0c60d8c5881531d51bec470743f88ac41a84641020000001976a914444f0e1099709ba4d742454a7d98a5c9c162ceab88ac6d84395d"},"type":"TakerFeeSent"},"timestamp":1564050545296},{"event":{"data":{"tx_hash":"0a0f11fa82802c2c30862c50ab2162185dae8de7f7235f32c506f814c142b382","tx_hex":"0400008085202f8902ace337db2dd4c56b0697f58fb8cfb6bd1cd6f469d925fc0376d1dcfb7581bf82000000006b483045022100d1f95be235c5c8880f5d703ace287e2768548792c58c5dbd27f5578881b30ea70220030596106e21c7e0057ee0dab283f9a1fe273f15208cba80870c447bd559ef0d0121031bb83b58ec130e28e0a6d5d2acf2eb01b0d3f1670e021d47d31db8a858219da8ffffffff9f339752567c404427fd77f2b35cecdb4c21489edc64e25e729fdb281785e423000000006a47304402203179e95877dbc107123a417f1e648e3ff13d384890f1e4a67b6dd5087235152e0220102a8ab799fadb26b5d89ceb9c7bc721a7e0c2a0d0d7e46bbe0cf3d130010d430121031bb83b58ec130e28e0a6d5d2acf2eb01b0d3f1670e021d47d31db8a858219da8ffffffff025635c0000000000017a91480a95d366d65e34a465ab17b0c9eb1d5a33bae08876cbfce05000000001976a914c3f710deb7320b0efa6edb14e3ebeeb9155fa90d88ac8d7c395d000000000000000000000000000000"},"type":"MakerPaymentReceived"},"timestamp":1564050588176},{"event":{"type":"MakerPaymentWaitConfirmStarted"},"timestamp":1564050588178},{"event":{"type":"MakerPaymentValidatedAndConfirmed"},"timestamp":1564050693585},{"event":{"data":{"tx_hash":"539cb6dbdc25465bbccc575554f05d1bb04c70efce4316e41194e747375c3659","tx_hex":"0100000001ffc8a8a1b43b4dceed0f8b7dcc2f72fdda92d52f32d25cc21c6d2d498b82debd010000006a47304402203967b7f9f5532fa47116585c7d1bcba51861ea2059cca00409f34660db18e33a0220640991911852533a12fdfeb039fb9c8ca2c45482c6993bd84636af3670d49c1501210326846707a52a233cfc49a61ef51b1698bbe6aa78fa8b8d411c02743c09688f0affffffff0200f2052a0100000017a914f2fa08ae416b576779ae5da975e5442663215fce87415173f9000000001976a914444f0e1099709ba4d742454a7d98a5c9c162ceab88ac0585395d"},"type":"TakerPaymentSent"},"timestamp":1564050695611},{"event":{"data":{"secret":"1b8886b8a2cdb62505699400b694ac20f04d7bd4abd80e1ab154aa8d861fc093","transaction":{"tx_hash":"cc5af1cf68d246419fee49c3d74c0cd173599d115b86efe274368a614951bc47","tx_hex":"010000000159365c3747e79411e41643ceef704cb01b5df0545557ccbc5b4625dcdbb69c5300000000d747304402200e78e27d2f1c18676f98ca3dfa4e4a9eeaa8209b55f57b4dd5d9e1abdf034cfa0220623b5c22b62234cec230342aa306c497e43494b44ec2425b84e236b1bf01257001201b8886b8a2cdb62505699400b694ac20f04d7bd4abd80e1ab154aa8d861fc093004c6b6304a7a2395db175210326846707a52a233cfc49a61ef51b1698bbe6aa78fa8b8d411c02743c09688f0aac6782012088a9143669eb83a007a3c507448d79f45a9f06ec2f36a88821031bb83b58ec130e28e0a6d5d2acf2eb01b0d3f1670e021d47d31db8a858219da8ac68ffffffff01008d380c010000001976a914c3f710deb7320b0efa6edb14e3ebeeb9155fa90d88ac8c77395d"}},"type":"TakerPaymentSpent"},"timestamp":1564051092890},{"event":{"data":{"error":"lp_swap:1981] utxo:891] rpc_clients:738] JsonRpcError { request: JsonRpcRequest { jsonrpc: \"2.0\", id: \"67\", method: \"blockchain.transaction.broadcast\", params: [String(\"0400008085202f890182b342c114f806c5325f23f7e78dae5d186221ab502c86302c2c8082fa110f0a00000000d7473044022035791ea5548f87484065c9e1f0bdca9ebc699f2c7f51182c84f360102e32dc3d02200612ed53bca52d9c2568437f087598531534badf26229fe0f652ea72ddf03ca501201b8886b8a2cdb62505699400b694ac20f04d7bd4abd80e1ab154aa8d861fc093004c6b630420c1395db17521031bb83b58ec130e28e0a6d5d2acf2eb01b0d3f1670e021d47d31db8a858219da8ac6782012088a9143669eb83a007a3c507448d79f45a9f06ec2f36a888210326846707a52a233cfc49a61ef51b1698bbe6aa78fa8b8d411c02743c09688f0aac68ffffffff01460ec000000000001976a914444f0e1099709ba4d742454a7d98a5c9c162ceab88ac967e395d000000000000000000000000000000\")] }, error: Transport(\"rpc_clients:668] All electrums are currently disconnected\") }"},"type":"MakerPaymentSpendFailed"},"timestamp":1564051092897}],"success_events":["Started","Negotiated","TakerFeeSent","MakerPaymentReceived","MakerPaymentWaitConfirmStarted","MakerPaymentValidatedAndConfirmed","TakerPaymentSent","TakerPaymentSpent","MakerPaymentSpent","MakerPaymentSpendConfirmed","Finished"],"uuid":"41383f43-46a5-478c-9386-3b2cce0aca20"}"#;
-        let taker_saved_swap: TakerSavedSwap = json::from_str(taker_saved_json).unwrap();
-
-        TestCoin::ticker.mock_safe(|_| MockResult::Return("ticker"));
-        TestCoin::swap_contract_address.mock_safe(|_| MockResult::Return(None));
-        let maker_coin = MmCoinEnum::Test(TestCoin::default());
-        let taker_coin = MmCoinEnum::Test(TestCoin::default());
-        let (taker_swap, _) = block_on(TakerSwap::load_from_saved(
-            ctx,
-            maker_coin,
-            taker_coin,
-            taker_saved_swap,
-        ))
-        .unwrap();
-        assert!(block_on(taker_swap.recover_funds()).is_err());
     }
 
     #[test]


### PR DESCRIPTION
This PR attempts to follow a more robust recovery process by attempting both *refunding* OR *spending* if the swap goes the ugly way.
This is done by replacing the refund-only logic with refund-or-spend-logic (recovery, `recover_funds`).

Also `recover_funds` has been adapted to return more structured error types for information about retrials and such. Also removing some pre-checks that makes us fail early based on local data (e.g. is_swap_finished), as we should still query the rpc to make sure our recovery tx isn't lost or something.