### PR TITLE
improvement(error-handling): main files

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -22,6 +22,7 @@ jobs:
           types: |
             feat
             fix
+            improvement
             chore
             docs
             deps
@@ -38,9 +39,9 @@ jobs:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
           title_length=${#TITLE}
-          if [ $title_length -gt 72 ]
+          if [ $title_length -gt 85 ]
           then
-            echo "PR title is too long (greater than 72 characters)"
+            echo "PR title is too long (greater than 85 characters)"
             exit 1
           fi
 

--- a/mm2src/mm2_main/src/mm2.rs
+++ b/mm2src/mm2_main/src/mm2.rs
@@ -303,22 +303,23 @@ pub fn mm2_main(version: String, datetime: String) {
 /// Parses and returns the `first_arg` as JSON.
 /// Attempts to load the config from `MM2.json` file if `first_arg` is None
 pub fn get_mm2config(first_arg: Option<&str>) -> Result<Json, String> {
-    let conf_path = common::kdf_config_file().map_err(|e| e.to_string())?;
-    let conf_from_file = slurp(&conf_path);
     let conf = match first_arg {
-        Some(s) => s,
+        Some(s) => s.to_owned(),
         None => {
+            let conf_path = common::kdf_config_file().map_err(|e| e.to_string())?;
+            let conf_from_file = slurp(&conf_path);
+
             if conf_from_file.is_empty() {
                 return ERR!(
                     "Config is not set from command line arg and {} file doesn't exist.",
                     conf_path.display()
                 );
             }
-            try_s!(std::str::from_utf8(&conf_from_file))
+            try_s!(String::from_utf8(conf_from_file))
         },
     };
 
-    let mut conf: Json = match json::from_str(conf) {
+    let mut conf: Json = match json::from_str(&conf) {
         Ok(json) => json,
         // Syntax or io errors may include the conf string in the error message so we don't want to take risks and show these errors internals in the log.
         // If new variants are added to the Error enum, there can be a risk of exposing the conf string in the error message when updating serde_json so

--- a/mm2src/mm2_main/src/mm2.rs
+++ b/mm2src/mm2_main/src/mm2.rs
@@ -303,7 +303,7 @@ pub fn mm2_main(version: String, datetime: String) {
 /// Parses and returns the `first_arg` as JSON.
 /// Attempts to load the config from `MM2.json` file if `first_arg` is None
 pub fn get_mm2config(first_arg: Option<&str>) -> Result<Json, String> {
-    let conf_path = common::kdf_config_file();
+    let conf_path = common::kdf_config_file().map_err(|e| e.to_string())?;
     let conf_from_file = slurp(&conf_path);
     let conf = match first_arg {
         Some(s) => s,
@@ -327,7 +327,7 @@ pub fn get_mm2config(first_arg: Option<&str>) -> Result<Json, String> {
     };
 
     if conf["coins"].is_null() {
-        let coins_path = common::kdf_coins_file();
+        let coins_path = common::kdf_coins_file().map_err(|e| e.to_string())?;
 
         let coins_from_file = slurp(&coins_path);
         if coins_from_file.is_empty() {


### PR DESCRIPTION
Makes KDF to check main files before reading them to prevent potential panics.

**To Test:** @KomodoPlatform/qa 
Start KDF with a path that is a dir or a non-existing path and better error messages will be displayed. Starting using CLI args should work as before and also any existing way of loading mm2 config and coins file should work as before.