### PR TITLE
feat(txfee): add priority transaction fee support for tendermint coins

### DIFF
--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -47,8 +47,8 @@ use crate::rpc_command::init_withdraw::{InitWithdrawCoin, WithdrawTaskHandleShar
 use crate::rpc_command::{account_balance, get_new_address, init_account_balance, init_create_account,
                          init_scan_for_new_addresses};
 use crate::{coin_balance, scan_for_new_addresses_impl, BalanceResult, CoinWithDerivationMethod, DerivationMethod,
-            DexFee, Eip1559Ops, MakerNftSwapOpsV2, ParseCoinAssocTypes, ParseNftAssocTypes, PayForGasParams,
-            PrivKeyPolicy, RpcCommonOps, SendNftMakerPaymentArgs, SpendNftMakerPaymentArgs, ToBytes,
+            DexFee, MakerNftSwapOpsV2, ParseCoinAssocTypes, ParseNftAssocTypes, PayForGasParams, PrivKeyPolicy,
+            RpcCommonOps, SendNftMakerPaymentArgs, SpendNftMakerPaymentArgs, SwapPriorityFeeOps, ToBytes,
             ValidateNftMakerPaymentArgs, ValidateWatcherSpendInput, WatcherSpendType};
 use async_trait::async_trait;
 use bitcrypto::{dhash160, keccak256, ripemd160, sha256};
@@ -7238,7 +7238,7 @@ fn extract_gas_limit_from_conf<T: ExtractGasLimit>(coin_conf: &Json) -> Result<T
     }
 }
 
