### PR TITLE
fix(mm2_bitcoin): don't rely on `core`

### DIFF
--- a/mm2src/mm2_bitcoin/rpc/src/lib.rs
+++ b/mm2src/mm2_bitcoin/rpc/src/lib.rs
@@ -1,4 +1,3 @@
-extern crate core;
 #[cfg(test)] extern crate lazy_static;
 extern crate log;
 extern crate rustc_hex as hex;

--- a/mm2src/mm2_bitcoin/rpc/src/v1/types/bytes.rs
+++ b/mm2src/mm2_bitcoin/rpc/src/v1/types/bytes.rs
@@ -85,8 +85,8 @@ impl ops::Deref for Bytes {
     fn deref(&self) -> &Self::Target { &self.0 }
 }
 
-impl ::core::fmt::LowerHex for Bytes {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+impl ::std::fmt::LowerHex for Bytes {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         for i in &self.0[..] {
             write!(f, "{:02x}", i)?;
         }

--- a/mm2src/mm2_bitcoin/rpc/src/v1/types/hash.rs
+++ b/mm2src/mm2_bitcoin/rpc/src/v1/types/hash.rs
@@ -147,8 +147,8 @@ macro_rules! impl_hash {
             }
         }
 
-        impl ::core::fmt::LowerHex for $name {
-            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        impl ::std::fmt::LowerHex for $name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 for i in &self.0[..] {
                     write!(f, "{:02x}", i)?;
                 }


### PR DESCRIPTION
Makes no sense to rely on `core` on KDF.