### PR TITLE
fix(legacy_swap): check for existing maker/taker payment before timeout

### DIFF
--- a/mm2src/mm2_main/src/lp_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap.rs
@@ -91,7 +91,7 @@ use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 use uuid::Uuid;
 
-#[cfg(feature = "custom-swap-locktime")]
+#[cfg(any(feature = "custom-swap-locktime", test, feature = "run-docker-tests"))]
 use std::sync::atomic::{AtomicU64, Ordering};
 
 mod check_balance;
@@ -420,13 +420,13 @@ async fn recv_swap_msg<T>(
 /// in order to give different and/or heavy communication channels a chance.
 const BASIC_COMM_TIMEOUT: u64 = 90;
 
-#[cfg(not(feature = "custom-swap-locktime"))]
+#[cfg(not(any(feature = "custom-swap-locktime", test, feature = "run-docker-tests")))]
 /// Default atomic swap payment locktime, in seconds.
 /// Maker sends payment with LOCKTIME * 2
 /// Taker sends payment with LOCKTIME
 const PAYMENT_LOCKTIME: u64 = 3600 * 2 + 300 * 2;
 
-#[cfg(feature = "custom-swap-locktime")]
+#[cfg(any(feature = "custom-swap-locktime", test, feature = "run-docker-tests"))]
 /// Default atomic swap payment locktime, in seconds.
 /// Maker sends payment with LOCKTIME * 2
 /// Taker sends payment with LOCKTIME
@@ -435,9 +435,9 @@ pub(crate) static PAYMENT_LOCKTIME: AtomicU64 = AtomicU64::new(super::CUSTOM_PAY
 #[inline]
 /// Returns `PAYMENT_LOCKTIME`
 pub fn get_payment_locktime() -> u64 {
-    #[cfg(not(feature = "custom-swap-locktime"))]
+    #[cfg(not(any(feature = "custom-swap-locktime", test, feature = "run-docker-tests")))]
     return PAYMENT_LOCKTIME;
-    #[cfg(feature = "custom-swap-locktime")]
+    #[cfg(any(feature = "custom-swap-locktime", test, feature = "run-docker-tests"))]
     PAYMENT_LOCKTIME.load(Ordering::Relaxed)
 }
 

--- a/mm2src/mm2_main/src/lp_swap/maker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap.rs
@@ -801,7 +801,7 @@ impl MakerSwap {
     /// The reward configuration depends on the specific requirements of the coins
     /// involved in the swap.
     /// Some coins may not support watcher rewards at all.
-    async fn setup_maker_watcher_reward(&self, wait_maker_payment_until: u64) -> Result<Option<WatcherReward>, String> {
+    async fn setup_watcher_reward(&self, wait_maker_payment_until: u64) -> Result<Option<WatcherReward>, String> {
         if !self.r().watcher_reward {
             return Ok(None);
         }
@@ -860,7 +860,7 @@ impl MakerSwap {
         }
 
         // Set up watcher reward if enabled
-        let watcher_reward = match self.setup_maker_watcher_reward(wait_maker_payment_until).await {
+        let watcher_reward = match self.setup_watcher_reward(wait_maker_payment_until).await {
             Ok(reward) => reward,
             Err(err) => {
                 return Ok((Some(MakerSwapCommand::Finish), vec![

--- a/mm2src/mm2_main/src/lp_swap/maker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap.rs
@@ -794,32 +794,52 @@ impl MakerSwap {
     }
 
     async fn maker_payment(&self) -> Result<(Option<MakerSwapCommand>, Vec<MakerSwapEvent>), String> {
+        // Extract values from lock before async operations
         let lock_duration = self.r().data.lock_duration;
-        let timeout = self.r().data.started_at + lock_duration / 3;
-        let now = now_sec();
-        if now > timeout {
-            return Ok((Some(MakerSwapCommand::Finish), vec![
-                MakerSwapEvent::MakerPaymentTransactionFailed(ERRL!("Timeout {} > {}", now, timeout).into()),
-            ]));
-        }
-
         let maker_payment_lock = self.r().data.maker_payment_lock;
         let other_maker_coin_htlc_pub = self.r().other_maker_coin_htlc_pub;
         let secret_hash = self.secret_hash();
         let maker_coin_swap_contract_address = self.r().data.maker_coin_swap_contract_address.clone();
         let unique_data = self.unique_swap_data();
         let payment_instructions = self.r().payment_instructions.clone();
-        let transaction_f = self.maker_coin.check_if_my_payment_sent(CheckIfMyPaymentSentArgs {
-            time_lock: maker_payment_lock,
-            other_pub: &*other_maker_coin_htlc_pub,
-            secret_hash: secret_hash.as_slice(),
-            search_from_block: self.r().data.maker_coin_start_block,
-            swap_contract_address: &maker_coin_swap_contract_address,
-            swap_unique_data: &unique_data,
-            amount: &self.maker_amount,
-            payment_instructions: &payment_instructions,
-        });
+        let maker_coin_start_block = self.r().data.maker_coin_start_block;
 
+        // Look for previously sent maker payment in case of restart
+        let maybe_existing_payment = match self
+            .maker_coin
+            .check_if_my_payment_sent(CheckIfMyPaymentSentArgs {
+                time_lock: maker_payment_lock,
+                other_pub: &*other_maker_coin_htlc_pub,
+                secret_hash: secret_hash.as_slice(),
+                search_from_block: maker_coin_start_block,
+                swap_contract_address: &maker_coin_swap_contract_address,
+                swap_unique_data: &unique_data,
+                amount: &self.maker_amount,
+                payment_instructions: &payment_instructions,
+            })
+            .await
+        {
+            Ok(Some(tx)) => Some(tx),
+            Ok(None) => None,
+            Err(e) => {
+                return Ok((Some(MakerSwapCommand::Finish), vec![
+                    MakerSwapEvent::MakerPaymentTransactionFailed(ERRL!("{}", e).into()),
+                ]))
+            },
+        };
+
+        // Skip timeout check if payment was already sent
+        if maybe_existing_payment.is_none() {
+            let timeout = self.r().data.started_at + lock_duration / 3;
+            let now = now_sec();
+            if now > timeout {
+                return Ok((Some(MakerSwapCommand::Finish), vec![
+                    MakerSwapEvent::MakerPaymentTransactionFailed(ERRL!("Timeout {} > {}", now, timeout).into()),
+                ]));
+            }
+        }
+
+        // Set up watcher reward if enabled
         let wait_maker_payment_until = wait_for_maker_payment_conf_until(self.r().data.started_at, lock_duration);
         let watcher_reward = if self.r().watcher_reward {
             match self
@@ -838,45 +858,39 @@ impl MakerSwap {
             None
         };
 
-        let transaction = match transaction_f.await {
-            Ok(res) => match res {
-                Some(tx) => tx,
-                None => {
-                    let payment = self
-                        .maker_coin
-                        .send_maker_payment(SendPaymentArgs {
-                            time_lock_duration: lock_duration,
-                            time_lock: maker_payment_lock,
-                            other_pubkey: &*other_maker_coin_htlc_pub,
-                            secret_hash: secret_hash.as_slice(),
-                            amount: self.maker_amount.clone(),
-                            swap_contract_address: &maker_coin_swap_contract_address,
-                            swap_unique_data: &unique_data,
-                            payment_instructions: &payment_instructions,
-                            watcher_reward,
-                            wait_for_confirmation_until: wait_maker_payment_until,
-                        })
-                        .await;
-
-                    match payment {
-                        Ok(t) => t,
-                        Err(err) => {
-                            return Ok((Some(MakerSwapCommand::Finish), vec![
-                                MakerSwapEvent::MakerPaymentTransactionFailed(
-                                    ERRL!("{}", err.get_plain_text_format()).into(),
-                                ),
-                            ]));
-                        },
-                    }
-                },
-            },
-            Err(e) => {
-                return Ok((Some(MakerSwapCommand::Finish), vec![
-                    MakerSwapEvent::MakerPaymentTransactionFailed(ERRL!("{}", e).into()),
-                ]))
+        // Use existing payment or create new one
+        let transaction = match maybe_existing_payment {
+            Some(tx) => tx,
+            None => {
+                match self
+                    .maker_coin
+                    .send_maker_payment(SendPaymentArgs {
+                        time_lock_duration: lock_duration,
+                        time_lock: maker_payment_lock,
+                        other_pubkey: &*other_maker_coin_htlc_pub,
+                        secret_hash: secret_hash.as_slice(),
+                        amount: self.maker_amount.clone(),
+                        swap_contract_address: &maker_coin_swap_contract_address,
+                        swap_unique_data: &unique_data,
+                        payment_instructions: &payment_instructions,
+                        watcher_reward,
+                        wait_for_confirmation_until: wait_maker_payment_until,
+                    })
+                    .await
+                {
+                    Ok(t) => t,
+                    Err(err) => {
+                        return Ok((Some(MakerSwapCommand::Finish), vec![
+                            MakerSwapEvent::MakerPaymentTransactionFailed(
+                                ERRL!("{}", err.get_plain_text_format()).into(),
+                            ),
+                        ]));
+                    },
+                }
             },
         };
 
+        // Build transaction identifier and prepare events
         let tx_hash = transaction.tx_hash_as_bytes();
         info!("{}: Maker payment tx {:02x}", MAKER_PAYMENT_SENT_LOG, tx_hash);
 

--- a/mm2src/mm2_main/src/lp_swap/maker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap.rs
@@ -793,6 +793,14 @@ impl MakerSwap {
         Ok((Some(MakerSwapCommand::SendPayment), swap_events))
     }
 
+    /// Sets up the watcher reward for the maker's payment in the swap.
+    ///
+    /// The reward mainly serves as compensation to watchers for the mining fees
+    /// paid to execute the transactions.
+    ///
+    /// The reward configuration depends on the specific requirements of the coins
+    /// involved in the swap.
+    /// Some coins may not support watcher rewards at all.
     async fn setup_maker_watcher_reward(&self, wait_maker_payment_until: u64) -> Result<Option<WatcherReward>, String> {
         if !self.r().watcher_reward {
             return Ok(None);

--- a/mm2src/mm2_main/src/lp_swap/maker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap.rs
@@ -803,6 +803,7 @@ impl MakerSwap {
         let unique_data = self.unique_swap_data();
         let payment_instructions = self.r().payment_instructions.clone();
         let maker_coin_start_block = self.r().data.maker_coin_start_block;
+        let wait_maker_payment_until = wait_for_maker_payment_conf_until(self.r().data.started_at, lock_duration);
 
         // Look for previously sent maker payment in case of restart
         let maybe_existing_payment = match self
@@ -828,7 +829,7 @@ impl MakerSwap {
             },
         };
 
-        // Skip timeout check if payment was already sent
+        // If the payment is not yet sent, make sure we didn't miss the deadline for sending it.
         if maybe_existing_payment.is_none() {
             let timeout = self.r().data.started_at + lock_duration / 3;
             let now = now_sec();
@@ -840,7 +841,6 @@ impl MakerSwap {
         }
 
         // Set up watcher reward if enabled
-        let wait_maker_payment_until = wait_for_maker_payment_conf_until(self.r().data.started_at, lock_duration);
         let watcher_reward = if self.r().watcher_reward {
             match self
                 .maker_coin

--- a/mm2src/mm2_main/src/lp_swap/taker_restart.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_restart.rs
@@ -154,11 +154,7 @@ pub async fn check_taker_payment_spend(swap: &TakerSwap) -> Result<Option<FoundS
     let other_taker_coin_htlc_pub = swap.r().other_taker_coin_htlc_pub;
     let taker_coin_start_block = swap.r().data.taker_coin_start_block;
     let taker_coin_swap_contract_address = swap.r().data.taker_coin_swap_contract_address.clone();
-
-    let taker_payment_lock = match std::env::var("USE_TEST_LOCKTIME") {
-        Ok(_) => swap.r().data.started_at,
-        Err(_) => swap.r().data.taker_payment_lock,
-    };
+    let taker_payment_lock = swap.r().data.taker_payment_lock;
     let secret_hash = swap.r().secret_hash.0.clone();
     let unique_data = swap.unique_swap_data();
     let watcher_reward = swap.r().watcher_reward;
@@ -223,10 +219,7 @@ pub async fn add_taker_payment_refunded_by_watcher_event(
 ) -> Result<TakerSwapCommand, String> {
     let other_maker_coin_htlc_pub = swap.r().other_maker_coin_htlc_pub;
     let taker_coin_swap_contract_address = swap.r().data.taker_coin_swap_contract_address.clone();
-    let taker_payment_lock = match std::env::var("USE_TEST_LOCKTIME") {
-        Ok(_) => swap.r().data.started_at,
-        Err(_) => swap.r().data.taker_payment_lock,
-    };
+    let taker_payment_lock = swap.r().data.taker_payment_lock;
     let secret_hash = swap.r().secret_hash.0.clone();
 
     let validate_input = ValidateWatcherSpendInput {

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -1526,10 +1526,11 @@ impl TakerSwap {
     }
 
     async fn process_watcher_logic(&self, transaction: &TransactionEnum) -> Option<TakerSwapEvent> {
-        if !(self.ctx.use_watchers()
+        let watchers_enabled_and_supported = self.ctx.use_watchers()
             && self.taker_coin.is_supported_by_watchers()
-            && self.maker_coin.is_supported_by_watchers())
-        {
+            && self.maker_coin.is_supported_by_watchers();
+
+        if !watchers_enabled_and_supported {
             return None;
         }
 

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -1548,7 +1548,7 @@ impl TakerSwap {
             },
         };
 
-        // Skip timeout check if payment was already sent
+        // If the payment is not yet sent, make sure we didn't miss the deadline for sending it.
         if maybe_existing_payment.is_none() {
             let timeout = self.r().data.maker_payment_wait;
             let now = now_sec();

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -1506,6 +1506,14 @@ impl TakerSwap {
         }
     }
 
+    /// Sets up the watcher reward for the taker's payment in the swap.
+    ///
+    /// The reward mainly serves as compensation to watchers for the mining fees
+    /// paid to execute the transactions.
+    ///
+    /// The reward configuration depends on the specific requirements of the coins
+    /// involved in the swap.
+    /// Some coins may not support watcher rewards at all.
     async fn setup_watcher_reward(&self, taker_payment_lock: u64) -> Result<Option<WatcherReward>, String> {
         if !self.r().watcher_reward {
             return Ok(None);
@@ -1525,6 +1533,13 @@ impl TakerSwap {
             .map_err(|err| ERRL!("Watcher reward error: {}", err.to_string()))
     }
 
+    /// Processes watcher-related logic for the swap by preparing and broadcasting necessary data.
+    ///
+    /// This function creates spend/refund preimages and broadcasts them to watchers if both coins
+    /// support watcher functionality and watchers are enabled.
+    ///
+    /// The preimages allow watchers to either complete the swap by spending the maker payment
+    /// or refund the taker payment if needed.
     async fn process_watcher_logic(&self, transaction: &TransactionEnum) -> Option<TakerSwapEvent> {
         let watchers_enabled_and_supported = self.ctx.use_watchers()
             && self.taker_coin.is_supported_by_watchers()

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -1578,7 +1578,7 @@ impl TakerSwap {
             }
         }
 
-        // Set up watcher reward
+        // Set up watcher reward if enable
         let watcher_reward = match self.setup_watcher_reward(taker_payment_lock).await {
             Ok(reward) => reward,
             Err(err) => {

--- a/mm2src/mm2_main/src/mm2.rs
+++ b/mm2src/mm2_main/src/mm2.rs
@@ -47,10 +47,11 @@ use common::log::LogLevel;
 use common::password_policy::password_policy;
 use mm2_core::mm_ctx::MmCtxBuilder;
 
-#[cfg(feature = "custom-swap-locktime")] use common::log::warn;
-#[cfg(feature = "custom-swap-locktime")]
+#[cfg(any(feature = "custom-swap-locktime", test, feature = "run-docker-tests"))]
+use common::log::warn;
+#[cfg(any(feature = "custom-swap-locktime", test, feature = "run-docker-tests"))]
 use lp_swap::PAYMENT_LOCKTIME;
-#[cfg(feature = "custom-swap-locktime")]
+#[cfg(any(feature = "custom-swap-locktime", test, feature = "run-docker-tests"))]
 use std::sync::atomic::Ordering;
 
 use gstuff::slurp;
@@ -85,7 +86,7 @@ pub mod rpc;
 
 pub const PASSWORD_MAXIMUM_CONSECUTIVE_CHARACTERS: usize = 3;
 
-#[cfg(feature = "custom-swap-locktime")]
+#[cfg(any(feature = "custom-swap-locktime", test, feature = "run-docker-tests"))]
 const CUSTOM_PAYMENT_LOCKTIME_DEFAULT: u64 = 900;
 
 pub struct LpMainParams {
@@ -102,7 +103,7 @@ impl LpMainParams {
     }
 }
 
-#[cfg(feature = "custom-swap-locktime")]
+#[cfg(any(feature = "custom-swap-locktime", test, feature = "run-docker-tests"))]
 /// Reads `payment_locktime` from conf arg and assigns it into `PAYMENT_LOCKTIME` in lp_swap.
 /// Assigns 900 if `payment_locktime` is invalid or not provided.
 fn initialize_payment_locktime(conf: &Json) {
@@ -150,7 +151,7 @@ pub async fn lp_main(
         }
     }
 
-    #[cfg(feature = "custom-swap-locktime")]
+    #[cfg(any(feature = "custom-swap-locktime", test, feature = "run-docker-tests"))]
     initialize_payment_locktime(&conf);
 
     let ctx = MmCtxBuilder::new()


### PR DESCRIPTION
This PR moves payment existence check in `maker_payment`/`send_taker_payment` before timeout validation and skips timeout if payment is already sent, as the taker swap should proceed to waiting for maker to spend the taker payment.

Should fix https://github.com/KomodoPlatform/komodo-defi-framework/issues/2136 , but we are still not aware why the electrum request doesn't timeout.