-impl Eip1559Ops for EthCoin {
+impl SwapPriorityFeeOps for EthCoin {
     fn get_swap_transaction_fee_policy(&self) -> SwapTxFeePolicy { self.swap_txfee_policy.lock().unwrap().clone() }
 
     fn set_swap_transaction_fee_policy(&self, swap_txfee_policy: SwapTxFeePolicy) {

--- a/mm2src/coins/qrc20.rs
+++ b/mm2src/coins/qrc20.rs
@@ -17,13 +17,13 @@ use crate::utxo::{qtum, ActualTxFee, AdditionalTxData, AddrFromStrError, Broadca
                   UtxoFromLegacyReqErr, UtxoTx, UtxoTxBroadcastOps, UtxoTxGenerationOps, VerboseTransactionFrom,
                   UTXO_LOCK};
 use crate::{BalanceError, BalanceFut, CheckIfMyPaymentSentArgs, CoinBalance, CoinFutSpawner, ConfirmPaymentInput,
-            DexFee, Eip1559Ops, FeeApproxStage, FoundSwapTxSpend, HistorySyncState, IguanaPrivKey, MakerSwapTakerCoin,
+            DexFee, FeeApproxStage, FoundSwapTxSpend, HistorySyncState, IguanaPrivKey, MakerSwapTakerCoin,
             MarketCoinOps, MmCoin, MmCoinEnum, NegotiateSwapContractAddrErr, PaymentInstructionArgs,
             PaymentInstructions, PaymentInstructionsErr, PrivKeyBuildPolicy, PrivKeyPolicyNotAllowed,
             RawTransactionFut, RawTransactionRequest, RawTransactionResult, RefundError, RefundPaymentArgs,
             RefundResult, SearchForSwapTxSpendInput, SendMakerPaymentSpendPreimageInput, SendPaymentArgs,
-            SignRawTransactionRequest, SignatureResult, SpendPaymentArgs, SwapOps, SwapTxFeePolicy,
-            TakerSwapMakerCoin, TradeFee, TradePreimageError, TradePreimageFut, TradePreimageResult,
+            SignRawTransactionRequest, SignatureResult, SpendPaymentArgs, SwapOps, SwapPriorityFeeOps,
+            SwapTxFeePolicy, TakerSwapMakerCoin, TradeFee, TradePreimageError, TradePreimageFut, TradePreimageResult,
             TradePreimageValue, TransactionData, TransactionDetails, TransactionEnum, TransactionErr, TransactionFut,
             TransactionResult, TransactionType, TxMarshalingErr, UnexpectedDerivationMethod, ValidateAddressResult,
             ValidateFeeArgs, ValidateInstructionsErr, ValidateOtherPubKeyErr, ValidatePaymentFut,
@@ -1655,7 +1655,7 @@ fn transfer_event_from_log(log: &LogEntry) -> Result<TransferEventDetails, Strin
     })
 }
 
-impl Eip1559Ops for Qrc20Coin {
+impl SwapPriorityFeeOps for Qrc20Coin {
     fn get_swap_transaction_fee_policy(&self) -> SwapTxFeePolicy { SwapTxFeePolicy::Unsupported }
 
     fn set_swap_transaction_fee_policy(&self, _swap_txfee_policy: SwapTxFeePolicy) {}

--- a/mm2src/coins/tendermint/tendermint_token.rs
+++ b/mm2src/coins/tendermint/tendermint_token.rs
@@ -584,9 +584,9 @@ impl MmCoin for TendermintToken {
             let timeout_height = current_block + TIMEOUT_HEIGHT_DELTA;
 
             let (_, gas_limit) = if is_ibc_transfer {
-                platform.gas_info_for_withdraw(&req.fee, IBC_GAS_LIMIT_DEFAULT)
+                platform.gas_price_and_limit(req.fee.clone().into(), IBC_GAS_LIMIT_DEFAULT)
             } else {
-                platform.gas_info_for_withdraw(&req.fee, GAS_LIMIT_DEFAULT)
+                platform.gas_price_and_limit(req.fee.clone().into(), GAS_LIMIT_DEFAULT)
             };
 
             let fee_amount_u64 = platform
@@ -596,7 +596,7 @@ impl MmCoin for TendermintToken {
                     msg_payload.clone(),
                     timeout_height,
                     memo.clone(),
-                    req.fee,
+                    req.fee.into(),
                 )
                 .await?;
 

--- a/mm2src/mm2_main/tests/docker_tests/eth_docker_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/eth_docker_tests.rs
@@ -13,18 +13,18 @@ use coins::eth::v2_activation::{eth_coin_from_conf_and_request_v2, EthActivation
 use coins::eth::{checksum_address, eth_addr_to_hex, eth_coin_from_conf_and_request, EthCoin, EthCoinType,
                  EthPrivKeyBuildPolicy, SignedEthTx, SwapV2Contracts, ERC20_ABI};
 use coins::nft::nft_structs::{Chain, ContractType, NftInfo};
-use coins::{lp_coinfind, CoinProtocol, CoinWithDerivationMethod, CommonSwapOpsV2, ConfirmPaymentInput,
-            DerivationMethod, Eip1559Ops, FoundSwapTxSpend, MakerNftSwapOpsV2, MarketCoinOps, NftSwapInfo,
-            ParseCoinAssocTypes, ParseNftAssocTypes, PrivKeyBuildPolicy, RefundNftMakerPaymentArgs, RefundPaymentArgs,
-            SearchForSwapTxSpendInput, SendNftMakerPaymentArgs, SendPaymentArgs, SpendNftMakerPaymentArgs,
-            SpendPaymentArgs, SwapOps, SwapTxFeePolicy, SwapTxTypeWithSecretHash, ToBytes, Transaction,
-            ValidateNftMakerPaymentArgs};
 #[cfg(any(feature = "sepolia-maker-swap-v2-tests", feature = "sepolia-taker-swap-v2-tests"))]
-use coins::{CoinsContext, DexFee, FundingTxSpend, GenTakerFundingSpendArgs, GenTakerPaymentSpendArgs,
+use coins::{lp_coinfind, CoinsContext, DexFee, FundingTxSpend, GenTakerFundingSpendArgs, GenTakerPaymentSpendArgs,
             MakerCoinSwapOpsV2, MmCoinEnum, MmCoinStruct, RefundFundingSecretArgs, RefundMakerPaymentSecretArgs,
             RefundMakerPaymentTimelockArgs, RefundTakerPaymentArgs, SendMakerPaymentArgs, SendTakerFundingArgs,
             SpendMakerPaymentArgs, TakerCoinSwapOpsV2, TxPreimageWithSig, ValidateMakerPaymentArgs,
             ValidateTakerFundingArgs};
+use coins::{CoinProtocol, CoinWithDerivationMethod, CommonSwapOpsV2, ConfirmPaymentInput, DerivationMethod,
+            FoundSwapTxSpend, MakerNftSwapOpsV2, MarketCoinOps, NftSwapInfo, ParseCoinAssocTypes, ParseNftAssocTypes,
+            PrivKeyBuildPolicy, RefundNftMakerPaymentArgs, RefundPaymentArgs, SearchForSwapTxSpendInput,
+            SendNftMakerPaymentArgs, SendPaymentArgs, SpendNftMakerPaymentArgs, SpendPaymentArgs, SwapOps,
+            SwapPriorityFeeOps, SwapTxFeePolicy, SwapTxTypeWithSecretHash, ToBytes, Transaction,
+            ValidateNftMakerPaymentArgs};
 use common::{block_on, block_on_f01, now_sec};
 use crypto::Secp256k1Secret;
 use ethereum_types::U256;
@@ -55,6 +55,7 @@ const SEPOLIA_MAKER_PRIV: &str = "6e2f3a6223b928a05a3a3622b0c3f3573d03663b704a61
 const SEPOLIA_TAKER_PRIV: &str = "e0be82dca60ff7e4c6d6db339ac9e1ae249af081dba2110bddd281e711608f16";
 const NFT_ETH: &str = "NFT_ETH";
 const ETH: &str = "ETH";
+#[cfg(any(feature = "sepolia-maker-swap-v2-tests", feature = "sepolia-taker-swap-v2-tests"))]
 const ERC20: &str = "ERC20DEV";
 
 /// # Safety

--- a/mm2src/mm2_main/tests/docker_tests/tendermint_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/tendermint_tests.rs
@@ -1,3 +1,4 @@
+use coins::utxo::utxo_common::big_decimal_from_sat;
 use common::{block_on, log};
 use mm2_number::BigDecimal;
 use mm2_rpc::data::legacy::OrderbookResponse;
@@ -11,6 +12,7 @@ use mm2_test_helpers::structs::{Bip44Chain, HDAccountAddressId, OrderbookAddress
 use serde_json::json;
 use std::collections::HashSet;
 use std::iter::FromIterator;
+use std::str::FromStr;
 
 const TENDERMINT_TEST_SEED: &str = "tendermint test seed";
 const TENDERMINT_CONSTANT_BALANCE_SEED: &str = "tendermint constant balance seed";
@@ -649,6 +651,45 @@ fn test_passive_coin_and_force_disable() {
     // Try to disable token when platform coin force disabled.
     // This should failed, because platform coin was purged with its tokens.
     block_on(disable_coin_err(&mm, token, false));
+}
+
+#[test]
+fn test_priority_gas_on_tendermint_withdraw() {
+    const GAS_PRICE_HIGH: f64 = 0.3;
+    const GAS_USED: u64 = 55470;
+    const GAS_USED_MULTIPLIER: f64 = 1.5;
+    let coins = json!([atom_testnet_conf()]);
+    let coin = coins[0]["coin"].as_str().unwrap();
+
+    let conf = Mm2TestConf::seednode(TENDERMINT_TEST_SEED, &coins);
+    let mm = MarketMakerIt::start(conf.conf, conf.rpc_password, None).unwrap();
+
+    let activation_res = block_on(enable_tendermint(&mm, coin, &[], ATOM_TENDERMINT_RPC_URLS, false));
+    log!("Activation {}", serde_json::to_string(&activation_res).unwrap());
+
+    let request = block_on(mm.rpc(&json!({
+        "userpass": mm.userpass,
+        "method": "withdraw",
+        "coin": coin,
+        "to": "cosmos1w5h6wud7a8zpa539rc99ehgl9gwkad3wjsjq8v",
+        "amount": "0.1",
+        "fee": {
+            "type": "CosmosGasPriority",
+            "gas_limit": 150000,
+            "gas_price_option": "High"
+        }
+    })))
+    .unwrap();
+    assert_eq!(request.0, common::StatusCode::OK, "'withdraw' failed: {}", request.1);
+    let tx_details: TransactionDetails = serde_json::from_str(&request.1).unwrap();
+    let expected = big_decimal_from_sat(
+        (GAS_PRICE_HIGH * GAS_USED as f64 * GAS_USED_MULTIPLIER).ceil() as i64,
+        6,
+    );
+    assert_eq!(
+        BigDecimal::from_str(tx_details.fee_details["amount"].as_str().unwrap()).unwrap(),
+        expected
+    );
 }
 
 mod swap {

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -614,6 +614,7 @@ pub fn atom_testnet_conf() -> Json {
                 "denom": "uatom",
                 "account_prefix": "cosmos",
                 "chain_id": "cosmoshub-testnet",
+                "priority_gas_prices": [0.1, 0.2, 0.3]
             },
         },
         "derivation_path": "m/44'/118'",


### PR DESCRIPTION
Continuing adding priority transaction fee requested in issue #1848, now for Tendermint.
There are three priority levels for tx fees: low, average and high, allowing to users to set higher priority for their transactions by paying more fees.
Cosmos has a registry for its chain ecosystem: https://github.com/cosmos/chain-registry which contains suggested priority tx fees for different coins. 
The priority fees from the Cosmos registry should be added in the coins file (for the platform coin only) like:
```
"coin":"ATOM",
        "protocol":{
            "type":"TENDERMINT",
            "protocol_data": {
                ...
                "priority_gas_prices": [0.1, 0.2, 0.3]
            },
        },
   }
```
To set priority level with withdraw, WithdrawFee::CosmosGasPriority variant is added.
To set priority for swaps, `set_swap_transaction_fee_policy()` implemented for TendermintCoin.