### PR TITLE
chore(ci): Update docker build for wasm

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -51,7 +51,7 @@ RUN apt-get install -y 	  \
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile minimal --default-toolchain nightly-2023-06-01 -y
 ENV PATH="/root/.cargo/bin:$PATH"
-RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | bash -s -- -y
+RUN cargo install wasm-pack --version 0.10.3
 RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v25.3/protoc-25.3-linux-x86_64.zip
 RUN unzip protoc-25.3-linux-x86_64.zip && mv ./include/google /usr/include/google
 

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/debian:10
 
-MAINTAINER Onur Özkan <onur@komodoplatform.com>
+LABEL authors="Onur Özkan <onur@komodoplatform.com>"
 
 RUN apt-get update -y
 
@@ -11,6 +11,7 @@ RUN apt-get install -y 	\
     curl             	\
     wget             	\
     unzip             	\
+	libudev-dev			\
     gnupg
 
 RUN ln -s /usr/bin/python3 /bin/python
@@ -49,8 +50,8 @@ RUN apt-get install -y 	  \
 	docker-buildx-plugin
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile minimal --default-toolchain nightly-2023-06-01 -y
-
-RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.20.1/protoc-3.20.1-linux-x86_64.zip
-RUN unzip protoc-3.20.1-linux-x86_64.zip && mv ./include/google /usr/include/google
-
 ENV PATH="/root/.cargo/bin:$PATH"
+RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | bash -s -- -y
+RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v25.3/protoc-25.3-linux-x86_64.zip
+RUN unzip protoc-25.3-linux-x86_64.zip && mv ./include/google /usr/include/google
+

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -368,7 +368,7 @@ jobs:
           rustup target add wasm32-unknown-unknown
 
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | bash -s -- -y
+        run: CARGO_HOME=/root/.cargo cargo install wasm-pack --version 0.10.3
 
       - name: Calculate commit hash for PR commit
         if: github.event_name == 'pull_request'

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -334,7 +334,7 @@ jobs:
           rustup target add wasm32-unknown-unknown
 
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | bash -s -- -y
+        run: CARGO_HOME=/root/.cargo cargo install wasm-pack --version 0.10.3
 
       - name: Calculate commit hash for PR commit
         if: github.event_name == 'pull_request'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -245,6 +245,9 @@ jobs:
           deps: ('protoc')
 
       - name: Install wasm-pack
+        # Use the latest wasm-pack for up-to-date compatibility coverage on KDF.
+        # As we don't share any build artifacts from this pipeline, we don't need
+        # to lock the version here.
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Download geckodriver

--- a/docs/WASM_BUILD.md
+++ b/docs/WASM_BUILD.md
@@ -1,5 +1,20 @@
 # Building WASM binary
 
+## From Container:
+
+If you want to build from source without installing prerequisites to your host system, you can do so by binding the source code inside a container and compiling it there.
+
+Build the image:
+
+```sh
+docker build -t kdf-build-container -f .docker/Dockerfile .
+```
+
+Bind source code into container and compile it:
+```sh
+docker run -v "$(pwd)":/app -w /app kdf-build-container wasm-pack build mm2src/mm2_bin_lib --target web --out-dir wasm_build/deps/pkg/
+```
+
 ## Setting up the environment
 
 To build WASM binary from source, the following prerequisites are required:
@@ -40,3 +55,5 @@ wasm-pack build mm2src/mm2_bin_lib --target web --out-dir wasm_build/deps/pkg/ -
 ```
 
 Please don't forget to specify `CC` and `AR` if you run the command on OSX.
+
+


### PR DESCRIPTION
I was getting errors building current dev branch in both container and local system: 

```
error: failed to compile `wasm-pack v0.13.1`, intermediate artifacts can be found at `/tmp/cargo-installqtfHhI`

Caused by:
  package `bumpalo v3.16.0` cannot be built because it requires rustc 1.73.0 or newer, while the currently active rustc version is 1.72.0-nightly
  Try re-running cargo install with `--locked`
```

Referring to the [GHA workflow deps](https://github.com/KomodoPlatform/komodo-defi-framework/blob/main/.github/actions/deps-install/action.yml#L19), I noticed a different protoc version so updated it in the Dockerfile.

I also added [rustwasm install from script step from GHA](https://github.com/KomodoPlatform/komodo-defi-framework/blob/main/.github/workflows/dev-build.yml#L371) to avoid the version error above. 

Additionally the WASM_BUILD doc was updated to include instructions for building via docker.