### PR TITLE
chore(release): v2.3.0-beta

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -22,6 +22,7 @@ jobs:
           types: |
             feat
             fix
+            improvement
             chore
             docs
             deps
@@ -38,9 +39,9 @@ jobs:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
           title_length=${#TITLE}
-          if [ $title_length -gt 72 ]
+          if [ $title_length -gt 85 ]
           then
-            echo "PR title is too long (greater than 72 characters)"
+            echo "PR title is too long (greater than 85 characters)"
             exit 1
           fi
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "mm2_bin_lib"
-version = "2.2.0-beta"
+version = "2.3.0-beta"
 dependencies = [
  "chrono",
  "common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3100,7 +3100,7 @@ checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 [[package]]
 name = "libp2p"
 version = "0.52.1"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.4#6fc061b58853c1b0dafaa19a4a29343c0ac6eab3"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.11#f949f65669f5dbfb95eb38e7e9393b48202c2995"
 dependencies = [
  "bytes 1.4.0",
  "futures 0.3.28",
@@ -3132,7 +3132,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.2.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.4#6fc061b58853c1b0dafaa19a4a29343c0ac6eab3"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.11#f949f65669f5dbfb95eb38e7e9393b48202c2995"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -3143,7 +3143,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.2.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.4#6fc061b58853c1b0dafaa19a4a29343c0ac6eab3"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.11#f949f65669f5dbfb95eb38e7e9393b48202c2995"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -3154,7 +3154,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.40.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.4#6fc061b58853c1b0dafaa19a4a29343c0ac6eab3"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.11#f949f65669f5dbfb95eb38e7e9393b48202c2995"
 dependencies = [
  "either",
  "fnv",
@@ -3181,7 +3181,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.40.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.4#6fc061b58853c1b0dafaa19a4a29343c0ac6eab3"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.11#f949f65669f5dbfb95eb38e7e9393b48202c2995"
 dependencies = [
  "futures 0.3.28",
  "libp2p-core",
@@ -3195,7 +3195,7 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.43.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.4#6fc061b58853c1b0dafaa19a4a29343c0ac6eab3"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.11#f949f65669f5dbfb95eb38e7e9393b48202c2995"
 dependencies = [
  "asynchronous-codec",
  "cuckoofilter",
@@ -3215,7 +3215,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.45.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.4#6fc061b58853c1b0dafaa19a4a29343c0ac6eab3"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.11#f949f65669f5dbfb95eb38e7e9393b48202c2995"
 dependencies = [
  "asynchronous-codec",
  "base64 0.21.7",
@@ -3246,7 +3246,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.43.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.4#6fc061b58853c1b0dafaa19a4a29343c0ac6eab3"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.11#f949f65669f5dbfb95eb38e7e9393b48202c2995"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -3286,7 +3286,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.44.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.4#6fc061b58853c1b0dafaa19a4a29343c0ac6eab3"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.11#f949f65669f5dbfb95eb38e7e9393b48202c2995"
 dependencies = [
  "data-encoding",
  "futures 0.3.28",
@@ -3306,7 +3306,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.13.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.4#6fc061b58853c1b0dafaa19a4a29343c0ac6eab3"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.11#f949f65669f5dbfb95eb38e7e9393b48202c2995"
 dependencies = [
  "instant",
  "libp2p-core",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.43.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.4#6fc061b58853c1b0dafaa19a4a29343c0ac6eab3"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.11#f949f65669f5dbfb95eb38e7e9393b48202c2995"
 dependencies = [
  "bytes 1.4.0",
  "curve25519-dalek 3.2.0",
@@ -3346,7 +3346,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.43.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.4#6fc061b58853c1b0dafaa19a4a29343c0ac6eab3"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.11#f949f65669f5dbfb95eb38e7e9393b48202c2995"
 dependencies = [
  "either",
  "futures 0.3.28",
@@ -3363,7 +3363,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.25.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.4#6fc061b58853c1b0dafaa19a4a29343c0ac6eab3"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.11#f949f65669f5dbfb95eb38e7e9393b48202c2995"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -3380,7 +3380,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.43.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.4#6fc061b58853c1b0dafaa19a4a29343c0ac6eab3"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.11#f949f65669f5dbfb95eb38e7e9393b48202c2995"
 dependencies = [
  "either",
  "fnv",
@@ -3402,7 +3402,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.33.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.4#6fc061b58853c1b0dafaa19a4a29343c0ac6eab3"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.11#f949f65669f5dbfb95eb38e7e9393b48202c2995"
 dependencies = [
  "heck",
  "proc-macro-warning",
@@ -3414,7 +3414,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.40.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.4#6fc061b58853c1b0dafaa19a4a29343c0ac6eab3"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.11#f949f65669f5dbfb95eb38e7e9393b48202c2995"
 dependencies = [
  "futures 0.3.28",
  "futures-timer",
@@ -3430,7 +3430,7 @@ dependencies = [
 [[package]]
 name = "libp2p-wasm-ext"
 version = "0.40.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.4#6fc061b58853c1b0dafaa19a4a29343c0ac6eab3"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.11#f949f65669f5dbfb95eb38e7e9393b48202c2995"
 dependencies = [
  "futures 0.3.28",
  "js-sys",
@@ -3443,7 +3443,7 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.42.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.4#6fc061b58853c1b0dafaa19a4a29343c0ac6eab3"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.11#f949f65669f5dbfb95eb38e7e9393b48202c2995"
 dependencies = [
  "either",
  "futures 0.3.28",
@@ -3462,7 +3462,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.44.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.4#6fc061b58853c1b0dafaa19a4a29343c0ac6eab3"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.11#f949f65669f5dbfb95eb38e7e9393b48202c2995"
 dependencies = [
  "either",
  "futures 0.3.28",
@@ -4380,7 +4380,7 @@ checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.4#6fc061b58853c1b0dafaa19a4a29343c0ac6eab3"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.11#f949f65669f5dbfb95eb38e7e9393b48202c2995"
 dependencies = [
  "bytes 1.4.0",
  "futures 0.3.28",
@@ -5112,7 +5112,7 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.2.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.4#6fc061b58853c1b0dafaa19a4a29343c0ac6eab3"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.11#f949f65669f5dbfb95eb38e7e9393b48202c2995"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.4.0",
@@ -5852,7 +5852,7 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.4#6fc061b58853c1b0dafaa19a4a29343c0ac6eab3"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git?tag=k-0.52.11#f949f65669f5dbfb95eb38e7e9393b48202c2995"
 dependencies = [
  "futures 0.3.28",
  "pin-project",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,6 +1013,7 @@ dependencies = [
  "log",
  "parking_lot",
  "parking_lot_core 0.6.2",
+ "paste",
  "primitive-types",
  "rand 0.7.3",
  "regex",
@@ -4076,6 +4077,7 @@ dependencies = [
  "num-traits",
  "parity-util-mem",
  "parking_lot",
+ "primitive-types",
  "primitives",
  "prost",
  "prost-build",
@@ -4105,6 +4107,7 @@ dependencies = [
  "spv_validation",
  "testcontainers",
  "tokio",
+ "trading_api",
  "trie-db",
  "trie-root 0.16.0",
  "url",
@@ -7263,6 +7266,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "trading_api"
+version = "0.1.0"
+dependencies = [
+ "common",
+ "derive_more",
+ "enum_derives",
+ "ethereum-types",
+ "lazy_static",
+ "mm2_core",
+ "mm2_err_handle",
+ "mm2_net",
+ "mm2_number",
+ "mocktopus",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "mm2src/proxy_signature",
     "mm2src/rpc_task",
     "mm2src/trezor",
+    "mm2src/trading_api",
 ]
 
 exclude = [

--- a/mm2src/adex_cli/src/scenarios/init_mm2_cfg.rs
+++ b/mm2src/adex_cli/src/scenarios/init_mm2_cfg.rs
@@ -107,7 +107,7 @@ impl Mm2Cfg {
 
         self.dbdir = CustomType::<InquireOption<String>>::new("What is dbdir")
                 .with_placeholder(DEFAULT_OPTION_PLACEHOLDER)
-                .with_help_message("AtomicDEX API database path. Optional, defaults to a subfolder named DB in the path of your mm2 binary")
+                .with_help_message("Komodo DeFi Framework database path. Optional, defaults to a subfolder named DB in the path of your mm2 binary")
                 .with_validator(is_reachable_dir)
                 .prompt()
                 .map_err(|error|
@@ -128,7 +128,7 @@ impl Mm2Cfg {
     fn inquire_net_id(&mut self) -> Result<()> {
         self.netid = CustomType::<u16>::new("What is the network `mm2` is going to be a part, netid:")
                 .with_default(DEFAULT_NET_ID)
-                .with_help_message(r#"Network ID number, telling the AtomicDEX API which network to join. 8762 is the current main network, though alternative netids can be used for testing or "private" trades"#)
+                .with_help_message(r#"Network ID number, telling the Komodo DeFi Framework which network to join. 8762 is the current main network, though alternative netids can be used for testing or "private" trades"#)
                 .with_placeholder(format!("{DEFAULT_NET_ID}").as_str())
                 .prompt()
                 .map_err(|error|
@@ -268,7 +268,7 @@ impl Mm2Cfg {
                 .with_formatter(DEFAULT_OPTION_BOOL_FORMATTER)
                 .with_default_value_formatter(DEFAULT_DEFAULT_OPTION_BOOL_FORMATTER)
                 .with_default(InquireOption::None)
-                .with_help_message("If false the AtomicDEX API will allow rpc methods sent from external IP addresses. Optional, defaults to true. Warning: Only use this if you know what you are doing, and have put the appropriate security measures in place.")
+                .with_help_message("If false the Komodo DeFi Framework will allow rpc methods sent from external IP addresses. Optional, defaults to true. Warning: Only use this if you know what you are doing, and have put the appropriate security measures in place.")
                 .prompt()
                 .map_err(|error|
                     error_anyhow!("Failed to get rpc_local_only: {error}")
@@ -283,7 +283,7 @@ impl Mm2Cfg {
                 .with_formatter(DEFAULT_OPTION_BOOL_FORMATTER)
                 .with_default_value_formatter(DEFAULT_DEFAULT_OPTION_BOOL_FORMATTER)
                 .with_default(InquireOption::None)
-                .with_help_message("Runs AtomicDEX API as a seed node mode (acting as a relay for AtomicDEX API clients). Optional, defaults to false. Use of this mode is not reccomended on the main network (8762) as it could result in a pubkey ban if non-compliant. on alternative testing or private networks, at least one seed node is required to relay information to other AtomicDEX API clients using the same netID.")
+                .with_help_message("Runs Komodo DeFi Framework as a seed node mode (acting as a relay for Komodo DeFi Framework clients). Optional, defaults to false. Use of this mode is not reccomended on the main network (8762) as it could result in a pubkey ban if non-compliant. on alternative testing or private networks, at least one seed node is required to relay information to other Komodo DeFi Framework clients using the same netID.")
                 .prompt()
                 .map_err(|error|
                     error_anyhow!("Failed to get i_am_a_seed: {error}")

--- a/mm2src/coins/eth/eip1559_gas_fee.rs
+++ b/mm2src/coins/eth/eip1559_gas_fee.rs
@@ -1,8 +1,8 @@
 //! Provides estimations of base and priority fee per gas or fetch estimations from a gas api provider
 
 use super::web3_transport::FeeHistoryResult;
-use super::{Web3RpcError, Web3RpcResult};
-use crate::{wei_from_gwei_decimal, wei_to_gwei_decimal, EthCoin, NumConversError};
+use super::{wei_from_gwei_decimal, wei_to_gwei_decimal, Web3RpcError, Web3RpcResult};
+use crate::{EthCoin, NumConversError};
 use ethereum_types::U256;
 use mm2_err_handle::mm_error::MmError;
 use mm2_err_handle::or_mm_error::OrMmError;
@@ -104,24 +104,24 @@ impl TryFrom<InfuraFeePerGas> for FeePerGasEstimated {
 
     fn try_from(infura_fees: InfuraFeePerGas) -> Result<Self, Self::Error> {
         Ok(Self {
-            base_fee: wei_from_gwei_decimal!(&infura_fees.estimated_base_fee)?,
+            base_fee: wei_from_gwei_decimal(&infura_fees.estimated_base_fee)?,
             low: FeePerGasLevel {
-                max_fee_per_gas: wei_from_gwei_decimal!(&infura_fees.low.suggested_max_fee_per_gas)?,
-                max_priority_fee_per_gas: wei_from_gwei_decimal!(&infura_fees.low.suggested_max_priority_fee_per_gas)?,
+                max_fee_per_gas: wei_from_gwei_decimal(&infura_fees.low.suggested_max_fee_per_gas)?,
+                max_priority_fee_per_gas: wei_from_gwei_decimal(&infura_fees.low.suggested_max_priority_fee_per_gas)?,
                 min_wait_time: Some(infura_fees.low.min_wait_time_estimate),
                 max_wait_time: Some(infura_fees.low.max_wait_time_estimate),
             },
             medium: FeePerGasLevel {
-                max_fee_per_gas: wei_from_gwei_decimal!(&infura_fees.medium.suggested_max_fee_per_gas)?,
-                max_priority_fee_per_gas: wei_from_gwei_decimal!(
-                    &infura_fees.medium.suggested_max_priority_fee_per_gas
+                max_fee_per_gas: wei_from_gwei_decimal(&infura_fees.medium.suggested_max_fee_per_gas)?,
+                max_priority_fee_per_gas: wei_from_gwei_decimal(
+                    &infura_fees.medium.suggested_max_priority_fee_per_gas,
                 )?,
                 min_wait_time: Some(infura_fees.medium.min_wait_time_estimate),
                 max_wait_time: Some(infura_fees.medium.max_wait_time_estimate),
             },
             high: FeePerGasLevel {
-                max_fee_per_gas: wei_from_gwei_decimal!(&infura_fees.high.suggested_max_fee_per_gas)?,
-                max_priority_fee_per_gas: wei_from_gwei_decimal!(&infura_fees.high.suggested_max_priority_fee_per_gas)?,
+                max_fee_per_gas: wei_from_gwei_decimal(&infura_fees.high.suggested_max_fee_per_gas)?,
+                max_priority_fee_per_gas: wei_from_gwei_decimal(&infura_fees.high.suggested_max_priority_fee_per_gas)?,
                 min_wait_time: Some(infura_fees.high.min_wait_time_estimate),
                 max_wait_time: Some(infura_fees.high.max_wait_time_estimate),
             },
@@ -143,33 +143,33 @@ impl TryFrom<BlocknativeBlockPricesResponse> for FeePerGasEstimated {
             return Ok(FeePerGasEstimated::default());
         }
         Ok(Self {
-            base_fee: wei_from_gwei_decimal!(&block_prices.block_prices[0].base_fee_per_gas)?,
+            base_fee: wei_from_gwei_decimal(&block_prices.block_prices[0].base_fee_per_gas)?,
             low: FeePerGasLevel {
-                max_fee_per_gas: wei_from_gwei_decimal!(
-                    &block_prices.block_prices[0].estimated_prices[2].max_fee_per_gas
+                max_fee_per_gas: wei_from_gwei_decimal(
+                    &block_prices.block_prices[0].estimated_prices[2].max_fee_per_gas,
                 )?,
-                max_priority_fee_per_gas: wei_from_gwei_decimal!(
-                    &block_prices.block_prices[0].estimated_prices[2].max_priority_fee_per_gas
+                max_priority_fee_per_gas: wei_from_gwei_decimal(
+                    &block_prices.block_prices[0].estimated_prices[2].max_priority_fee_per_gas,
                 )?,
                 min_wait_time: None,
                 max_wait_time: None,
             },
             medium: FeePerGasLevel {
-                max_fee_per_gas: wei_from_gwei_decimal!(
-                    &block_prices.block_prices[0].estimated_prices[1].max_fee_per_gas
+                max_fee_per_gas: wei_from_gwei_decimal(
+                    &block_prices.block_prices[0].estimated_prices[1].max_fee_per_gas,
                 )?,
-                max_priority_fee_per_gas: wei_from_gwei_decimal!(
-                    &block_prices.block_prices[0].estimated_prices[1].max_priority_fee_per_gas
+                max_priority_fee_per_gas: wei_from_gwei_decimal(
+                    &block_prices.block_prices[0].estimated_prices[1].max_priority_fee_per_gas,
                 )?,
                 min_wait_time: None,
                 max_wait_time: None,
             },
             high: FeePerGasLevel {
-                max_fee_per_gas: wei_from_gwei_decimal!(
-                    &block_prices.block_prices[0].estimated_prices[0].max_fee_per_gas
+                max_fee_per_gas: wei_from_gwei_decimal(
+                    &block_prices.block_prices[0].estimated_prices[0].max_fee_per_gas,
                 )?,
-                max_priority_fee_per_gas: wei_from_gwei_decimal!(
-                    &block_prices.block_prices[0].estimated_prices[0].max_priority_fee_per_gas
+                max_priority_fee_per_gas: wei_from_gwei_decimal(
+                    &block_prices.block_prices[0].estimated_prices[0].max_priority_fee_per_gas,
                 )?,
                 min_wait_time: None,
                 max_wait_time: None,
@@ -260,7 +260,7 @@ impl FeePerGasSimpleEstimator {
         let max_priority_fee_per_gas = Self::percentile_of(&level_rewards, Self::PRIORITY_FEE_PERCENTILES[level_index]);
         // Convert the priority fee to BigDecimal gwei, falling back to 0 on error.
         let max_priority_fee_per_gas_gwei =
-            wei_to_gwei_decimal!(max_priority_fee_per_gas).unwrap_or_else(|_| BigDecimal::from(0));
+            wei_to_gwei_decimal(max_priority_fee_per_gas).unwrap_or_else(|_| BigDecimal::from(0));
 
         // Calculate the max fee per gas by adjusting the base fee and adding the priority fee.
         let adjust_max_fee =
@@ -273,7 +273,7 @@ impl FeePerGasSimpleEstimator {
 
         Ok(FeePerGasLevel {
             max_priority_fee_per_gas,
-            max_fee_per_gas: wei_from_gwei_decimal!(&max_fee_per_gas_dec)?,
+            max_fee_per_gas: wei_from_gwei_decimal(&max_fee_per_gas_dec)?,
             // TODO: Consider adding default wait times if applicable (and mark them as uncertain).
             min_wait_time: None,
             max_wait_time: None,
@@ -290,7 +290,7 @@ impl FeePerGasSimpleEstimator {
             .first()
             .cloned()
             .unwrap_or_else(|| U256::from(0));
-        let latest_base_fee_dec = wei_to_gwei_decimal!(latest_base_fee).unwrap_or_else(|_| BigDecimal::from(0));
+        let latest_base_fee_dec = wei_to_gwei_decimal(latest_base_fee).unwrap_or_else(|_| BigDecimal::from(0));
 
         // The predicted base fee is not used for calculating eip1559 values here and is provided for other purposes
         // (f.e if the caller would like to do own estimates of max fee and max priority fee)

--- a/mm2src/coins/eth/eth_rpc.rs
+++ b/mm2src/coins/eth/eth_rpc.rs
@@ -241,8 +241,8 @@ impl EthCoin {
             .and_then(|t| serde_json::from_value(t).map_err(Into::into))
     }
 
-    /// Get chain id
-    pub(crate) async fn chain_id(&self) -> Result<U256, web3::Error> {
+    /// Get chain id from network
+    pub(crate) async fn network_chain_id(&self) -> Result<U256, web3::Error> {
         self.try_rpc_send("eth_chainId", vec![])
             .await
             .and_then(|t| serde_json::from_value(t).map_err(Into::into))

--- a/mm2src/coins/eth/eth_tests.rs
+++ b/mm2src/coins/eth/eth_tests.rs
@@ -1,13 +1,13 @@
 use super::*;
 use crate::IguanaPrivKey;
-use common::{block_on, block_on_f01};
+use common::block_on;
 use mm2_core::mm_ctx::MmCtxBuilder;
 
 cfg_native!(
     use crate::eth::for_tests::{eth_coin_for_test, eth_coin_from_keypair};
     use crate::DexFee;
 
-    use common::now_sec;
+    use common::{now_sec, block_on_f01};
     use ethkey::{Generator, Random};
     use mm2_test_helpers::for_tests::{ETH_MAINNET_CHAIN_ID, ETH_MAINNET_NODE, ETH_SEPOLIA_CHAIN_ID, ETH_SEPOLIA_NODES,
                                   ETH_SEPOLIA_TOKEN_CONTRACT};

--- a/mm2src/coins/eth/eth_tests.rs
+++ b/mm2src/coins/eth/eth_tests.rs
@@ -1040,3 +1040,10 @@ fn test_gas_limit_conf() {
             && eth_coin.gas_limit.eth_max_trade_gas == 150_000
     );
 }
+
+#[test]
+fn test_h256_to_str() {
+    let h = H256::from_str("5136701f11060010841c9708c3eb26f6606a070b8ae43f4b98b6d7b10a545258").unwrap();
+    let b: BytesJson = h.0.to_vec().into();
+    println!("H256={}", format!("0x{:02x}", b));
+}

--- a/mm2src/coins/hd_wallet/storage/sqlite_storage.rs
+++ b/mm2src/coins/hd_wallet/storage/sqlite_storage.rs
@@ -101,7 +101,7 @@ impl HDWalletStorageInternalOps for HDWalletSqliteStorage {
     where
         Self: Sized,
     {
-        let shared = ctx.shared_sqlite_conn.as_option().or_mm_err(|| {
+        let shared = ctx.shared_sqlite_conn.get().or_mm_err(|| {
             HDWalletStorageError::Internal("'MmCtx::shared_sqlite_conn' is not initialized".to_owned())
         })?;
         let storage = HDWalletSqliteStorage {

--- a/mm2src/coins/lightning/ln_utils.rs
+++ b/mm2src/coins/lightning/ln_utils.rs
@@ -87,6 +87,7 @@ pub async fn init_db(ctx: &MmArc, ticker: String) -> EnableLightningResult<Sqlit
     let db = SqliteLightningDB::new(
         ticker,
         ctx.sqlite_connection
+            .get()
             .ok_or(MmError::new(EnableLightningError::DbError(
                 "sqlite_connection is not initialized".into(),
             )))?

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -220,9 +220,8 @@ pub mod coins_tests;
 pub mod eth;
 use eth::erc20::get_erc20_ticker_by_contract_address;
 use eth::eth_swap_v2::{PaymentStatusErr, PrepareTxDataError, ValidatePaymentV2Err};
-use eth::GetValidEthWithdrawAddError;
 use eth::{eth_coin_from_conf_and_request, get_eth_address, EthCoin, EthGasDetailsErr, EthTxFeeDetails,
-          GetEthAddressError, SignedEthTx};
+          GetEthAddressError, GetValidEthWithdrawAddError, SignedEthTx};
 
 pub mod hd_wallet;
 use hd_wallet::{AccountUpdatingError, AddressDerivingError, HDAccountOps, HDAddressId, HDAddressOps, HDCoinAddress,
@@ -659,6 +658,10 @@ impl TransactionErr {
             TransactionErr::Plain(err) | TransactionErr::ProtocolNotSupported(err) => err.to_string(),
         }
     }
+}
+
+impl std::fmt::Display for TransactionErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result { write!(f, "{}", self.get_plain_text_format()) }
 }
 
 #[derive(Debug, PartialEq)]

--- a/mm2src/coins/nft/nft_structs.rs
+++ b/mm2src/coins/nft/nft_structs.rs
@@ -734,14 +734,15 @@ impl NftCtx {
     /// If an `NftCtx` instance doesn't already exist in the MM context, it gets created and cached for subsequent use.
     #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn from_ctx(ctx: &MmArc) -> Result<Arc<NftCtx>, String> {
-        Ok(try_s!(from_ctx(&ctx.nft_ctx, move || {
+        from_ctx(&ctx.nft_ctx, move || {
             let async_sqlite_connection = ctx
                 .async_sqlite_connection
+                .get()
                 .ok_or("async_sqlite_connection is not initialized".to_owned())?;
             Ok(NftCtx {
                 nft_cache_db: async_sqlite_connection.clone(),
             })
-        })))
+        })
     }
 
     #[cfg(target_arch = "wasm32")]

--- a/mm2src/coins/rpc_command/get_estimated_fees.rs
+++ b/mm2src/coins/rpc_command/get_estimated_fees.rs
@@ -1,7 +1,7 @@
 //! RPCs to start/stop gas fee estimator and get estimated base and priority fee per gas
 
-use crate::eth::{EthCoin, EthCoinType, FeeEstimatorContext, FeeEstimatorState, FeePerGasEstimated};
-use crate::{lp_coinfind_or_err, wei_to_gwei_decimal, AsyncMutex, CoinFindError, MmCoinEnum, NumConversError};
+use crate::eth::{wei_to_gwei_decimal, EthCoin, EthCoinType, FeeEstimatorContext, FeeEstimatorState, FeePerGasEstimated};
+use crate::{lp_coinfind_or_err, AsyncMutex, CoinFindError, MmCoinEnum, NumConversError};
 use common::executor::{spawn_abortable, Timer};
 use common::log::debug;
 use common::{HttpStatusCode, StatusCode};
@@ -66,22 +66,22 @@ impl TryFrom<FeePerGasEstimated> for FeePerGasEstimatedExt {
 
     fn try_from(fees: FeePerGasEstimated) -> Result<Self, Self::Error> {
         Ok(Self {
-            base_fee: wei_to_gwei_decimal!(fees.base_fee)?,
+            base_fee: wei_to_gwei_decimal(fees.base_fee)?,
             low: FeePerGasLevel {
-                max_fee_per_gas: wei_to_gwei_decimal!(fees.low.max_fee_per_gas)?,
-                max_priority_fee_per_gas: wei_to_gwei_decimal!(fees.low.max_priority_fee_per_gas)?,
+                max_fee_per_gas: wei_to_gwei_decimal(fees.low.max_fee_per_gas)?,
+                max_priority_fee_per_gas: wei_to_gwei_decimal(fees.low.max_priority_fee_per_gas)?,
                 min_wait_time: fees.low.min_wait_time,
                 max_wait_time: fees.low.max_wait_time,
             },
             medium: FeePerGasLevel {
-                max_fee_per_gas: wei_to_gwei_decimal!(fees.medium.max_fee_per_gas)?,
-                max_priority_fee_per_gas: wei_to_gwei_decimal!(fees.medium.max_priority_fee_per_gas)?,
+                max_fee_per_gas: wei_to_gwei_decimal(fees.medium.max_fee_per_gas)?,
+                max_priority_fee_per_gas: wei_to_gwei_decimal(fees.medium.max_priority_fee_per_gas)?,
                 min_wait_time: fees.medium.min_wait_time,
                 max_wait_time: fees.medium.max_wait_time,
             },
             high: FeePerGasLevel {
-                max_fee_per_gas: wei_to_gwei_decimal!(fees.high.max_fee_per_gas)?,
-                max_priority_fee_per_gas: wei_to_gwei_decimal!(fees.high.max_priority_fee_per_gas)?,
+                max_fee_per_gas: wei_to_gwei_decimal(fees.high.max_fee_per_gas)?,
+                max_priority_fee_per_gas: wei_to_gwei_decimal(fees.high.max_priority_fee_per_gas)?,
                 min_wait_time: fees.high.min_wait_time,
                 max_wait_time: fees.high.max_wait_time,
             },

--- a/mm2src/coins/tx_history_storage/sql_tx_history_storage_v2.rs
+++ b/mm2src/coins/tx_history_storage/sql_tx_history_storage_v2.rs
@@ -376,11 +376,12 @@ pub struct SqliteTxHistoryStorage(Arc<Mutex<Connection>>);
 
 impl SqliteTxHistoryStorage {
     pub fn new(ctx: &MmArc) -> Result<Self, MmError<CreateTxHistoryStorageError>> {
-        let sqlite_connection = ctx
-            .sqlite_connection
-            .ok_or(MmError::new(CreateTxHistoryStorageError::Internal(
-                "sqlite_connection is not initialized".to_owned(),
-            )))?;
+        let sqlite_connection =
+            ctx.sqlite_connection
+                .get()
+                .ok_or(MmError::new(CreateTxHistoryStorageError::Internal(
+                    "sqlite_connection is not initialized".to_owned(),
+                )))?;
         Ok(SqliteTxHistoryStorage(sqlite_connection.clone()))
     }
 }

--- a/mm2src/common/Cargo.toml
+++ b/mm2src/common/Cargo.toml
@@ -34,6 +34,7 @@ lazy_static = "1.4"
 log = "0.4.17"
 parking_lot = { version = "0.12.0", features = ["nightly"] }
 parking_lot_core = { version = "0.6", features = ["nightly"] }
+paste = "1.0"
 primitive-types = "0.11.1"
 rand = { version = "0.7", features = ["std", "small_rng"] }
 rustc-hash = "1.1.0"

--- a/mm2src/common/common.rs
+++ b/mm2src/common/common.rs
@@ -152,6 +152,7 @@ use futures01::{future, Future};
 use http::header::CONTENT_TYPE;
 use http::Response;
 use parking_lot::{Mutex as PaMutex, MutexGuard as PaMutexGuard};
+pub use paste::paste;
 use rand::RngCore;
 use rand::{rngs::SmallRng, SeedableRng};
 use serde::{de, ser};
@@ -1127,6 +1128,37 @@ pub fn http_uri_to_ws_address(uri: http::Uri) -> String {
     let port = uri.port_u16().map(|p| format!(":{}", p)).unwrap_or_default();
 
     format!("{}{}{}{}", address_prefix, host_address, port, path)
+}
+
+/// If 0x prefix exists in an str strip it or return the str as-is  
+#[macro_export]
+macro_rules! str_strip_0x {
+    ($s: expr) => {
+        $s.strip_prefix("0x").unwrap_or($s)
+    };
+}
+
+/// If value is 'some' push key and value (as string) into an array containing (key, value) elements
+#[macro_export]
+macro_rules! push_if_some {
+    ($arr: expr, $k: expr, $v: expr) => {
+        if let Some(v) = $v {
+            $arr.push(($k, v.to_string()))
+        }
+    };
+}
+
+/// Define 'with_...' method to set a parameter with an optional value in a builder
+#[macro_export]
+macro_rules! def_with_opt_param {
+    ($var: ident, $var_type: ty) => {
+        $crate::paste! {
+            pub fn [<with_ $var>](&mut self, $var: Option<$var_type>) -> &mut Self {
+                self.$var = $var;
+                self
+            }
+        }
+    };
 }
 
 #[test]

--- a/mm2src/crypto/src/crypto_ctx.rs
+++ b/mm2src/crypto/src/crypto_ctx.rs
@@ -316,10 +316,12 @@ impl CryptoCtx {
         *ctx_field = Some(result.clone());
         drop(ctx_field);
 
-        ctx.rmd160.pin(rmd160).map_to_mm(CryptoInitError::Internal)?;
+        ctx.rmd160
+            .set(rmd160)
+            .map_to_mm(|_| CryptoInitError::Internal("Already Initialized".to_string()))?;
         ctx.shared_db_id
-            .pin(shared_db_id)
-            .map_to_mm(CryptoInitError::Internal)?;
+            .set(shared_db_id)
+            .map_to_mm(|_| CryptoInitError::Internal("Already Initialized".to_string()))?;
 
         info!("Public key hash: {rmd160}");
         info!("Shared Database ID: {shared_db_id}");

--- a/mm2src/mm2_bin_lib/Cargo.toml
+++ b/mm2src/mm2_bin_lib/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "mm2_bin_lib"
-version = "2.2.0-beta"
+version = "2.3.0-beta"
 authors = ["James Lee", "Artem Pikulin", "Artem Grinblat", "Omar S.", "Onur Ozkan", "Alina Sharon", "Caglar Kaya", "Cipi", "Sergey Boiko", "Samuel Onoja", "Roman Sztergbaum", "Kadan Stadelmann <ca333@komodoplatform.com>", "Dimxy", "Omer Yacine"]
 edition = "2018"
 default-run = "kdf"

--- a/mm2src/mm2_bin_lib/src/lib.rs
+++ b/mm2src/mm2_bin_lib/src/lib.rs
@@ -41,7 +41,7 @@ fn mm2_status() -> MainStatus {
         Err(_) => return MainStatus::NoRpc,
     };
 
-    if ctx.rpc_started.copy_or(false) {
+    if *ctx.rpc_started.get().unwrap_or(&false) {
         MainStatus::RpcIsUp
     } else {
         MainStatus::NoRpc

--- a/mm2src/mm2_bin_lib/src/mm2_wasm_lib.rs
+++ b/mm2src/mm2_bin_lib/src/mm2_wasm_lib.rs
@@ -216,7 +216,7 @@ pub async fn mm2_rpc(payload: JsValue) -> Result<JsValue, JsValue> {
         Err(_) => return Err(Mm2RpcErr::NotRunning.into()),
     };
 
-    let wasm_rpc = ctx.wasm_rpc.ok_or(JsValue::from(Mm2RpcErr::NotRunning))?;
+    let wasm_rpc = ctx.wasm_rpc.get().ok_or(JsValue::from(Mm2RpcErr::NotRunning))?;
     let response: Mm2RpcResponse = wasm_rpc.request(request_json).await.into();
 
     serialize_to_js(&response).map_err(|e| {

--- a/mm2src/mm2_bitcoin/rpc/src/lib.rs
+++ b/mm2src/mm2_bitcoin/rpc/src/lib.rs
@@ -1,4 +1,3 @@
-extern crate core;
 #[cfg(test)] extern crate lazy_static;
 extern crate log;
 extern crate rustc_hex as hex;

--- a/mm2src/mm2_bitcoin/rpc/src/v1/types/bytes.rs
+++ b/mm2src/mm2_bitcoin/rpc/src/v1/types/bytes.rs
@@ -85,8 +85,8 @@ impl ops::Deref for Bytes {
     fn deref(&self) -> &Self::Target { &self.0 }
 }
 
-impl ::core::fmt::LowerHex for Bytes {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+impl ::std::fmt::LowerHex for Bytes {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         for i in &self.0[..] {
             write!(f, "{:02x}", i)?;
         }

--- a/mm2src/mm2_bitcoin/rpc/src/v1/types/hash.rs
+++ b/mm2src/mm2_bitcoin/rpc/src/v1/types/hash.rs
@@ -147,8 +147,8 @@ macro_rules! impl_hash {
             }
         }
 
-        impl ::core::fmt::LowerHex for $name {
-            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        impl ::std::fmt::LowerHex for $name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 for i in &self.0[..] {
                     write!(f, "{:02x}", i)?;
                 }

--- a/mm2src/mm2_core/Cargo.toml
+++ b/mm2src/mm2_core/Cargo.toml
@@ -18,7 +18,7 @@ futures = { version = "0.3", package = "futures", features = ["compat", "async-a
 gstuff = { version = "0.7", features = ["nightly"] }
 hex = "0.4.2"
 lazy_static = "1.4"
-libp2p = { git = "https://github.com/KomodoPlatform/rust-libp2p.git", tag = "k-0.52.4", default-features = false, features = ["identify"] }
+libp2p = { git = "https://github.com/KomodoPlatform/rust-libp2p.git", tag = "k-0.52.11", default-features = false, features = ["identify"] }
 mm2_err_handle = { path = "../mm2_err_handle" }
 mm2_event_stream = { path = "../mm2_event_stream" }
 mm2_metrics = { path = "../mm2_metrics" }

--- a/mm2src/mm2_core/Cargo.toml
+++ b/mm2src/mm2_core/Cargo.toml
@@ -15,6 +15,7 @@ common = { path = "../common" }
 db_common = { path = "../db_common" }
 derive_more = "0.99"
 futures = { version = "0.3", package = "futures", features = ["compat", "async-await", "thread-pool"] }
+gstuff = { version = "0.7", features = ["nightly"] }
 hex = "0.4.2"
 lazy_static = "1.4"
 libp2p = { git = "https://github.com/KomodoPlatform/rust-libp2p.git", tag = "k-0.52.4", default-features = false, features = ["identify"] }
@@ -31,13 +32,11 @@ shared_ref_counter = { path = "../common/shared_ref_counter" }
 uuid = { version = "1.2.2", features = ["fast-rng", "serde", "v4"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-gstuff = { version = "0.7", features = ["nightly"] }
 instant = { version = "0.1.12", features = ["wasm-bindgen"] }
 mm2_rpc = { path = "../mm2_rpc", features = [ "rpc_facilities" ] }
 wasm-bindgen-test = { version = "0.3.2" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rustls = { version = "0.21", default-features = false }
-gstuff = { version = "0.7", features = ["nightly"] }
 instant = "0.1.12"
 tokio = { version = "1.20", features = ["io-util", "rt-multi-thread", "net"] }

--- a/mm2src/mm2_core/src/mm_ctx.rs
+++ b/mm2src/mm2_core/src/mm_ctx.rs
@@ -7,7 +7,7 @@ use common::{executor::{abortable_queue::{AbortableQueue, WeakSpawner},
              expirable_map::ExpirableMap};
 use futures::channel::oneshot;
 use futures::lock::Mutex as AsyncMutex;
-use gstuff::{try_s, Constructible, ERR, ERRL};
+use gstuff::{try_s, ERR, ERRL};
 use lazy_static::lazy_static;
 use libp2p::PeerId;
 use mm2_event_stream::{controller::Controller, Event, EventStreamConfiguration};
@@ -22,7 +22,7 @@ use std::collections::HashSet;
 use std::fmt;
 use std::future::Future;
 use std::ops::Deref;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::data_asker::DataAsker;
 
@@ -76,9 +76,9 @@ pub struct MmCtx {
     /// Should be refactored away in the future. State should always be valid.
     /// If there are things that are loaded in background then they should be separately optional,
     /// without invalidating the entire state.
-    pub initialized: Constructible<bool>,
+    pub initialized: OnceLock<bool>,
     /// True if the RPC HTTP server was started.
-    pub rpc_started: Constructible<bool>,
+    pub rpc_started: OnceLock<bool>,
     /// Controller for continuously streaming data using streaming channels of `mm2_event_stream`.
     pub stream_channel_controller: Controller<Event>,
     /// Data transfer bridge between server and client where server (which is the mm2 runtime) initiates the request.
@@ -86,10 +86,10 @@ pub struct MmCtx {
     /// Configuration of event streaming used for SSE.
     pub event_stream_configuration: Option<EventStreamConfiguration>,
     /// True if the MarketMaker instance needs to stop.
-    pub stop: Constructible<bool>,
+    pub stop: OnceLock<bool>,
     /// Unique context identifier, allowing us to more easily pass the context through the FFI boundaries.  
     /// 0 if the handler ID is allocated yet.
-    pub ffi_handle: Constructible<u32>,
+    pub ffi_handle: OnceLock<u32>,
     /// The context belonging to the `ordermatch` mod: `OrdermatchContext`.
     pub ordermatch_ctx: Mutex<Option<Arc<dyn Any + 'static + Send + Sync>>>,
     pub rate_limit_ctx: Mutex<Option<Arc<dyn Any + 'static + Send + Sync>>>,
@@ -104,10 +104,10 @@ pub struct MmCtx {
     pub crypto_ctx: Mutex<Option<Arc<dyn Any + 'static + Send + Sync>>>,
     /// RIPEMD160(SHA256(x)) where x is secp256k1 pubkey derived from passphrase.
     /// This hash is **unique** among Iguana and each HD accounts derived from the same passphrase.
-    pub rmd160: Constructible<H160>,
+    pub rmd160: OnceLock<H160>,
     /// A shared DB identifier - RIPEMD160(SHA256(x)) where x is secp256k1 pubkey derived from (passphrase + magic salt).
     /// This hash is **the same** for Iguana and all HD accounts derived from the same passphrase.
-    pub shared_db_id: Constructible<H160>,
+    pub shared_db_id: OnceLock<H160>,
     /// Coins that should be enabled to kick start the interrupted swaps and orders.
     pub coins_needed_for_kick_start: Mutex<HashSet<String>>,
     /// The context belonging to the `lp_swap` mod: `SwapsContext`.
@@ -115,19 +115,19 @@ pub struct MmCtx {
     /// The context belonging to the `lp_stats` mod: `StatsContext`
     pub stats_ctx: Mutex<Option<Arc<dyn Any + 'static + Send + Sync>>>,
     /// Wallet name for this mm2 instance. Optional for backwards compatibility.
-    pub wallet_name: Constructible<Option<String>>,
+    pub wallet_name: OnceLock<Option<String>>,
     /// The context belonging to the `lp_wallet` mod: `WalletsContext`.
     #[cfg(target_arch = "wasm32")]
     pub wallets_ctx: Mutex<Option<Arc<dyn Any + 'static + Send + Sync>>>,
     /// The RPC sender forwarding requests to writing part of underlying stream.
     #[cfg(target_arch = "wasm32")]
-    pub wasm_rpc: Constructible<WasmRpcSender>,
+    pub wasm_rpc: OnceLock<WasmRpcSender>,
     /// Deprecated, please use `async_sqlite_connection` for new implementations.
     #[cfg(not(target_arch = "wasm32"))]
-    pub sqlite_connection: Constructible<Arc<Mutex<Connection>>>,
+    pub sqlite_connection: OnceLock<Arc<Mutex<Connection>>>,
     /// Deprecated, please create `shared_async_sqlite_conn` for new implementations and call db `KOMODEFI-shared.db`.
     #[cfg(not(target_arch = "wasm32"))]
-    pub shared_sqlite_conn: Constructible<Arc<Mutex<Connection>>>,
+    pub shared_sqlite_conn: OnceLock<Arc<Mutex<Connection>>>,
     pub mm_version: String,
     pub datetime: String,
     pub mm_init_ctx: Mutex<Option<Arc<dyn Any + 'static + Send + Sync>>>,
@@ -144,7 +144,7 @@ pub struct MmCtx {
     pub nft_ctx: Mutex<Option<Arc<dyn Any + 'static + Send + Sync>>>,
     /// asynchronous handle for rusqlite connection.
     #[cfg(not(target_arch = "wasm32"))]
-    pub async_sqlite_connection: Constructible<Arc<AsyncMutex<AsyncConnection>>>,
+    pub async_sqlite_connection: OnceLock<Arc<AsyncMutex<AsyncConnection>>>,
     /// Links the RPC context to the P2P context to handle health check responses.
     pub healthcheck_response_handler: AsyncMutex<ExpirableMap<PeerId, oneshot::Sender<()>>>,
 }
@@ -155,13 +155,13 @@ impl MmCtx {
             conf: Json::Object(json::Map::new()),
             log: log::LogArc::new(log),
             metrics: MetricsArc::new(),
-            initialized: Constructible::default(),
-            rpc_started: Constructible::default(),
+            initialized: OnceLock::default(),
+            rpc_started: OnceLock::default(),
             stream_channel_controller: Controller::new(),
             data_asker: DataAsker::default(),
             event_stream_configuration: None,
-            stop: Constructible::default(),
-            ffi_handle: Constructible::default(),
+            stop: OnceLock::default(),
+            ffi_handle: OnceLock::default(),
             ordermatch_ctx: Mutex::new(None),
             rate_limit_ctx: Mutex::new(None),
             simple_market_maker_bot_ctx: Mutex::new(None),
@@ -172,20 +172,20 @@ impl MmCtx {
             coins_ctx: Mutex::new(None),
             coins_activation_ctx: Mutex::new(None),
             crypto_ctx: Mutex::new(None),
-            rmd160: Constructible::default(),
-            shared_db_id: Constructible::default(),
+            rmd160: OnceLock::default(),
+            shared_db_id: OnceLock::default(),
             coins_needed_for_kick_start: Mutex::new(HashSet::new()),
             swaps_ctx: Mutex::new(None),
             stats_ctx: Mutex::new(None),
-            wallet_name: Constructible::default(),
+            wallet_name: OnceLock::default(),
             #[cfg(target_arch = "wasm32")]
             wallets_ctx: Mutex::new(None),
             #[cfg(target_arch = "wasm32")]
-            wasm_rpc: Constructible::default(),
+            wasm_rpc: OnceLock::default(),
             #[cfg(not(target_arch = "wasm32"))]
-            sqlite_connection: Constructible::default(),
+            sqlite_connection: OnceLock::default(),
             #[cfg(not(target_arch = "wasm32"))]
-            shared_sqlite_conn: Constructible::default(),
+            shared_sqlite_conn: OnceLock::default(),
             mm_version: "".into(),
             datetime: "".into(),
             mm_init_ctx: Mutex::new(None),
@@ -195,7 +195,7 @@ impl MmCtx {
             db_namespace: DbNamespaceId::Main,
             nft_ctx: Mutex::new(None),
             #[cfg(not(target_arch = "wasm32"))]
-            async_sqlite_connection: Constructible::default(),
+            async_sqlite_connection: OnceLock::default(),
             healthcheck_response_handler: AsyncMutex::new(ExpirableMap::default()),
         }
     }
@@ -204,14 +204,14 @@ impl MmCtx {
         lazy_static! {
             static ref DEFAULT: H160 = [0; 20].into();
         }
-        self.rmd160.or(&|| &*DEFAULT)
+        self.rmd160.get().unwrap_or(&*DEFAULT)
     }
 
     pub fn shared_db_id(&self) -> &H160 {
         lazy_static! {
             static ref DEFAULT: H160 = [0; 20].into();
         }
-        self.shared_db_id.or(&|| &*DEFAULT)
+        self.shared_db_id.get().unwrap_or(&*DEFAULT)
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -346,7 +346,7 @@ impl MmCtx {
     pub fn spawner(&self) -> MmFutSpawner { MmFutSpawner::new(&self.abortable_system) }
 
     /// True if the MarketMaker instance needs to stop.
-    pub fn is_stopping(&self) -> bool { self.stop.copy_or(false) }
+    pub fn is_stopping(&self) -> bool { *self.stop.get().unwrap_or(&false) }
 
     pub fn gui(&self) -> Option<&str> { self.conf["gui"].as_str() }
 
@@ -357,7 +357,10 @@ impl MmCtx {
         let sqlite_file_path = self.dbdir().join("MM2.db");
         log_sqlite_file_open_attempt(&sqlite_file_path);
         let connection = try_s!(Connection::open(sqlite_file_path));
-        try_s!(self.sqlite_connection.pin(Arc::new(Mutex::new(connection))));
+        try_s!(self
+            .sqlite_connection
+            .set(Arc::new(Mutex::new(connection)))
+            .map_err(|_| "Already initialized".to_string()));
         Ok(())
     }
 
@@ -366,7 +369,10 @@ impl MmCtx {
         let sqlite_file_path = self.shared_dbdir().join("MM2-shared.db");
         log_sqlite_file_open_attempt(&sqlite_file_path);
         let connection = try_s!(Connection::open(sqlite_file_path));
-        try_s!(self.shared_sqlite_conn.pin(Arc::new(Mutex::new(connection))));
+        try_s!(self
+            .shared_sqlite_conn
+            .set(Arc::new(Mutex::new(connection)))
+            .map_err(|_| "Already initialized".to_string()));
         Ok(())
     }
 
@@ -375,19 +381,23 @@ impl MmCtx {
         let sqlite_file_path = self.dbdir().join("KOMODEFI.db");
         log_sqlite_file_open_attempt(&sqlite_file_path);
         let async_conn = try_s!(AsyncConnection::open(sqlite_file_path).await);
-        try_s!(self.async_sqlite_connection.pin(Arc::new(AsyncMutex::new(async_conn))));
+        try_s!(self
+            .async_sqlite_connection
+            .set(Arc::new(AsyncMutex::new(async_conn)))
+            .map_err(|_| "Already initialized".to_string()));
         Ok(())
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     pub fn sqlite_conn_opt(&self) -> Option<MutexGuard<Connection>> {
-        self.sqlite_connection.as_option().map(|conn| conn.lock().unwrap())
+        self.sqlite_connection.get().map(|conn| conn.lock().unwrap())
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     pub fn sqlite_connection(&self) -> MutexGuard<Connection> {
         self.sqlite_connection
-            .or(&|| panic!("sqlite_connection is not initialized"))
+            .get()
+            .expect("sqlite_connection is not initialized")
             .lock()
             .unwrap()
     }
@@ -395,7 +405,8 @@ impl MmCtx {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn shared_sqlite_conn(&self) -> MutexGuard<Connection> {
         self.shared_sqlite_conn
-            .or(&|| panic!("shared_sqlite_conn is not initialized"))
+            .get()
+            .expect("shared_sqlite_conn is not initialized")
             .lock()
             .unwrap()
     }
@@ -409,7 +420,7 @@ impl Drop for MmCtx {
     fn drop(&mut self) {
         let ffi_handle = self
             .ffi_handle
-            .as_option()
+            .get()
             .map(|handle| handle.to_string())
             .unwrap_or_else(|| "UNKNOWN".to_owned());
         log::info!("MmCtx ({}) has been dropped", ffi_handle)
@@ -512,7 +523,7 @@ impl MmArc {
         #[cfg(not(target_arch = "wasm32"))]
         try_s!(self.close_async_connection().await);
 
-        try_s!(self.stop.pin(true));
+        try_s!(self.stop.set(true));
 
         // Notify shutdown listeners.
         self.graceful_shutdown_registry.abort_all().warn_log();
@@ -527,7 +538,7 @@ impl MmArc {
 
     #[cfg(not(target_arch = "wasm32"))]
     async fn close_async_connection(&self) -> Result<(), db_common::async_sql_conn::AsyncConnError> {
-        if let Some(async_conn) = self.async_sqlite_connection.as_option() {
+        if let Some(async_conn) = self.async_sqlite_connection.get() {
             let mut conn = async_conn.lock().await;
             conn.close().await?;
         }
@@ -560,7 +571,7 @@ impl MmArc {
     /// Unique context identifier, allowing us to more easily pass the context through the FFI boundaries.
     pub fn ffi_handle(&self) -> Result<u32, String> {
         let mut mm_ctx_ffi = try_s!(MM_CTX_FFI.lock());
-        if let Some(have) = self.ffi_handle.as_option() {
+        if let Some(have) = self.ffi_handle.get() {
             return Ok(*have);
         }
         let mut tries = 0;
@@ -579,7 +590,7 @@ impl MmArc {
                 Entry::Occupied(_) => continue, // Try another ID.
                 Entry::Vacant(ve) => {
                     ve.insert(self.weak());
-                    try_s!(self.ffi_handle.pin(rid));
+                    try_s!(self.ffi_handle.set(rid));
                     return Ok(rid);
                 },
             }
@@ -698,25 +709,19 @@ impl SpawnAbortable for MmFutSpawner {
 ///
 /// * `ctx_field` - A dedicated crate context field in `MmCtx`, such as the `MmCtx::portfolio_ctx`.
 /// * `constructor` - Generates the initial crate context.
-pub fn from_ctx<T, C>(
-    ctx_field: &Mutex<Option<Arc<dyn Any + 'static + Send + Sync>>>,
-    constructor: C,
-) -> Result<Arc<T>, String>
+pub fn from_ctx<T, F>(ctx: &Mutex<Option<Arc<dyn Any + Send + Sync>>>, init: F) -> Result<Arc<T>, String>
 where
-    C: FnOnce() -> Result<T, String>,
     T: 'static + Send + Sync,
+    F: FnOnce() -> Result<T, String>,
 {
-    let mut ctx_field = try_s!(ctx_field.lock());
-    if let Some(ref ctx) = *ctx_field {
-        let ctx: Arc<T> = match ctx.clone().downcast() {
-            Ok(p) => p,
-            Err(_) => return ERR!("Error casting the context field"),
-        };
-        return Ok(ctx);
+    let mut guard = try_s!(ctx.lock());
+    if let Some(ctx) = guard.as_ref() {
+        return ctx.clone().downcast().map_err(|_| "Context type mismatch".to_string());
     }
-    let arc = Arc::new(try_s!(constructor()));
-    *ctx_field = Some(arc.clone());
-    Ok(arc)
+
+    let new_ctx = Arc::new(init()?);
+    *guard = Some(new_ctx.clone());
+    Ok(new_ctx)
 }
 
 #[derive(Default)]

--- a/mm2src/mm2_gui_storage/src/account/storage/sqlite_storage.rs
+++ b/mm2src/mm2_gui_storage/src/account/storage/sqlite_storage.rs
@@ -118,7 +118,7 @@ impl SqliteAccountStorage {
     pub(crate) fn new(ctx: &MmArc) -> AccountStorageResult<SqliteAccountStorage> {
         let shared = ctx
             .sqlite_connection
-            .as_option()
+            .get()
             .or_mm_err(|| AccountStorageError::Internal("'MmCtx::sqlite_connection' is not initialized".to_owned()))?;
         Ok(SqliteAccountStorage {
             conn: Arc::clone(shared),

--- a/mm2src/mm2_main/Cargo.toml
+++ b/mm2src/mm2_main/Cargo.toml
@@ -71,10 +71,12 @@ mm2_net = { path = "../mm2_net" }
 mm2_number = { path = "../mm2_number" }
 mm2_rpc = { path = "../mm2_rpc", features = ["rpc_facilities"]}
 mm2_state_machine = { path = "../mm2_state_machine" }
+trading_api = { path = "../trading_api" }
 num-traits = "0.2"
 parity-util-mem = "0.11"
 parking_lot = { version = "0.12.0", features = ["nightly"] }
 primitives = { path = "../mm2_bitcoin/primitives" }
+primitive-types = "0.11.1"
 prost = "0.12"
 rand = { version = "0.7", features = ["std", "small_rng"] }
 rand6 = { version = "0.6", package = "rand" }
@@ -123,6 +125,7 @@ winapi = "0.3"
 coins = { path = "../coins", features = ["for-tests"] }
 coins_activation = { path = "../coins_activation", features = ["for-tests"] }
 mm2_test_helpers = { path = "../mm2_test_helpers" }
+trading_api = { path = "../trading_api", features = ["mocktopus"] }
 mocktopus = "0.8.0"
 testcontainers = "0.15.0"
 web3 = { git = "https://github.com/KomodoPlatform/rust-web3", tag = "v0.20.0", default-features = false, features = ["http-rustls-tls"] }

--- a/mm2src/mm2_main/src/ext_api.rs
+++ b/mm2src/mm2_main/src/ext_api.rs
@@ -1,0 +1,3 @@
+//! RPCs for integration with external third party trading APIs.
+
+pub mod one_inch;

--- a/mm2src/mm2_main/src/lp_native_dex.rs
+++ b/mm2src/mm2_main/src/lp_native_dex.rs
@@ -476,7 +476,9 @@ pub async fn lp_init_continue(ctx: MmArc) -> MmInitResult<()> {
     let balance_update_ordermatch_handler = BalanceUpdateOrdermatchHandler::new(ctx.clone());
     register_balance_update_handler(ctx.clone(), Box::new(balance_update_ordermatch_handler)).await;
 
-    ctx.initialized.pin(true).map_to_mm(MmInitError::Internal)?;
+    ctx.initialized
+        .set(true)
+        .map_to_mm(|_| MmInitError::Internal("Already Initialized".to_string()))?;
 
     // launch kickstart threads before RPC is available, this will prevent the API user to place
     // an order and start new swap that might get started 2 times because of kick-start

--- a/mm2src/mm2_main/src/lp_wallet/mnemonics_storage.rs
+++ b/mm2src/mm2_main/src/lp_wallet/mnemonics_storage.rs
@@ -47,6 +47,7 @@ pub(super) async fn save_encrypted_passphrase(
 pub(super) async fn read_encrypted_passphrase_if_available(ctx: &MmArc) -> WalletsStorageResult<Option<EncryptedData>> {
     let wallet_name = ctx
         .wallet_name
+        .get()
         .ok_or(WalletsStorageError::Internal(
             "`wallet_name` not initialized yet!".to_string(),
         ))?

--- a/mm2src/mm2_main/src/lp_wallet/mnemonics_wasm_db.rs
+++ b/mm2src/mm2_main/src/lp_wallet/mnemonics_wasm_db.rs
@@ -126,6 +126,7 @@ pub(super) async fn read_encrypted_passphrase_if_available(ctx: &MmArc) -> Walle
 
     let wallet_name = ctx
         .wallet_name
+        .get()
         .ok_or(WalletsDBError::Internal(
             "`wallet_name` not initialized yet!".to_string(),
         ))?

--- a/mm2src/mm2_main/src/mm2.rs
+++ b/mm2src/mm2_main/src/mm2.rs
@@ -277,7 +277,7 @@ pub fn mm2_main(version: String, datetime: String) {
     }
 
     if first_arg == Some("--version") || first_arg == Some("-v") || first_arg == Some("version") {
-        println!("AtomicDEX API: {version}");
+        println!("Komodo DeFi Framework: {version}");
         return;
     }
 
@@ -291,7 +291,7 @@ pub fn mm2_main(version: String, datetime: String) {
         return;
     }
 
-    log!("AtomicDEX API {} DT {}", version, datetime);
+    log!("Komodo DeFi Framework {} DT {}", version, datetime);
 
     if let Err(err) = run_lp_main(first_arg, &|_| (), version, datetime) {
         log!("{}", err);

--- a/mm2src/mm2_main/src/ordermatch_tests.rs
+++ b/mm2src/mm2_main/src/ordermatch_tests.rs
@@ -1055,7 +1055,10 @@ fn test_cancel_by_single_coin() {
     let rx = prepare_for_cancel_by(&ctx);
 
     let connection = Connection::open_in_memory().unwrap();
-    let _ = ctx.sqlite_connection.pin(Arc::new(Mutex::new(connection)));
+    let _ = ctx
+        .sqlite_connection
+        .set(Arc::new(Mutex::new(connection)))
+        .map_err(|_| "Already Initialized".to_string());
 
     delete_my_maker_order.mock_safe(|_, _, _| MockResult::Return(Box::new(futures01::future::ok(()))));
     delete_my_taker_order.mock_safe(|_, _, _| MockResult::Return(Box::new(futures01::future::ok(()))));
@@ -1074,7 +1077,10 @@ fn test_cancel_by_pair() {
     let rx = prepare_for_cancel_by(&ctx);
 
     let connection = Connection::open_in_memory().unwrap();
-    let _ = ctx.sqlite_connection.pin(Arc::new(Mutex::new(connection)));
+    let _ = ctx
+        .sqlite_connection
+        .set(Arc::new(Mutex::new(connection)))
+        .map_err(|_| "Already Initialized".to_string());
 
     delete_my_maker_order.mock_safe(|_, _, _| MockResult::Return(Box::new(futures01::future::ok(()))));
     delete_my_taker_order.mock_safe(|_, _, _| MockResult::Return(Box::new(futures01::future::ok(()))));
@@ -1097,7 +1103,10 @@ fn test_cancel_by_all() {
     let rx = prepare_for_cancel_by(&ctx);
 
     let connection = Connection::open_in_memory().unwrap();
-    let _ = ctx.sqlite_connection.pin(Arc::new(Mutex::new(connection)));
+    let _ = ctx
+        .sqlite_connection
+        .set(Arc::new(Mutex::new(connection)))
+        .map_err(|_| "Already Initialized".to_string());
 
     delete_my_maker_order.mock_safe(|_, _, _| MockResult::Return(Box::new(futures01::future::ok(()))));
     delete_my_taker_order.mock_safe(|_, _, _| MockResult::Return(Box::new(futures01::future::ok(()))));

--- a/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
+++ b/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
@@ -11,8 +11,14 @@ use crate::lp_swap::swap_v2_rpcs::{active_swaps_rpc, my_recent_swaps_rpc, my_swa
 use crate::lp_swap::{get_locked_amount_rpc, max_maker_vol, recreate_swap_data, trade_preimage_rpc};
 use crate::lp_wallet::{get_mnemonic_rpc, get_wallet_names_rpc};
 use crate::rpc::lp_commands::db_id::get_shared_db_id;
+use crate::rpc::lp_commands::one_inch::rpcs::{one_inch_v6_0_classic_swap_contract_rpc,
+                                              one_inch_v6_0_classic_swap_create_rpc,
+                                              one_inch_v6_0_classic_swap_liquidity_sources_rpc,
+                                              one_inch_v6_0_classic_swap_quote_rpc,
+                                              one_inch_v6_0_classic_swap_tokens_rpc};
 use crate::rpc::lp_commands::pubkey::*;
 use crate::rpc::lp_commands::tokens::get_token_info;
+use crate::rpc::lp_commands::tokens::{approve_token_rpc, get_token_allowance_rpc};
 use crate::rpc::lp_commands::trezor::trezor_connection_status;
 use crate::rpc::rate_limiter::{process_rate_limit, RateLimitContext};
 use coins::eth::EthCoin;
@@ -162,6 +168,8 @@ async fn dispatcher_v2(request: MmRpcRequest, ctx: MmArc) -> DispatcherResult<Re
         "active_swaps" => handle_mmrpc(ctx, request, active_swaps_rpc).await,
         "add_delegation" => handle_mmrpc(ctx, request, add_delegation).await,
         "add_node_to_version_stat" => handle_mmrpc(ctx, request, add_node_to_version_stat).await,
+        "approve_token" => handle_mmrpc(ctx, request, approve_token_rpc).await,
+        "get_token_allowance" => handle_mmrpc(ctx, request, get_token_allowance_rpc).await,
         "best_orders" => handle_mmrpc(ctx, request, best_orders_rpc_v2).await,
         "clear_nft_db" => handle_mmrpc(ctx, request, clear_nft_db).await,
         "enable_bch_with_tokens" => handle_mmrpc(ctx, request, enable_platform_coin_with_tokens::<BchCoin>).await,
@@ -221,6 +229,13 @@ async fn dispatcher_v2(request: MmRpcRequest, ctx: MmArc) -> DispatcherResult<Re
         "set_swap_transaction_fee_policy" => handle_mmrpc(ctx, request, set_swap_transaction_fee_policy).await,
         "send_asked_data" => handle_mmrpc(ctx, request, send_asked_data_rpc).await,
         "z_coin_tx_history" => handle_mmrpc(ctx, request, coins::my_tx_history_v2::z_coin_tx_history_rpc).await,
+        "1inch_v6_0_classic_swap_contract" => handle_mmrpc(ctx, request, one_inch_v6_0_classic_swap_contract_rpc).await,
+        "1inch_v6_0_classic_swap_quote" => handle_mmrpc(ctx, request, one_inch_v6_0_classic_swap_quote_rpc).await,
+        "1inch_v6_0_classic_swap_create" => handle_mmrpc(ctx, request, one_inch_v6_0_classic_swap_create_rpc).await,
+        "1inch_v6_0_classic_swap_liquidity_sources" => {
+            handle_mmrpc(ctx, request, one_inch_v6_0_classic_swap_liquidity_sources_rpc).await
+        },
+        "1inch_v6_0_classic_swap_tokens" => handle_mmrpc(ctx, request, one_inch_v6_0_classic_swap_tokens_rpc).await,
         _ => MmError::err(DispatcherError::NoSuchMethod),
     }
 }

--- a/mm2src/mm2_main/src/rpc/lp_commands/mod.rs
+++ b/mm2src/mm2_main/src/rpc/lp_commands/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod db_id;
 pub mod legacy;
+pub(crate) mod one_inch;
 pub(crate) mod pubkey;
 pub(crate) mod tokens;
 pub(crate) mod trezor;

--- a/mm2src/mm2_main/src/rpc/lp_commands/one_inch.rs
+++ b/mm2src/mm2_main/src/rpc/lp_commands/one_inch.rs
@@ -1,0 +1,5 @@
+//! RPC implementation for integration with 1inch swap API provider.
+
+pub mod errors;
+pub mod rpcs;
+pub mod types;

--- a/mm2src/mm2_main/src/rpc/lp_commands/one_inch/errors.rs
+++ b/mm2src/mm2_main/src/rpc/lp_commands/one_inch/errors.rs
@@ -1,0 +1,99 @@
+use coins::{eth::u256_to_big_decimal, NumConversError};
+use common::{HttpStatusCode, StatusCode};
+use enum_derives::EnumFromStringify;
+use mm2_number::BigDecimal;
+use ser_error_derive::SerializeErrorType;
+use serde::Serialize;
+use trading_api::one_inch_api::errors::ApiClientError;
+
+#[derive(Debug, Display, Serialize, SerializeErrorType, EnumFromStringify)]
+#[serde(tag = "error_type", content = "error_data")]
+pub enum ApiIntegrationRpcError {
+    #[from_stringify("coins::CoinFindError")]
+    NoSuchCoin(String),
+    #[display(fmt = "EVM token needed")]
+    CoinTypeError,
+    #[display(fmt = "NFT not supported")]
+    NftNotSupported,
+    #[display(fmt = "Chain not supported")]
+    ChainNotSupported,
+    #[display(fmt = "Must be same chain")]
+    DifferentChains,
+    #[from_stringify("coins::UnexpectedDerivationMethod")]
+    MyAddressError(String),
+    InvalidParam(String),
+    #[display(fmt = "Parameter {param} out of bounds, value: {value}, min: {min} max: {max}")]
+    OutOfBounds {
+        param: String,
+        value: String,
+        min: String,
+        max: String,
+    },
+    #[display(fmt = "allowance not enough for 1inch contract, available: {allowance}, needed: {amount}")]
+    OneInchAllowanceNotEnough {
+        allowance: BigDecimal,
+        amount: BigDecimal,
+    },
+    #[display(fmt = "1inch API error: {}", _0)]
+    OneInchError(ApiClientError),
+    ApiDataError(String),
+}
+
+impl HttpStatusCode for ApiIntegrationRpcError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            ApiIntegrationRpcError::NoSuchCoin { .. } => StatusCode::NOT_FOUND,
+            ApiIntegrationRpcError::CoinTypeError
+            | ApiIntegrationRpcError::NftNotSupported
+            | ApiIntegrationRpcError::ChainNotSupported
+            | ApiIntegrationRpcError::DifferentChains
+            | ApiIntegrationRpcError::MyAddressError(_)
+            | ApiIntegrationRpcError::InvalidParam(_)
+            | ApiIntegrationRpcError::OutOfBounds { .. }
+            | ApiIntegrationRpcError::OneInchAllowanceNotEnough { .. } => StatusCode::BAD_REQUEST,
+            ApiIntegrationRpcError::OneInchError(_) | ApiIntegrationRpcError::ApiDataError(_) => {
+                StatusCode::BAD_GATEWAY
+            },
+        }
+    }
+}
+
+impl ApiIntegrationRpcError {
+    pub(crate) fn from_api_error(error: ApiClientError, decimals: Option<u8>) -> Self {
+        match error {
+            ApiClientError::InvalidParam(error) => ApiIntegrationRpcError::InvalidParam(error),
+            ApiClientError::OutOfBounds { param, value, min, max } => {
+                ApiIntegrationRpcError::OutOfBounds { param, value, min, max }
+            },
+            ApiClientError::TransportError(_)
+            | ApiClientError::ParseBodyError { .. }
+            | ApiClientError::GeneralApiError { .. } => ApiIntegrationRpcError::OneInchError(error),
+            ApiClientError::AllowanceNotEnough { allowance, amount, .. } => {
+                ApiIntegrationRpcError::OneInchAllowanceNotEnough {
+                    allowance: u256_to_big_decimal(allowance, decimals.unwrap_or_default()).unwrap_or_default(),
+                    amount: u256_to_big_decimal(amount, decimals.unwrap_or_default()).unwrap_or_default(),
+                }
+            },
+        }
+    }
+}
+
+/// Error aggregator for errors of conversion of api returned values
+#[derive(Debug, Display, Serialize)]
+pub(crate) struct FromApiValueError(String);
+
+impl From<NumConversError> for FromApiValueError {
+    fn from(err: NumConversError) -> Self { Self(err.to_string()) }
+}
+
+impl From<primitive_types::Error> for FromApiValueError {
+    fn from(err: primitive_types::Error) -> Self { Self(format!("{:?}", err)) }
+}
+
+impl From<hex::FromHexError> for FromApiValueError {
+    fn from(err: hex::FromHexError) -> Self { Self(err.to_string()) }
+}
+
+impl From<ethereum_types::FromDecStrErr> for FromApiValueError {
+    fn from(err: ethereum_types::FromDecStrErr) -> Self { Self(err.to_string()) }
+}

--- a/mm2src/mm2_main/src/rpc/lp_commands/one_inch/rpcs.rs
+++ b/mm2src/mm2_main/src/rpc/lp_commands/one_inch/rpcs.rs
@@ -1,0 +1,439 @@
+use super::errors::ApiIntegrationRpcError;
+use super::types::{AggregationContractRequest, ClassicSwapCreateRequest, ClassicSwapLiquiditySourcesRequest,
+                   ClassicSwapLiquiditySourcesResponse, ClassicSwapQuoteRequest, ClassicSwapResponse,
+                   ClassicSwapTokensRequest, ClassicSwapTokensResponse};
+use coins::eth::{display_eth_address, wei_from_big_decimal, EthCoin, EthCoinType};
+use coins::{lp_coinfind_or_err, CoinWithDerivationMethod, MmCoin, MmCoinEnum};
+use mm2_core::mm_ctx::MmArc;
+use mm2_err_handle::prelude::*;
+use trading_api::one_inch_api::client::ApiClient;
+use trading_api::one_inch_api::types::{ClassicSwapCreateParams, ClassicSwapQuoteParams, ProtocolsResponse,
+                                       TokensResponse};
+
+/// "1inch_v6_0_classic_swap_contract" rpc impl
+/// used to get contract address (for e.g. to approve funds)
+pub async fn one_inch_v6_0_classic_swap_contract_rpc(
+    _ctx: MmArc,
+    _req: AggregationContractRequest,
+) -> MmResult<String, ApiIntegrationRpcError> {
+    Ok(ApiClient::classic_swap_contract().to_owned())
+}
+
+/// "1inch_classic_swap_quote" rpc impl
+pub async fn one_inch_v6_0_classic_swap_quote_rpc(
+    ctx: MmArc,
+    req: ClassicSwapQuoteRequest,
+) -> MmResult<ClassicSwapResponse, ApiIntegrationRpcError> {
+    let (base, base_contract) = get_coin_for_one_inch(&ctx, &req.base).await?;
+    let (rel, rel_contract) = get_coin_for_one_inch(&ctx, &req.rel).await?;
+    api_supports_pair(&base, &rel)?;
+    let sell_amount = wei_from_big_decimal(&req.amount.to_decimal(), base.decimals())
+        .mm_err(|err| ApiIntegrationRpcError::InvalidParam(err.to_string()))?;
+    let query_params = ClassicSwapQuoteParams::new(base_contract, rel_contract, sell_amount.to_string())
+        .with_fee(req.fee)
+        .with_protocols(req.protocols)
+        .with_gas_price(req.gas_price)
+        .with_complexity_level(req.complexity_level)
+        .with_parts(req.parts)
+        .with_main_route_parts(req.main_route_parts)
+        .with_gas_limit(req.gas_limit)
+        .with_include_tokens_info(Some(req.include_tokens_info))
+        .with_include_protocols(Some(req.include_protocols))
+        .with_include_gas(Some(req.include_gas))
+        .with_connector_tokens(req.connector_tokens)
+        .build_query_params()
+        .mm_err(|api_err| ApiIntegrationRpcError::from_api_error(api_err, Some(base.decimals())))?;
+    let quote = ApiClient::new(ctx)
+        .mm_err(|api_err| ApiIntegrationRpcError::from_api_error(api_err, Some(base.decimals())))?
+        .call_swap_api(
+            base.chain_id(),
+            ApiClient::get_quote_method().to_owned(),
+            Some(query_params),
+        )
+        .await
+        .mm_err(|api_err| ApiIntegrationRpcError::from_api_error(api_err, Some(base.decimals())))?; // use 'base' as amount in errors is in the src coin
+    ClassicSwapResponse::from_api_classic_swap_data(quote, rel.decimals()) // use 'rel' as quote value is in the dst coin
+        .mm_err(|err| ApiIntegrationRpcError::ApiDataError(err.to_string()))
+}
+
+/// "1inch_classic_swap_create" rpc implementation
+/// This rpc actually returns a transaction to call the 1inch swap aggregation contract. GUI should sign it and send to the chain.
+/// We don't verify the transaction in any way and trust the 1inch api.
+pub async fn one_inch_v6_0_classic_swap_create_rpc(
+    ctx: MmArc,
+    req: ClassicSwapCreateRequest,
+) -> MmResult<ClassicSwapResponse, ApiIntegrationRpcError> {
+    let (base, base_contract) = get_coin_for_one_inch(&ctx, &req.base).await?;
+    let (rel, rel_contract) = get_coin_for_one_inch(&ctx, &req.rel).await?;
+    api_supports_pair(&base, &rel)?;
+    let sell_amount = wei_from_big_decimal(&req.amount.to_decimal(), base.decimals())
+        .mm_err(|err| ApiIntegrationRpcError::InvalidParam(err.to_string()))?;
+    let single_address = base.derivation_method().single_addr_or_err().await?;
+
+    let query_params = ClassicSwapCreateParams::new(
+        base_contract,
+        rel_contract,
+        sell_amount.to_string(),
+        display_eth_address(&single_address),
+        req.slippage,
+    )
+    .with_fee(req.fee)
+    .with_protocols(req.protocols)
+    .with_gas_price(req.gas_price)
+    .with_complexity_level(req.complexity_level)
+    .with_parts(req.parts)
+    .with_main_route_parts(req.main_route_parts)
+    .with_gas_limit(req.gas_limit)
+    .with_include_tokens_info(Some(req.include_tokens_info))
+    .with_include_protocols(Some(req.include_protocols))
+    .with_include_gas(Some(req.include_gas))
+    .with_connector_tokens(req.connector_tokens)
+    .with_excluded_protocols(req.excluded_protocols)
+    .with_permit(req.permit)
+    .with_compatibility(req.compatibility)
+    .with_receiver(req.receiver)
+    .with_referrer(req.referrer)
+    .with_disable_estimate(req.disable_estimate)
+    .with_allow_partial_fill(req.allow_partial_fill)
+    .with_use_permit2(req.use_permit2)
+    .build_query_params()
+    .mm_err(|api_err| ApiIntegrationRpcError::from_api_error(api_err, Some(base.decimals())))?;
+    let swap_with_tx = ApiClient::new(ctx)
+        .mm_err(|api_err| ApiIntegrationRpcError::from_api_error(api_err, Some(base.decimals())))?
+        .call_swap_api(
+            base.chain_id(),
+            ApiClient::get_swap_method().to_owned(),
+            Some(query_params),
+        )
+        .await
+        .mm_err(|api_err| ApiIntegrationRpcError::from_api_error(api_err, Some(base.decimals())))?; // use 'base' as amount in errors is in the src coin
+    ClassicSwapResponse::from_api_classic_swap_data(swap_with_tx, base.decimals()) // use 'base' as we spend in the src coin
+        .mm_err(|err| ApiIntegrationRpcError::ApiDataError(err.to_string()))
+}
+
+/// "1inch_v6_0_classic_swap_liquidity_sources" rpc implementation.
+/// Returns list of DEX available for routing with the 1inch Aggregation contract
+pub async fn one_inch_v6_0_classic_swap_liquidity_sources_rpc(
+    ctx: MmArc,
+    req: ClassicSwapLiquiditySourcesRequest,
+) -> MmResult<ClassicSwapLiquiditySourcesResponse, ApiIntegrationRpcError> {
+    let response: ProtocolsResponse = ApiClient::new(ctx)
+        .mm_err(|api_err| ApiIntegrationRpcError::from_api_error(api_err, None))?
+        .call_swap_api(req.chain_id, ApiClient::get_liquidity_sources_method().to_owned(), None)
+        .await
+        .mm_err(|api_err| ApiIntegrationRpcError::from_api_error(api_err, None))?;
+    Ok(ClassicSwapLiquiditySourcesResponse {
+        protocols: response.protocols,
+    })
+}
+
+/// "1inch_classic_swap_tokens" rpc implementation.
+/// Returns list of tokens available for 1inch classic swaps
+pub async fn one_inch_v6_0_classic_swap_tokens_rpc(
+    ctx: MmArc,
+    req: ClassicSwapTokensRequest,
+) -> MmResult<ClassicSwapTokensResponse, ApiIntegrationRpcError> {
+    let response: TokensResponse = ApiClient::new(ctx)
+        .mm_err(|api_err| ApiIntegrationRpcError::from_api_error(api_err, None))?
+        .call_swap_api(req.chain_id, ApiClient::get_tokens_method().to_owned(), None)
+        .await
+        .mm_err(|api_err| ApiIntegrationRpcError::from_api_error(api_err, None))?;
+    Ok(ClassicSwapTokensResponse {
+        tokens: response.tokens,
+    })
+}
+
+async fn get_coin_for_one_inch(ctx: &MmArc, ticker: &str) -> MmResult<(EthCoin, String), ApiIntegrationRpcError> {
+    let coin = match lp_coinfind_or_err(ctx, ticker).await? {
+        MmCoinEnum::EthCoin(coin) => coin,
+        _ => return Err(MmError::new(ApiIntegrationRpcError::CoinTypeError)),
+    };
+    let contract = match coin.coin_type {
+        EthCoinType::Eth => ApiClient::eth_special_contract().to_owned(),
+        EthCoinType::Erc20 { token_addr, .. } => display_eth_address(&token_addr),
+        EthCoinType::Nft { .. } => return Err(MmError::new(ApiIntegrationRpcError::NftNotSupported)),
+    };
+    Ok((coin, contract))
+}
+
+#[allow(clippy::result_large_err)]
+fn api_supports_pair(base: &EthCoin, rel: &EthCoin) -> MmResult<(), ApiIntegrationRpcError> {
+    if !ApiClient::is_chain_supported(base.chain_id()) {
+        return MmError::err(ApiIntegrationRpcError::ChainNotSupported);
+    }
+    if base.chain_id() != rel.chain_id() {
+        return MmError::err(ApiIntegrationRpcError::DifferentChains);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::rpc::lp_commands::one_inch::{rpcs::{one_inch_v6_0_classic_swap_create_rpc,
+                                                   one_inch_v6_0_classic_swap_quote_rpc},
+                                            types::{ClassicSwapCreateRequest, ClassicSwapQuoteRequest}};
+    use coins::eth::EthCoin;
+    use coins_activation::platform_for_tests::init_platform_coin_with_tokens_loop;
+    use common::block_on;
+    use crypto::CryptoCtx;
+    use mm2_core::mm_ctx::MmCtxBuilder;
+    use mm2_number::{BigDecimal, MmNumber};
+    use mocktopus::mocking::{MockResult, Mockable};
+    use std::str::FromStr;
+    use trading_api::one_inch_api::{client::ApiClient, types::ClassicSwapData};
+
+    #[test]
+    fn test_classic_swap_response_conversion() {
+        let ticker_coin = "ETH".to_owned();
+        let ticker_token = "JST".to_owned();
+        let eth_conf = json!({
+            "coin": ticker_coin,
+            "name": "ethereum",
+            "derivation_path": "m/44'/1'",
+            "chain_id": 1,
+            "protocol": {
+                "type": "ETH"
+            },
+            "trezor_coin": "Ethereum"
+        });
+        let jst_conf = json!({
+            "coin": ticker_token,
+            "name": "jst",
+            "chain_id": 1,
+            "protocol": {
+                "type": "ERC20",
+                "protocol_data": {
+                    "platform": "ETH",
+                    "contract_address": "0x09d0d71FBC00D7CCF9CFf132f5E6825C88293F19"
+                }
+            },
+        });
+
+        let conf = json!({
+            "coins": [eth_conf, jst_conf],
+            "1inch_api": "https://api.1inch.dev"
+        });
+        let ctx = MmCtxBuilder::new().with_conf(conf).into_mm_arc();
+        CryptoCtx::init_with_iguana_passphrase(ctx.clone(), "123").unwrap();
+
+        block_on(init_platform_coin_with_tokens_loop::<EthCoin>(
+            ctx.clone(),
+            serde_json::from_value(json!({
+                "ticker": ticker_coin,
+                "rpc_mode": "Default",
+                "nodes": [
+                    {"url": "https://rpc2.sepolia.org"},
+                    {"url": "https://rpc.sepolia.org/"}
+                ],
+                "swap_contract_address": "0xeA6D65434A15377081495a9E7C5893543E7c32cB",
+                "erc20_tokens_requests": [{"ticker": ticker_token}],
+                "priv_key_policy": "ContextPrivKey"
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+
+        let response_quote_raw = json!({
+            "dstAmount": "13",
+            "srcToken": {
+                "address": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                "symbol": ticker_coin,
+                "name": "Ether",
+                "decimals": 18,
+                "eip2612": false,
+                "isFoT": false,
+                "logoURI": "https://tokens.1inch.io/0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee.png",
+                "tags": [
+                    "crosschain",
+                    "GROUP:ETH",
+                    "native",
+                    "PEG:ETH"
+                ]
+            },
+            "dstToken": {
+                "address": "0x1234567890123456789012345678901234567890",
+                "symbol": ticker_token,
+                "name": "Test just token",
+                "decimals": 6,
+                "eip2612": false,
+                "isFoT": false,
+                "logoURI": "https://example.org/0x1234567890123456789012345678901234567890.png",
+                "tags": [
+                    "crosschain",
+                    "GROUP:JSTT",
+                    "PEG:JST",
+                    "tokens"
+                ]
+            },
+            "protocols": [
+            [
+                [
+                {
+                    "name": "SUSHI",
+                    "part": 100,
+                    "fromTokenAddress": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                    "toTokenAddress": "0xf16e81dce15b08f326220742020379b855b87df9"
+                }
+                ],
+                [
+                {
+                    "name": "ONE_INCH_LIMIT_ORDER_V3",
+                    "part": 100,
+                    "fromTokenAddress": "0xf16e81dce15b08f326220742020379b855b87df9",
+                    "toTokenAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7"
+                }
+                ]
+            ]
+            ],
+            "gas": 452704
+        });
+
+        let response_create_raw = json!({
+            "dstAmount": "13",
+            "tx": {
+            "from": "0x590559f6fb7720f24ff3e2fccf6015b466e9c92c",
+            "to": "0x111111125421ca6dc452d289314280a0f8842a65",
+            "data": "0x07ed23790000000000000000000000005f515f6c524b18ca30f7783fb58dd4be2e9904ec000000000000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec70000000000000000000000005f515f6c524b18ca30f7783fb58dd4be2e9904ec000000000000000000000000590559f6fb7720f24ff3e2fccf6015b466e9c92c0000000000000000000000000000000000000000000000000000000000989680000000000000000000000000000000000000000000000000000000000000000d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000648e8755f7ac30b5e4fa3f9c00e2cb6667501797b8bc01a7a367a4b2889ca6a05d9c31a31a781c12a4c3bdfc2ef1e02942e388b6565989ebe860bd67925bda74fbe0000000000000000000000000000000000000000000000000005ea0005bc00a007e5c0d200000000000000000000000000000000059800057e00018500009500001a4041c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2d0e30db00c20c02aaa39b223fe8d0a0e5c4f27ead9083c756cc27b73644935b8e68019ac6356c40661e1bc3158606ae4071118002dc6c07b73644935b8e68019ac6356c40661e1bc3158600000000000000000000000000000000000000000000000000294932ccadc9c58c02aaa39b223fe8d0a0e5c4f27ead9083c756cc251204dff5675ecff96b565ba3804dd4a63799ccba406761d38e5ddf6ccf6cf7c55759d5210750b5d60f30044e331d039000000000000000000000000761d38e5ddf6ccf6cf7c55759d5210750b5d60f3000000000000000000000000111111111117dc0aa78b770fa6a738034120c302000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002f8a744a79be00000000000000000000000042f527f50f16a103b6ccab48bccca214500c10210000000000000000000000005f515f6c524b18ca30f7783fb58dd4be2e9904ec00a0860a32ec00000000000000000000000000000000000000000000000000003005635d54300003d05120ead050515e10fdb3540ccd6f8236c46790508a76111111111117dc0aa78b770fa6a738034120c30200c4e525b10b000000000000000000000000000000000000000000000000000000000000002000000000000000000000000022b1a53ac4be63cdc1f47c99572290eff1edd8020000000000000000000000006a32cc044dd6359c27bb66e7b02dce6dd0fda2470000000000000000000000005f515f6c524b18ca30f7783fb58dd4be2e9904ec000000000000000000000000111111111117dc0aa78b770fa6a738034120c302000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec7000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003005635d5430000000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000067138e8c00000000000000000000000000000000000000000000000000030fb9b1525d8185f8d63fbcbe42e5999263c349cb5d81000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000026000000000000000000000000067297ee4eb097e072b4ab6f1620268061ae8046400000000000000000000000060cba82ddbf4b5ddcd4398cdd05354c6a790c309000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002e0000000000000000000000000000000000000000000000000000000000000036000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000041d26038ef66344af785ff342b86db3da06c4cc6a62f0ca80ffd78affc0a95ccad44e814acebb1deda729bbfe3050bec14a47af487cc1cadc75f43db2d073016c31c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000041a66cd52a747c5f60b9db637ffe30d0e413ec87858101832b4c5c1ae154bf247f3717c8ed4133e276ddf68d43a827f280863c91d6c42bc6ad1ec7083b2315b6fd1c0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020d6bdbf78dac17f958d2ee523a2206206994597c13d831ec780a06c4eca27dac17f958d2ee523a2206206994597c13d831ec7111111125421ca6dc452d289314280a0f8842a65000000000000000000000000000000000000000000000000c095c0a2",
+            "value": "10000000",
+            "gas": 721429,
+            "gasPrice": "9525172167"
+            },
+            "srcToken": {
+            "address": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            "symbol": ticker_coin,
+            "name": "Ether",
+            "decimals": 18,
+            "eip2612": false,
+            "isFoT": false,
+            "logoURI": "https://tokens.1inch.io/0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee.png",
+            "tags": [
+                "crosschain",
+                "GROUP:ETH",
+                "native",
+                "PEG:ETH"
+            ]
+            },
+            "dstToken": {
+            "address": "0x1234567890123456789012345678901234567890",
+            "symbol": ticker_token,
+            "name": "Just Token",
+            "decimals": 6,
+            "eip2612": false,
+            "isFoT": false,
+            "logoURI": "https://tokens.1inch.io/0x1234567890123456789012345678901234567890.png",
+            "tags": [
+                "crosschain",
+                "GROUP:USDT",
+                "PEG:USD",
+                "tokens"
+            ]
+            },
+            "protocols": [
+            [
+                [
+                {
+                    "name": "UNISWAP_V2",
+                    "part": 100,
+                    "fromTokenAddress": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                    "toTokenAddress": "0x761d38e5ddf6ccf6cf7c55759d5210750b5d60f3"
+                }
+                ],
+                [
+                {
+                    "name": "ONE_INCH_LP_1_1",
+                    "part": 100,
+                    "fromTokenAddress": "0x761d38e5ddf6ccf6cf7c55759d5210750b5d60f3",
+                    "toTokenAddress": "0x111111111117dc0aa78b770fa6a738034120c302"
+                }
+                ],
+                [
+                {
+                    "name": "PMM11",
+                    "part": 100,
+                    "fromTokenAddress": "0x111111111117dc0aa78b770fa6a738034120c302",
+                    "toTokenAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7"
+                }
+                ]
+            ]
+            ]
+        });
+
+        let quote_req = ClassicSwapQuoteRequest {
+            base: ticker_coin.clone(),
+            rel: ticker_token.clone(),
+            amount: MmNumber::from("1.0"),
+            fee: None,
+            protocols: None,
+            gas_price: None,
+            complexity_level: None,
+            parts: None,
+            main_route_parts: None,
+            gas_limit: None,
+            include_tokens_info: true,
+            include_protocols: true,
+            include_gas: true,
+            connector_tokens: None,
+        };
+
+        let create_req = ClassicSwapCreateRequest {
+            base: ticker_coin.clone(),
+            rel: ticker_token.clone(),
+            amount: MmNumber::from("1.0"),
+            fee: None,
+            protocols: None,
+            gas_price: None,
+            complexity_level: None,
+            parts: None,
+            main_route_parts: None,
+            gas_limit: None,
+            include_tokens_info: true,
+            include_protocols: true,
+            include_gas: true,
+            connector_tokens: None,
+            slippage: 0.0,
+            excluded_protocols: None,
+            permit: None,
+            compatibility: None,
+            receiver: None,
+            referrer: None,
+            disable_estimate: None,
+            allow_partial_fill: None,
+            use_permit2: None,
+        };
+
+        ApiClient::call_swap_api::<ClassicSwapData>.mock_safe(move |_, _, _, _| {
+            let response_quote_raw = response_quote_raw.clone();
+            MockResult::Return(Box::pin(async move {
+                Ok(serde_json::from_value::<ClassicSwapData>(response_quote_raw).unwrap())
+            }))
+        });
+
+        let quote_response = block_on(one_inch_v6_0_classic_swap_quote_rpc(ctx.clone(), quote_req)).unwrap();
+        assert_eq!(
+            quote_response.dst_amount.amount,
+            BigDecimal::from_str("0.000000000000000013").unwrap()
+        );
+        assert_eq!(quote_response.src_token.as_ref().unwrap().symbol, ticker_coin);
+        assert_eq!(quote_response.src_token.as_ref().unwrap().decimals, 18);
+        assert_eq!(quote_response.dst_token.as_ref().unwrap().symbol, ticker_token);
+        assert_eq!(quote_response.dst_token.as_ref().unwrap().decimals, 6);
+        assert_eq!(quote_response.gas.unwrap(), 452704_u128);
+
+        ApiClient::call_swap_api::<ClassicSwapData>.mock_safe(move |_, _, _, _| {
+            let response_create_raw = response_create_raw.clone();
+            MockResult::Return(Box::pin(async move {
+                Ok(serde_json::from_value::<ClassicSwapData>(response_create_raw).unwrap())
+            }))
+        });
+        let create_response = block_on(one_inch_v6_0_classic_swap_create_rpc(ctx, create_req)).unwrap();
+        assert_eq!(
+            create_response.dst_amount.amount,
+            BigDecimal::from_str("0.000000000000000013").unwrap()
+        );
+        assert_eq!(create_response.src_token.as_ref().unwrap().symbol, ticker_coin);
+        assert_eq!(create_response.src_token.as_ref().unwrap().decimals, 18);
+        assert_eq!(create_response.dst_token.as_ref().unwrap().symbol, ticker_token);
+        assert_eq!(create_response.dst_token.as_ref().unwrap().decimals, 6);
+        assert_eq!(create_response.tx.as_ref().unwrap().data.len(), 1960);
+    }
+}

--- a/mm2src/mm2_main/src/rpc/lp_commands/one_inch/types.rs
+++ b/mm2src/mm2_main/src/rpc/lp_commands/one_inch/types.rs
@@ -1,0 +1,213 @@
+use crate::rpc::lp_commands::one_inch::errors::FromApiValueError;
+use coins::eth::{u256_to_big_decimal, wei_to_gwei_decimal};
+use common::true_f;
+use ethereum_types::{Address, U256};
+use mm2_err_handle::prelude::*;
+use mm2_number::{construct_detailed, BigDecimal, MmNumber};
+use rpc::v1::types::Bytes as BytesJson;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use trading_api::one_inch_api::{self,
+                                types::{ProtocolImage, ProtocolInfo, TokenInfo}};
+
+construct_detailed!(DetailedAmount, amount);
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct AggregationContractRequest {}
+
+/// Request to get quote for 1inch classic swap.
+/// See 1inch docs for more details: https://portal.1inch.dev/documentation/apis/swap/classic-swap/Parameter%20Descriptions/quote_params
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClassicSwapQuoteRequest {
+    /// Base coin ticker
+    pub base: String,
+    /// Rel coin ticker
+    pub rel: String,
+    /// Swap amount in coins (with fraction)
+    pub amount: MmNumber,
+    /// Partner fee, percentage of src token amount will be sent to referrer address, min: 0; max: 3.
+    /// Should be the same for quote and swap rpc. Default is 0
+    pub fee: Option<f32>,
+    /// Specify liquidity sources
+    /// e.g.: &protocols=WETH,CURVE,BALANCER,...,ZRX
+    /// (by default - all used)
+    pub protocols: Option<String>,
+    /// Network price per gas, in Gwei for this rpc.
+    /// 1inch takes in account gas expenses to determine exchange route. Should be the same for a quote and swap.
+    /// If not set the 'fast' network gas price will be used
+    pub gas_price: Option<String>,
+    /// Maximum number of token-connectors to be used in a transaction, min: 0; max: 3; default: 2
+    pub complexity_level: Option<u32>,
+    /// Limit maximum number of parts each main route parts can be split into.
+    /// Should be the same for a quote and swap. Default: 20; max: 100
+    pub parts: Option<u32>,
+    /// Limit maximum number of main route parts. Should be the same for a quote and swap. Default: 20; max: 50;
+    pub main_route_parts: Option<u32>,
+    /// Maximum amount of gas for a swap.
+    /// Should be the same for a quote and swap. Default: 11500000; max: 11500000
+    pub gas_limit: Option<u128>,
+    /// Return fromToken and toToken info in response (default is true)
+    #[serde(default = "true_f")]
+    pub include_tokens_info: bool,
+    /// Return used swap protocols in response (default is true)
+    #[serde(default = "true_f")]
+    pub include_protocols: bool,
+    /// Include estimated gas in return value (default is true)
+    #[serde(default = "true_f")]
+    pub include_gas: bool,
+    /// Token-connectors can be specified via this parameter. If not set, default token-connectors will be used
+    pub connector_tokens: Option<String>,
+}
+
+/// Request to create transaction for 1inch classic swap.
+/// See 1inch docs for more details: https://portal.1inch.dev/documentation/apis/swap/classic-swap/Parameter%20Descriptions/swap_params
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClassicSwapCreateRequest {
+    /// Base coin ticker
+    pub base: String,
+    /// Rel coin ticker
+    pub rel: String,
+    /// Swap amount in coins (with fraction)
+    pub amount: MmNumber,
+    /// Allowed slippage, min: 0; max: 50
+    pub slippage: f32,
+    /// Partner fee, percentage of src token amount will be sent to referrer address, min: 0; max: 3.
+    /// Should be the same for quote and swap rpc. Default is 0
+    pub fee: Option<f32>,
+    /// Specify liquidity sources
+    /// e.g.: &protocols=WETH,CURVE,BALANCER,...,ZRX
+    /// (by default - all used)
+    pub protocols: Option<String>,
+    /// Network price per gas, in Gwei for this rpc.
+    /// 1inch takes in account gas expenses to determine exchange route. Should be the same for a quote and swap.
+    /// If not set the 'fast' network gas price will be used
+    pub gas_price: Option<String>,
+    /// Maximum number of token-connectors to be used in a transaction, min: 0; max: 3; default: 2
+    pub complexity_level: Option<u32>,
+    /// Limit maximum number of parts each main route parts can be split into.
+    /// Should be the same for a quote and swap. Default: 20; max: 100
+    pub parts: Option<u32>,
+    /// Limit maximum number of main route parts. Should be the same for a quote and swap. Default: 20; max: 50;
+    pub main_route_parts: Option<u32>,
+    /// Maximum amount of gas for a swap.
+    /// Should be the same for a quote and swap. Default: 11500000; max: 11500000
+    pub gas_limit: Option<u128>,
+    /// Return fromToken and toToken info in response (default is true)
+    #[serde(default = "true_f")]
+    pub include_tokens_info: bool,
+    /// Return used swap protocols in response (default is true)
+    #[serde(default = "true_f")]
+    pub include_protocols: bool,
+    /// Include estimated gas in response (default is true)
+    #[serde(default = "true_f")]
+    pub include_gas: bool,
+    /// Token-connectors can be specified via this parameter. If not set, default token-connectors will be used
+    pub connector_tokens: Option<String>,
+    /// Excluded supported liquidity sources. Should be the same for a quote and swap, max: 5
+    pub excluded_protocols: Option<String>,
+    /// Used according https://eips.ethereum.org/EIPS/eip-2612
+    pub permit: Option<String>,
+    /// Exclude the Unoswap method
+    pub compatibility: Option<bool>,
+    /// This address will receive funds after the swap. By default same address as 'my address'
+    pub receiver: Option<String>,
+    /// Address to receive the partner fee. Must be set explicitly if fee is also set
+    pub referrer: Option<String>,
+    /// if true, disable most of the checks, default: false
+    pub disable_estimate: Option<bool>,
+    /// if true, the algorithm can cancel part of the route, if the rate has become less attractive.
+    /// Unswapped tokens will return to 'my address'. Default: true
+    pub allow_partial_fill: Option<bool>,
+    /// Enable this flag for auto approval by Permit2 contract if you did an approval to Uniswap Permit2 smart contract for this token.
+    /// Default is false
+    pub use_permit2: Option<bool>,
+}
+
+/// Response for both classic swap quote or create swap calls
+#[derive(Serialize, Debug)]
+pub struct ClassicSwapResponse {
+    /// Destination token amount, in coins (with fraction)
+    pub dst_amount: DetailedAmount,
+    /// Source (base) token info
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub src_token: Option<TokenInfo>,
+    /// Destination (rel) token info
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dst_token: Option<TokenInfo>,
+    /// Used liquidity sources
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub protocols: Option<Vec<Vec<Vec<ProtocolInfo>>>>,
+    /// Swap tx fields (returned only for create swap rpc)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tx: Option<TxFields>,
+    /// Estimated (returned only for quote rpc)
+    pub gas: Option<u128>,
+}
+
+impl ClassicSwapResponse {
+    pub(crate) fn from_api_classic_swap_data(
+        data: one_inch_api::types::ClassicSwapData,
+        decimals: u8,
+    ) -> MmResult<Self, FromApiValueError> {
+        Ok(Self {
+            dst_amount: MmNumber::from(u256_to_big_decimal(U256::from_dec_str(&data.dst_amount)?, decimals)?).into(),
+            src_token: data.src_token,
+            dst_token: data.dst_token,
+            protocols: data.protocols,
+            tx: data
+                .tx
+                .map(|tx| TxFields::from_api_tx_fields(tx, decimals))
+                .transpose()?,
+            gas: data.gas,
+        })
+    }
+}
+
+#[derive(Serialize, Debug)]
+pub struct TxFields {
+    pub from: Address,
+    pub to: Address,
+    pub data: BytesJson,
+    pub value: BigDecimal,
+    /// Estimated gas price in gwei
+    pub gas_price: BigDecimal,
+    pub gas: u128, // TODO: in eth EthTxFeeDetails rpc we use u64. Better have identical u128 everywhere
+}
+
+impl TxFields {
+    pub(crate) fn from_api_tx_fields(
+        tx_fields: one_inch_api::types::TxFields,
+        decimals: u8,
+    ) -> MmResult<Self, FromApiValueError> {
+        Ok(Self {
+            from: tx_fields.from,
+            to: tx_fields.to,
+            data: BytesJson::from(hex::decode(str_strip_0x!(tx_fields.data.as_str()))?),
+            value: u256_to_big_decimal(U256::from_dec_str(&tx_fields.value)?, decimals)?,
+            gas_price: wei_to_gwei_decimal(U256::from_dec_str(&tx_fields.gas_price)?)?,
+            gas: tx_fields.gas,
+        })
+    }
+}
+
+#[derive(Deserialize)]
+pub struct ClassicSwapLiquiditySourcesRequest {
+    pub chain_id: u64,
+}
+
+#[derive(Serialize)]
+pub struct ClassicSwapLiquiditySourcesResponse {
+    pub protocols: Vec<ProtocolImage>,
+}
+
+#[derive(Deserialize)]
+pub struct ClassicSwapTokensRequest {
+    pub chain_id: u64,
+}
+
+#[derive(Serialize)]
+pub struct ClassicSwapTokensResponse {
+    pub tokens: HashMap<String, TokenInfo>,
+}

--- a/mm2src/mm2_main/src/rpc/lp_commands/tokens.rs
+++ b/mm2src/mm2_main/src/rpc/lp_commands/tokens.rs
@@ -1,10 +1,18 @@
+//! This source file is for RPCs specific for EVM platform
 use coins::eth::erc20::{get_erc20_ticker_by_contract_address, get_erc20_token_info, Erc20TokenInfo};
 use coins::eth::valid_addr_from_str;
-use coins::{lp_coinfind_or_err, CoinFindError, CoinProtocol, MmCoinEnum};
+use coins::eth::{u256_to_big_decimal, wei_from_big_decimal, EthCoin, Web3RpcError};
+use coins::{lp_coinfind_or_err, CoinFindError, CoinProtocol, MmCoin, MmCoinEnum, NumConversError, Transaction,
+            TransactionErr};
 use common::HttpStatusCode;
+use derive_more::Display;
+use enum_derives::EnumFromStringify;
+use ethereum_types::Address as EthAddress;
+use futures::compat::Future01CompatExt;
 use http::StatusCode;
 use mm2_core::mm_ctx::MmArc;
-use mm2_err_handle::prelude::*;
+use mm2_err_handle::{map_to_mm::MapToMmResult, mm_error::MmError, prelude::MmResult};
+use mm2_number::BigDecimal;
 
 #[derive(Deserialize)]
 pub struct TokenInfoRequest {
@@ -91,5 +99,75 @@ pub async fn get_token_info(ctx: MmArc, req: TokenInfoRequest) -> MmResult<Token
         _ => MmError::err(TokenInfoError::UnsupportedTokenProtocol {
             protocol: platform.to_string(),
         }),
+    }
+}
+
+#[derive(Debug, Deserialize, Display, EnumFromStringify, Serialize, SerializeErrorType)]
+#[serde(tag = "error_type", content = "error_data")]
+pub enum Erc20CallError {
+    #[display(fmt = "No such coin {}", coin)]
+    NoSuchCoin { coin: String },
+    #[display(fmt = "Coin not supported {}", coin)]
+    CoinNotSupported { coin: String },
+    #[from_stringify("NumConversError")]
+    #[display(fmt = "Invalid param: {}", _0)]
+    InvalidParam(String),
+    #[from_stringify("TransactionErr")]
+    #[display(fmt = "Transaction error {}", _0)]
+    TransactionError(String),
+    #[from_stringify("Web3RpcError")]
+    #[display(fmt = "Web3 RPC error {}", _0)]
+    Web3RpcError(String),
+}
+
+impl HttpStatusCode for Erc20CallError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Erc20CallError::NoSuchCoin { .. }
+            | Erc20CallError::CoinNotSupported { .. }
+            | Erc20CallError::InvalidParam(_) => StatusCode::BAD_REQUEST,
+            Erc20CallError::TransactionError(_) | Erc20CallError::Web3RpcError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Erc20AllowanceRequest {
+    coin: String,
+    spender: EthAddress,
+}
+
+/// Call allowance method for ERC20 tokens (see https://eips.ethereum.org/EIPS/eip-20#approve).
+/// Returns BigDecimal allowance value.
+pub async fn get_token_allowance_rpc(ctx: MmArc, req: Erc20AllowanceRequest) -> MmResult<BigDecimal, Erc20CallError> {
+    let eth_coin = find_erc20_eth_coin(&ctx, &req.coin).await?;
+    let wei = eth_coin.allowance(req.spender).compat().await?;
+    let amount = u256_to_big_decimal(wei, eth_coin.decimals())?;
+    Ok(amount)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Erc20ApproveRequest {
+    coin: String,
+    spender: EthAddress,
+    amount: BigDecimal,
+}
+
+/// Call approve method for ERC20 tokens (see https://eips.ethereum.org/EIPS/eip-20#allowance).
+/// Returns approval transaction hash.
+pub async fn approve_token_rpc(ctx: MmArc, req: Erc20ApproveRequest) -> MmResult<String, Erc20CallError> {
+    let eth_coin = find_erc20_eth_coin(&ctx, &req.coin).await?;
+    let amount = wei_from_big_decimal(&req.amount, eth_coin.decimals())?;
+    let tx = eth_coin.approve(req.spender, amount).compat().await?;
+    Ok(format!("0x{:02x}", tx.tx_hash_as_bytes()))
+}
+
+async fn find_erc20_eth_coin(ctx: &MmArc, coin: &str) -> Result<EthCoin, MmError<Erc20CallError>> {
+    match lp_coinfind_or_err(ctx, coin).await {
+        Ok(MmCoinEnum::EthCoin(eth_coin)) => Ok(eth_coin),
+        Ok(_) => Err(MmError::new(Erc20CallError::CoinNotSupported {
+            coin: coin.to_string(),
+        })),
+        Err(_) => Err(MmError::new(Erc20CallError::NoSuchCoin { coin: coin.to_string() })),
     }
 }

--- a/mm2src/mm2_main/tests/docker_tests/eth_docker_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/eth_docker_tests.rs
@@ -13,18 +13,18 @@ use coins::eth::v2_activation::{eth_coin_from_conf_and_request_v2, EthActivation
 use coins::eth::{checksum_address, eth_addr_to_hex, eth_coin_from_conf_and_request, EthCoin, EthCoinType,
                  EthPrivKeyBuildPolicy, SignedEthTx, SwapV2Contracts, ERC20_ABI};
 use coins::nft::nft_structs::{Chain, ContractType, NftInfo};
-use coins::{lp_coinfind, CoinProtocol, CoinWithDerivationMethod, CommonSwapOpsV2, ConfirmPaymentInput,
-            DerivationMethod, Eip1559Ops, FoundSwapTxSpend, MakerNftSwapOpsV2, MarketCoinOps, NftSwapInfo,
-            ParseCoinAssocTypes, ParseNftAssocTypes, PrivKeyBuildPolicy, RefundNftMakerPaymentArgs, RefundPaymentArgs,
-            SearchForSwapTxSpendInput, SendNftMakerPaymentArgs, SendPaymentArgs, SpendNftMakerPaymentArgs,
-            SpendPaymentArgs, SwapOps, SwapTxFeePolicy, SwapTxTypeWithSecretHash, ToBytes, Transaction,
-            ValidateNftMakerPaymentArgs};
 #[cfg(any(feature = "sepolia-maker-swap-v2-tests", feature = "sepolia-taker-swap-v2-tests"))]
-use coins::{CoinsContext, DexFee, FundingTxSpend, GenTakerFundingSpendArgs, GenTakerPaymentSpendArgs,
+use coins::{lp_coinfind, CoinsContext, DexFee, FundingTxSpend, GenTakerFundingSpendArgs, GenTakerPaymentSpendArgs,
             MakerCoinSwapOpsV2, MmCoinEnum, MmCoinStruct, RefundFundingSecretArgs, RefundMakerPaymentSecretArgs,
             RefundMakerPaymentTimelockArgs, RefundTakerPaymentArgs, SendMakerPaymentArgs, SendTakerFundingArgs,
             SpendMakerPaymentArgs, TakerCoinSwapOpsV2, TxPreimageWithSig, ValidateMakerPaymentArgs,
             ValidateTakerFundingArgs};
+use coins::{CoinProtocol, CoinWithDerivationMethod, CommonSwapOpsV2, ConfirmPaymentInput, DerivationMethod,
+            Eip1559Ops, FoundSwapTxSpend, MakerNftSwapOpsV2, MarketCoinOps, NftSwapInfo, ParseCoinAssocTypes,
+            ParseNftAssocTypes, PrivKeyBuildPolicy, RefundNftMakerPaymentArgs, RefundPaymentArgs,
+            SearchForSwapTxSpendInput, SendNftMakerPaymentArgs, SendPaymentArgs, SpendNftMakerPaymentArgs,
+            SpendPaymentArgs, SwapOps, SwapTxFeePolicy, SwapTxTypeWithSecretHash, ToBytes, Transaction,
+            ValidateNftMakerPaymentArgs};
 use common::{block_on, block_on_f01, now_sec};
 use crypto::Secp256k1Secret;
 use ethereum_types::U256;
@@ -55,6 +55,8 @@ const SEPOLIA_MAKER_PRIV: &str = "6e2f3a6223b928a05a3a3622b0c3f3573d03663b704a61
 const SEPOLIA_TAKER_PRIV: &str = "e0be82dca60ff7e4c6d6db339ac9e1ae249af081dba2110bddd281e711608f16";
 const NFT_ETH: &str = "NFT_ETH";
 const ETH: &str = "ETH";
+
+#[cfg(any(feature = "sepolia-maker-swap-v2-tests", feature = "sepolia-taker-swap-v2-tests"))]
 const ERC20: &str = "ERC20DEV";
 
 /// # Safety

--- a/mm2src/mm2_main/tests/docker_tests/swap_watcher_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/swap_watcher_tests.rs
@@ -3300,5 +3300,5 @@ fn test_watcher_reward() {
 
     let watcher_reward =
         block_on(utxo_coin.get_maker_watcher_reward(&MmCoinEnum::UtxoCoin(utxo_coin.clone()), None, timeout)).unwrap();
-    assert!(matches!(watcher_reward, None));
+    assert!(watcher_reward.is_none());
 }

--- a/mm2src/mm2_p2p/Cargo.toml
+++ b/mm2src/mm2_p2p/Cargo.toml
@@ -38,13 +38,13 @@ void = "1.0"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 futures-rustls = "0.24"
 instant = "0.1.12"
-libp2p = { git = "https://github.com/KomodoPlatform/rust-libp2p.git", tag = "k-0.52.4", default-features = false, features = ["dns", "identify", "floodsub", "gossipsub", "noise", "ping", "request-response", "secp256k1", "tcp", "tokio", "websocket", "macros", "yamux"] }
+libp2p = { git = "https://github.com/KomodoPlatform/rust-libp2p.git", tag = "k-0.52.11", default-features = false, features = ["dns", "identify", "floodsub", "gossipsub", "noise", "ping", "request-response", "secp256k1", "tcp", "tokio", "websocket", "macros", "yamux"] }
 tokio = { version = "1.20",  default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 futures-rustls = "0.22"
 instant = { version = "0.1.12", features = ["wasm-bindgen"] }
-libp2p = { git = "https://github.com/KomodoPlatform/rust-libp2p.git", tag = "k-0.52.4", default-features = false, features = ["identify", "floodsub", "noise", "gossipsub", "ping", "request-response", "secp256k1", "wasm-ext", "wasm-ext-websocket", "macros", "yamux"] }
+libp2p = { git = "https://github.com/KomodoPlatform/rust-libp2p.git", tag = "k-0.52.11", default-features = false, features = ["identify", "floodsub", "noise", "gossipsub", "ping", "request-response", "secp256k1", "wasm-ext", "wasm-ext-websocket", "macros", "yamux"] }
 
 [dev-dependencies]
 async-std = "1.6.2"

--- a/mm2src/proxy_signature/Cargo.toml
+++ b/mm2src/proxy_signature/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 chrono = "0.4"
 http = "0.2"
-libp2p = { git = "https://github.com/KomodoPlatform/rust-libp2p.git", tag = "k-0.52.4", default-features = false, features = ["identify"] }
+libp2p = { git = "https://github.com/KomodoPlatform/rust-libp2p.git", tag = "k-0.52.11", default-features = false, features = ["identify"] }
 serde = "1"
 serde_json = { version = "1", features = ["preserve_order", "raw_value"] }
 

--- a/mm2src/trading_api/Cargo.toml
+++ b/mm2src/trading_api/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+# integration with external trading api
+name = "trading_api"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+common = { path = "../common" }
+enum_derives = { path = "../derives/enum_derives" }
+mm2_core = { path = "../mm2_core" }
+mm2_err_handle = { path = "../mm2_err_handle" }
+mm2_net = { path = "../mm2_net" }
+mm2_number = { path = "../mm2_number" }
+mocktopus = { version = "0.8.0", optional = true }
+
+derive_more = "0.99"
+ethereum-types = { version = "0.13", default-features = false, features = ["std", "serialize"] }
+lazy_static = "1.4"
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = { version = "1", features = ["preserve_order", "raw_value"] }
+url = { version = "2.2.2", features = ["serde"] }
+
+[features]
+test-ext-api = [] # use test config to connect to an external api 
+
+[dev-dependencies]
+mocktopus = { version = "0.8.0" }

--- a/mm2src/trading_api/src/lib.rs
+++ b/mm2src/trading_api/src/lib.rs
@@ -1,0 +1,3 @@
+//! This module is for indirect connection to third-party trading APIs, processing their results and errors
+
+pub mod one_inch_api;

--- a/mm2src/trading_api/src/one_inch_api.rs
+++ b/mm2src/trading_api/src/one_inch_api.rs
@@ -1,0 +1,5 @@
+//! Wrapper for 1inch API.
+
+pub mod client;
+pub mod errors;
+pub mod types;

--- a/mm2src/trading_api/src/one_inch_api/client.rs
+++ b/mm2src/trading_api/src/one_inch_api/client.rs
@@ -1,0 +1,176 @@
+use super::errors::ApiClientError;
+use crate::one_inch_api::errors::NativeError;
+use common::StatusCode;
+#[cfg(feature = "test-ext-api")] use lazy_static::lazy_static;
+use mm2_core::mm_ctx::MmArc;
+use mm2_err_handle::{map_mm_error::MapMmError,
+                     map_to_mm::MapToMmResult,
+                     mm_error::{MmError, MmResult}};
+use mm2_net::transport::slurp_url_with_headers;
+use serde::de::DeserializeOwned;
+use url::Url;
+
+#[cfg(any(test, feature = "mocktopus"))]
+use mocktopus::macros::*;
+
+const ONE_INCH_API_ENDPOINT_V6_0: &str = "swap/v6.0/";
+const SWAP_METHOD: &str = "swap";
+const QUOTE_METHOD: &str = "quote";
+const LIQUIDITY_SOURCES_METHOD: &str = "liquidity-sources";
+const TOKENS_METHOD: &str = "tokens";
+
+const ONE_INCH_AGGREGATION_ROUTER_CONTRACT_V6_0: &str = "0x111111125421ca6dc452d289314280a0f8842a65";
+const ONE_INCH_ETH_SPECIAL_CONTRACT: &str = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+
+#[cfg(test)]
+const ONE_INCH_API_TEST_URL: &str = "https://api.1inch.dev";
+
+#[cfg(feature = "test-ext-api")]
+lazy_static! {
+    /// API key for testing
+    static ref ONE_INCH_API_TEST_AUTH: String = std::env::var("ONE_INCH_API_TEST_AUTH").unwrap_or_default();
+}
+
+pub(crate) type QueryParams<'life> = Vec<(&'life str, String)>;
+
+/// 1inch v6.0 supported eth-based chains
+const ONE_INCH_V6_0_SUPPORTED_CHAINS: &[(&str, u64)] = &[
+    ("Ethereum", 1),
+    ("Optimism", 10),
+    ("BSC", 56),
+    ("Gnosis", 100),
+    ("Polygon", 137),
+    ("Fantom", 250),
+    ("ZkSync", 324),
+    ("Klaytn", 8217),
+    ("Base", 8453),
+    ("Arbitrum", 42161),
+    ("Avalanche", 43114),
+    ("Aurora", 1313161554),
+];
+
+pub(crate) struct UrlBuilder<'a> {
+    base_url: Url,
+    endpoint: &'a str,
+    chain_id: u64,
+    method_name: String,
+    query_params: QueryParams<'a>,
+}
+
+impl<'a> UrlBuilder<'a> {
+    pub(crate) fn new(api_client: &ApiClient, chain_id: u64, method_name: String) -> Self {
+        Self {
+            base_url: api_client.base_url.clone(),
+            endpoint: ApiClient::get_swap_endpoint(),
+            chain_id,
+            method_name,
+            query_params: vec![],
+        }
+    }
+
+    pub(crate) fn with_query_params(&mut self, mut more_params: QueryParams<'a>) -> &mut Self {
+        self.query_params.append(&mut more_params);
+        self
+    }
+
+    #[allow(clippy::result_large_err)]
+    pub(crate) fn build(&self) -> MmResult<Url, ApiClientError> {
+        let url = self
+            .base_url
+            .join(self.endpoint)?
+            .join(&format!("{}/", self.chain_id.to_string()))?
+            .join(self.method_name.as_str())?;
+        Ok(Url::parse_with_params(
+            url.as_str(),
+            self.query_params
+                .iter()
+                .map(|v| (v.0, v.1.as_str()))
+                .collect::<Vec<_>>(),
+        )?)
+    }
+}
+
+/// 1-inch API caller
+pub struct ApiClient {
+    base_url: Url,
+}
+
+#[allow(clippy::swap_ptr_to_ref)] // need for moctopus
+#[cfg_attr(any(test, feature = "mocktopus"), mockable)]
+impl ApiClient {
+    #[allow(unused_variables)]
+    #[allow(clippy::result_large_err)]
+    pub fn new(ctx: MmArc) -> MmResult<Self, ApiClientError> {
+        #[cfg(not(test))]
+        let url_cfg = ctx.conf["1inch_api"]
+            .as_str()
+            .ok_or(ApiClientError::InvalidParam("No API config param".to_owned()))?;
+
+        #[cfg(test)]
+        let url_cfg = ONE_INCH_API_TEST_URL;
+
+        Ok(Self {
+            base_url: Url::parse(url_cfg)?,
+        })
+    }
+
+    pub const fn eth_special_contract() -> &'static str { ONE_INCH_ETH_SPECIAL_CONTRACT }
+
+    pub const fn classic_swap_contract() -> &'static str { ONE_INCH_AGGREGATION_ROUTER_CONTRACT_V6_0 }
+
+    pub fn is_chain_supported(chain_id: u64) -> bool {
+        ONE_INCH_V6_0_SUPPORTED_CHAINS.iter().any(|(_name, id)| *id == chain_id)
+    }
+
+    fn get_headers() -> Vec<(&'static str, &'static str)> {
+        vec![
+            #[cfg(feature = "test-ext-api")]
+            ("Authorization", ONE_INCH_API_TEST_AUTH.as_str()),
+            ("accept", "application/json"),
+        ]
+    }
+
+    fn get_swap_endpoint() -> &'static str { ONE_INCH_API_ENDPOINT_V6_0 }
+
+    pub const fn get_swap_method() -> &'static str { SWAP_METHOD }
+
+    pub const fn get_quote_method() -> &'static str { QUOTE_METHOD }
+
+    pub const fn get_liquidity_sources_method() -> &'static str { LIQUIDITY_SOURCES_METHOD }
+
+    pub const fn get_tokens_method() -> &'static str { TOKENS_METHOD }
+
+    pub(crate) async fn call_api<T: DeserializeOwned>(api_url: &Url) -> MmResult<T, ApiClientError> {
+        let (status_code, _, body) = slurp_url_with_headers(api_url.as_str(), ApiClient::get_headers())
+            .await
+            .mm_err(ApiClientError::TransportError)?;
+        let body = serde_json::from_slice(&body).map_to_mm(|err| ApiClientError::ParseBodyError {
+            error_msg: err.to_string(),
+        })?;
+        if status_code != StatusCode::OK {
+            let error = NativeError::new(status_code, body);
+            return Err(MmError::new(ApiClientError::from_native_error(error)));
+        }
+        serde_json::from_value(body).map_err(|err| {
+            ApiClientError::ParseBodyError {
+                error_msg: err.to_string(),
+            }
+            .into()
+        })
+    }
+
+    pub async fn call_swap_api<'l, T: DeserializeOwned>(
+        &self,
+        chain_id: u64,
+        method: String,
+        params: Option<QueryParams<'l>>,
+    ) -> MmResult<T, ApiClientError> {
+        let mut builder = UrlBuilder::new(self, chain_id, method);
+        if let Some(params) = params {
+            builder.with_query_params(params);
+        }
+        let api_url = builder.build()?;
+
+        ApiClient::call_api(&api_url).await
+    }
+}

--- a/mm2src/trading_api/src/one_inch_api/errors.rs
+++ b/mm2src/trading_api/src/one_inch_api/errors.rs
@@ -1,0 +1,130 @@
+use common::StatusCode;
+use derive_more::Display;
+use enum_derives::EnumFromStringify;
+use ethereum_types::U256;
+use mm2_net::transport::SlurpError;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Display, Serialize, EnumFromStringify)]
+pub enum ApiClientError {
+    #[from_stringify("url::ParseError")]
+    InvalidParam(String),
+    #[display(fmt = "Parameter {param} out of bounds, value: {value}, min: {min} max: {max}")]
+    OutOfBounds {
+        param: String,
+        value: String,
+        min: String,
+        max: String,
+    },
+    TransportError(SlurpError),
+    ParseBodyError {
+        error_msg: String,
+    },
+    #[display(fmt = "General API error: {error_msg} description: {description}")]
+    GeneralApiError {
+        error_msg: String,
+        description: String,
+        status_code: u16,
+    },
+    #[display(fmt = "Allowance not enough, needed: {amount} allowance: {allowance}")]
+    AllowanceNotEnough {
+        error_msg: String,
+        description: String,
+        status_code: u16,
+        /// Amount to approve for the API contract
+        amount: U256,
+        /// Existing allowance for the API contract
+        allowance: U256,
+    },
+}
+
+// API error meta 'type' field known values
+const META_TYPE_ALLOWANCE: &str = "allowance";
+const META_TYPE_AMOUNT: &str = "amount";
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct Error400 {
+    pub error: String,
+    pub description: Option<String>,
+    #[serde(rename = "statusCode")]
+    pub status_code: u16,
+    pub meta: Option<Vec<Meta>>,
+    #[allow(dead_code)]
+    #[serde(rename = "requestId")]
+    pub request_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct Meta {
+    #[serde(rename = "type")]
+    pub meta_type: String,
+    #[serde(rename = "value")]
+    pub meta_value: String,
+}
+
+#[derive(Debug)]
+pub(crate) enum NativeError {
+    HttpError { error_msg: String, status_code: u16 },
+    HttpError400(Error400),
+    ParseError { error_msg: String },
+}
+
+impl NativeError {
+    pub(crate) fn new(status_code: StatusCode, body: Value) -> Self {
+        if status_code == StatusCode::BAD_REQUEST {
+            match serde_json::from_value(body) {
+                Ok(err) => Self::HttpError400(err),
+                Err(err) => Self::ParseError {
+                    error_msg: format!("could not parse error response: {}", err.to_string()),
+                },
+            }
+        } else {
+            Self::HttpError {
+                error_msg: body["error"].as_str().unwrap_or_default().to_owned(),
+                status_code: status_code.into(),
+            }
+        }
+    }
+}
+
+impl ApiClientError {
+    /// Convert from native API errors to lib errors
+    /// Look for known API errors. If none found return as general API error
+    pub(crate) fn from_native_error(api_error: NativeError) -> ApiClientError {
+        match api_error {
+            NativeError::HttpError400(error_400) => {
+                if let Some(meta) = error_400.meta {
+                    // Try if it's "Not enough allowance" error 'meta' data:
+                    if let Some(meta_allowance) = meta.iter().find(|m| m.meta_type == META_TYPE_ALLOWANCE) {
+                        // try find 'amount' value
+                        let amount = if let Some(meta_amount) = meta.iter().find(|m| m.meta_type == META_TYPE_AMOUNT) {
+                            U256::from_dec_str(&meta_amount.meta_value).unwrap_or_default()
+                        } else {
+                            Default::default()
+                        };
+                        let allowance = U256::from_dec_str(&meta_allowance.meta_value).unwrap_or_default();
+                        return ApiClientError::AllowanceNotEnough {
+                            error_msg: error_400.error,
+                            status_code: error_400.status_code,
+                            description: error_400.description.unwrap_or_default(),
+                            amount,
+                            allowance,
+                        };
+                    }
+                }
+                ApiClientError::GeneralApiError {
+                    error_msg: error_400.error,
+                    status_code: error_400.status_code,
+                    description: error_400.description.unwrap_or_default(),
+                }
+            },
+            NativeError::HttpError { error_msg, status_code } => ApiClientError::GeneralApiError {
+                error_msg,
+                status_code,
+                description: Default::default(),
+            },
+            NativeError::ParseError { error_msg } => ApiClientError::ParseBodyError { error_msg },
+        }
+    }
+}

--- a/mm2src/trading_api/src/one_inch_api/types.rs
+++ b/mm2src/trading_api/src/one_inch_api/types.rs
@@ -1,0 +1,411 @@
+#![allow(clippy::result_large_err)]
+
+use super::client::QueryParams;
+use super::errors::ApiClientError;
+use common::{def_with_opt_param, push_if_some};
+use ethereum_types::Address;
+use mm2_err_handle::mm_error::{MmError, MmResult};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use url::Url;
+
+const ONE_INCH_MAX_SLIPPAGE: f32 = 50.0;
+const ONE_INCH_MAX_FEE_SHARE: f32 = 3.0;
+const ONE_INCH_MAX_GAS: u128 = 11500000;
+const ONE_INCH_MAX_PARTS: u32 = 100;
+const ONE_INCH_MAX_MAIN_ROUTE_PARTS: u32 = 50;
+const ONE_INCH_MAX_COMPLEXITY_LEVEL: u32 = 3;
+
+const BAD_URL_IN_RESPONSE_ERROR: &str = "unsupported url in response";
+const ONE_INCH_DOMAIN: &str = "1inch.io";
+
+/// API params builder for swap quote
+#[derive(Default)]
+pub struct ClassicSwapQuoteParams {
+    /// Source token address
+    src: String,
+    /// Destination token address
+    dst: String,
+    amount: String,
+    // Optional fields
+    fee: Option<f32>,
+    protocols: Option<String>,
+    gas_price: Option<String>,
+    complexity_level: Option<u32>,
+    parts: Option<u32>,
+    main_route_parts: Option<u32>,
+    gas_limit: Option<u128>,
+    include_tokens_info: Option<bool>,
+    include_protocols: Option<bool>,
+    include_gas: Option<bool>,
+    connector_tokens: Option<String>,
+}
+
+impl ClassicSwapQuoteParams {
+    pub fn new(src: String, dst: String, amount: String) -> Self {
+        Self {
+            src,
+            dst,
+            amount,
+            ..Default::default()
+        }
+    }
+
+    def_with_opt_param!(fee, f32);
+    def_with_opt_param!(protocols, String);
+    def_with_opt_param!(gas_price, String);
+    def_with_opt_param!(complexity_level, u32);
+    def_with_opt_param!(parts, u32);
+    def_with_opt_param!(main_route_parts, u32);
+    def_with_opt_param!(gas_limit, u128);
+    def_with_opt_param!(include_tokens_info, bool);
+    def_with_opt_param!(include_protocols, bool);
+    def_with_opt_param!(include_gas, bool);
+    def_with_opt_param!(connector_tokens, String);
+
+    pub fn build_query_params(&self) -> MmResult<QueryParams<'static>, ApiClientError> {
+        self.validate_params()?;
+
+        let mut params = vec![
+            ("src", self.src.clone()),
+            ("dst", self.dst.clone()),
+            ("amount", self.amount.clone()),
+        ];
+
+        push_if_some!(params, "fee", self.fee);
+        push_if_some!(params, "protocols", &self.protocols);
+        push_if_some!(params, "gasPrice", &self.gas_price);
+        push_if_some!(params, "complexityLevel", self.complexity_level);
+        push_if_some!(params, "parts", self.parts);
+        push_if_some!(params, "mainRouteParts", self.main_route_parts);
+        push_if_some!(params, "gasLimit", self.gas_limit);
+        push_if_some!(params, "includeTokensInfo", self.include_tokens_info);
+        push_if_some!(params, "includeProtocols", self.include_protocols);
+        push_if_some!(params, "includeGas", self.include_gas);
+        push_if_some!(params, "connectorTokens", &self.connector_tokens);
+        Ok(params)
+    }
+
+    /// Validate params by 1inch rules (to avoid extra requests)
+    fn validate_params(&self) -> MmResult<(), ApiClientError> {
+        validate_fee(&self.fee)?;
+        validate_complexity_level(&self.complexity_level)?;
+        validate_gas_limit(&self.gas_limit)?;
+        validate_parts(&self.parts)?;
+        validate_main_route_parts(&self.main_route_parts)?;
+        Ok(())
+    }
+}
+
+/// API params builder to create a tx for swap
+#[derive(Default)]
+pub struct ClassicSwapCreateParams {
+    src: String,
+    dst: String,
+    amount: String,
+    from: String,
+    slippage: f32,
+    // Optional fields
+    fee: Option<f32>,
+    protocols: Option<String>,
+    gas_price: Option<String>,
+    complexity_level: Option<u32>,
+    parts: Option<u32>,
+    main_route_parts: Option<u32>,
+    gas_limit: Option<u128>,
+    include_tokens_info: Option<bool>,
+    include_protocols: Option<bool>,
+    include_gas: Option<bool>,
+    connector_tokens: Option<String>,
+    excluded_protocols: Option<String>,
+    permit: Option<String>,
+    compatibility: Option<bool>,
+    receiver: Option<String>,
+    referrer: Option<String>,
+    disable_estimate: Option<bool>,
+    allow_partial_fill: Option<bool>,
+    use_permit2: Option<bool>,
+}
+
+impl ClassicSwapCreateParams {
+    pub fn new(src: String, dst: String, amount: String, from: String, slippage: f32) -> Self {
+        Self {
+            src,
+            dst,
+            amount,
+            from,
+            slippage,
+            ..Default::default()
+        }
+    }
+
+    def_with_opt_param!(fee, f32);
+    def_with_opt_param!(protocols, String);
+    def_with_opt_param!(gas_price, String);
+    def_with_opt_param!(complexity_level, u32);
+    def_with_opt_param!(parts, u32);
+    def_with_opt_param!(main_route_parts, u32);
+    def_with_opt_param!(gas_limit, u128);
+    def_with_opt_param!(include_tokens_info, bool);
+    def_with_opt_param!(include_protocols, bool);
+    def_with_opt_param!(include_gas, bool);
+    def_with_opt_param!(connector_tokens, String);
+    def_with_opt_param!(excluded_protocols, String);
+    def_with_opt_param!(permit, String);
+    def_with_opt_param!(compatibility, bool);
+    def_with_opt_param!(receiver, String);
+    def_with_opt_param!(referrer, String);
+    def_with_opt_param!(disable_estimate, bool);
+    def_with_opt_param!(allow_partial_fill, bool);
+    def_with_opt_param!(use_permit2, bool);
+
+    pub fn build_query_params(&self) -> MmResult<QueryParams<'static>, ApiClientError> {
+        self.validate_params()?;
+
+        let mut params = vec![
+            ("src", self.src.clone()),
+            ("dst", self.dst.clone()),
+            ("amount", self.amount.clone()),
+            ("from", self.from.clone()),
+            ("slippage", self.slippage.to_string()),
+        ];
+
+        push_if_some!(params, "fee", self.fee);
+        push_if_some!(params, "protocols", &self.protocols);
+        push_if_some!(params, "gasPrice", &self.gas_price);
+        push_if_some!(params, "complexityLevel", self.complexity_level);
+        push_if_some!(params, "parts", self.parts);
+        push_if_some!(params, "mainRouteParts", self.main_route_parts);
+        push_if_some!(params, "gasLimit", self.gas_limit);
+        push_if_some!(params, "includeTokensInfo", self.include_tokens_info);
+        push_if_some!(params, "includeProtocols", self.include_protocols);
+        push_if_some!(params, "includeGas", self.include_gas);
+        push_if_some!(params, "connectorTokens", &self.connector_tokens);
+        push_if_some!(params, "excludedProtocols", &self.excluded_protocols);
+        push_if_some!(params, "permit", &self.permit);
+        push_if_some!(params, "compatibility", &self.compatibility);
+        push_if_some!(params, "receiver", &self.receiver);
+        push_if_some!(params, "referrer", &self.referrer);
+        push_if_some!(params, "disableEstimate", self.disable_estimate);
+        push_if_some!(params, "allowPartialFill", self.allow_partial_fill);
+        push_if_some!(params, "usePermit2", self.use_permit2);
+
+        Ok(params)
+    }
+
+    /// Validate params by 1inch rules (to avoid extra requests)
+    fn validate_params(&self) -> MmResult<(), ApiClientError> {
+        validate_slippage(self.slippage)?;
+        validate_fee(&self.fee)?;
+        validate_complexity_level(&self.complexity_level)?;
+        validate_gas_limit(&self.gas_limit)?;
+        validate_parts(&self.parts)?;
+        validate_main_route_parts(&self.main_route_parts)?;
+        Ok(())
+    }
+}
+
+#[derive(Deserialize, Debug, Serialize)]
+pub struct TokenInfo {
+    pub address: Address,
+    pub symbol: String,
+    pub name: String,
+    pub decimals: u32,
+    pub eip2612: bool,
+    #[serde(rename = "isFoT", default)]
+    pub is_fot: bool,
+    #[serde(rename = "logoURI", with = "serde_one_inch_link")]
+    pub logo_uri: String,
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ProtocolInfo {
+    pub name: String,
+    pub part: f64,
+    #[serde(rename = "fromTokenAddress")]
+    pub from_token_address: Address,
+    #[serde(rename = "toTokenAddress")]
+    pub to_token_address: Address,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ClassicSwapData {
+    /// dst token amount to receive, in api is a decimal number as string
+    #[serde(rename = "dstAmount")]
+    pub dst_amount: String,
+    #[serde(rename = "srcToken")]
+    pub src_token: Option<TokenInfo>,
+    #[serde(rename = "dstToken")]
+    pub dst_token: Option<TokenInfo>,
+    pub protocols: Option<Vec<Vec<Vec<ProtocolInfo>>>>,
+    pub tx: Option<TxFields>,
+    pub gas: Option<u128>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct TxFields {
+    pub from: Address,
+    pub to: Address,
+    pub data: String,
+    /// tx value, in api is a decimal number as string
+    pub value: String,
+    /// gas price, in api is a decimal number as string
+    #[serde(rename = "gasPrice")]
+    pub gas_price: String,
+    /// gas limit, in api is a decimal number
+    pub gas: u128,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct ProtocolImage {
+    pub id: String,
+    pub title: String,
+    #[serde(with = "serde_one_inch_link")]
+    pub img: String,
+    #[serde(with = "serde_one_inch_link")]
+    pub img_color: String,
+}
+
+#[derive(Deserialize)]
+pub struct ProtocolsResponse {
+    pub protocols: Vec<ProtocolImage>,
+}
+
+#[derive(Deserialize)]
+pub struct TokensResponse {
+    pub tokens: HashMap<String, TokenInfo>,
+}
+
+mod serde_one_inch_link {
+    use super::validate_one_inch_link;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    /// Just forward to the normal serializer
+    pub(super) fn serialize<S>(s: &String, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        s.serialize(serializer)
+    }
+
+    /// Deserialise String with checking links
+    pub(super) fn deserialize<'a, D>(deserializer: D) -> Result<String, D::Error>
+    where
+        D: Deserializer<'a>,
+    {
+        <String as Deserialize>::deserialize(deserializer)
+            .map(|value| validate_one_inch_link(&value).unwrap_or_default())
+    }
+}
+
+fn validate_slippage(slippage: f32) -> MmResult<(), ApiClientError> {
+    if !(0.0..=ONE_INCH_MAX_SLIPPAGE).contains(&slippage) {
+        return Err(ApiClientError::OutOfBounds {
+            param: "slippage".to_owned(),
+            value: slippage.to_string(),
+            min: 0.0.to_string(),
+            max: ONE_INCH_MAX_SLIPPAGE.to_string(),
+        }
+        .into());
+    }
+    Ok(())
+}
+
+fn validate_fee(fee: &Option<f32>) -> MmResult<(), ApiClientError> {
+    if let Some(fee) = fee {
+        if !(0.0..=ONE_INCH_MAX_FEE_SHARE).contains(fee) {
+            return Err(ApiClientError::OutOfBounds {
+                param: "fee".to_owned(),
+                value: fee.to_string(),
+                min: 0.0.to_string(),
+                max: ONE_INCH_MAX_FEE_SHARE.to_string(),
+            }
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn validate_gas_limit(gas_limit: &Option<u128>) -> MmResult<(), ApiClientError> {
+    if let Some(gas_limit) = gas_limit {
+        if gas_limit > &ONE_INCH_MAX_GAS {
+            return Err(ApiClientError::OutOfBounds {
+                param: "gas_limit".to_owned(),
+                value: gas_limit.to_string(),
+                min: 0.to_string(),
+                max: ONE_INCH_MAX_GAS.to_string(),
+            }
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn validate_parts(parts: &Option<u32>) -> MmResult<(), ApiClientError> {
+    if let Some(parts) = parts {
+        if parts > &ONE_INCH_MAX_PARTS {
+            return Err(ApiClientError::OutOfBounds {
+                param: "parts".to_owned(),
+                value: parts.to_string(),
+                min: 0.to_string(),
+                max: ONE_INCH_MAX_PARTS.to_string(),
+            }
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn validate_main_route_parts(main_route_parts: &Option<u32>) -> MmResult<(), ApiClientError> {
+    if let Some(main_route_parts) = main_route_parts {
+        if main_route_parts > &ONE_INCH_MAX_MAIN_ROUTE_PARTS {
+            return Err(ApiClientError::OutOfBounds {
+                param: "main route parts".to_owned(),
+                value: main_route_parts.to_string(),
+                min: 0.to_string(),
+                max: ONE_INCH_MAX_MAIN_ROUTE_PARTS.to_string(),
+            }
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn validate_complexity_level(complexity_level: &Option<u32>) -> MmResult<(), ApiClientError> {
+    if let Some(complexity_level) = complexity_level {
+        if complexity_level > &ONE_INCH_MAX_COMPLEXITY_LEVEL {
+            return Err(ApiClientError::OutOfBounds {
+                param: "complexity level".to_owned(),
+                value: complexity_level.to_string(),
+                min: 0.to_string(),
+                max: ONE_INCH_MAX_COMPLEXITY_LEVEL.to_string(),
+            }
+            .into());
+        }
+    }
+    Ok(())
+}
+
+/// Check if url is valid and is a subdomain of 1inch domain (simple anti-phishing check)
+fn validate_one_inch_link(s: &str) -> MmResult<String, ApiClientError> {
+    let url = Url::parse(s).map_err(|_err| ApiClientError::ParseBodyError {
+        error_msg: BAD_URL_IN_RESPONSE_ERROR.to_owned(),
+    })?;
+    if let Some(host) = url.host() {
+        if host.to_string().ends_with(ONE_INCH_DOMAIN) {
+            return Ok(s.to_owned());
+        }
+    }
+    MmError::err(ApiClientError::ParseBodyError {
+        error_msg: BAD_URL_IN_RESPONSE_ERROR.to_owned(),
+    })
+}
+
+#[test]
+fn test_validate_one_inch_link() {
+    assert!(validate_one_inch_link("https://cdn.1inch.io/liquidity-sources-logo/wmatic_color.png").is_ok());
+    assert!(validate_one_inch_link("https://example.org/somepath/somefile.png").is_err());
+    assert!(validate_one_inch_link("https://inch.io/somepath/somefile.png").is_err());
+    assert!(validate_one_inch_link("127.0.0.1").is_err());
+}


### PR DESCRIPTION
### Release notes

- [feat(LRAPI): add 1inch classic swap rpc](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2222): Initial code to connect to 1inch Liquidity Routing API (LRAPI) provider and two new RPCs to use 1inch classic swap API. It also adds 'approve' and 'allowance' RPCs (for ERC20 tokens)

- [improvement(error-handling): main files](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2288): Makes KDF to check main files (config/coins/etc..) before reading them to prevent potential panics.

- [fix(rpc): remove character check blocking password input](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2287): Removes check for <, >, & characters in RPC request bodies that was incorrectly blocking valid password characters in get_mnemonic RPC call. These special characters should be allowed in passwords.

- [fix(mm2_bitcoin): don't rely on core](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2289) Makes no sense to rely on core on KDF.

- [chore(ctx): replace gstuff constructible with oncelock](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2267) Replaced Constructible from the gstuff crate with once_cell::sync::OnceCell for managing lazy-initialized values in [mm_ctx](https://github.com/KomodoPlatform/komodo-defi-framework/blob/c9baf0dfcfac8ec56bac58d9e4ca0e46bc6fb646/mm2src/mm2_core/src/mm_ctx.rs#L68) for better performance and stronger thread safety.

- [chore(adex-cli): use "Komodo DeFi Framework" name in adex_cli](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2290) self-explanatory

- [chore(libp2p): k-0.52.11 bump](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2296) Fixes a [security (memory leak) issue](https://github.com/KomodoPlatform/komodo-defi-framework/issues/771).