### PR TITLE
fix(wasm): add test-ext-api feature to mm2_main and mm2_bin_lib tomls

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -48,9 +48,9 @@ jobs:
       - name: Check PR labels
         env:
           LABEL_NAMES: ${{ toJson(github.event.pull_request.labels.*.name) }}
-        if: >
-          contains(env.LABEL_NAMES, 'status: in progress') ==
-          contains(env.LABEL_NAMES, 'status: pending review')
+        if: "!((contains(env.LABEL_NAMES, 'pending review') && !contains(env.LABEL_NAMES, 'in progress') && !contains(env.LABEL_NAMES, 'blocked'))
+          || (!contains(env.LABEL_NAMES, 'pending review') && contains(env.LABEL_NAMES, 'in progress') && !contains(env.LABEL_NAMES, 'blocked'))
+          || (!contains(env.LABEL_NAMES, 'pending review') && !contains(env.LABEL_NAMES, 'in progress') && contains(env.LABEL_NAMES, 'blocked')))"
         run: |
-          echo "PR must have exactly one of these labels: ['status: in progress', 'status: pending review']."
-          exit 1        
+          echo "PR must have "exactly one" of these labels: ['status: pending review', 'status: in progress', 'status: blocked']."
+          exit 1

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -50,7 +50,7 @@ jobs:
           LABEL_NAMES: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
           # Filter labels starting with "status:"
-          STATUS_LABELS=$(echo $LABEL_NAMES | jq -r '.[] | select(startswith("status:"))')
+          STATUS_LABELS=$(echo $LABEL_NAMES | jq -r '.[] | select(startswith("status:") and . != "status: blocked" and . != "status: invalid")')
           STATUS_COUNT=$(echo "$STATUS_LABELS" | wc -l)
           
           echo "Found status labels: $STATUS_LABELS"
@@ -58,6 +58,6 @@ jobs:
           
           if [ "$STATUS_COUNT" -ne 1 ]
           then
-            echo "PR must have exactly one label starting with 'status:'. Found $STATUS_COUNT."
+            echo "PR must have exactly one valid label starting with 'status:'. Found $STATUS_COUNT."
             exit 1
           fi

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -48,16 +48,9 @@ jobs:
       - name: Check PR labels
         env:
           LABEL_NAMES: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        if: >
+          contains(env.LABEL_NAMES, 'status: in progress') ==
+          contains(env.LABEL_NAMES, 'status: pending review')
         run: |
-          # Filter labels starting with "status:"
-          STATUS_LABELS=$(echo $LABEL_NAMES | jq -r '.[] | select(startswith("status:") and . != "status: blocked" and . != "status: invalid")')
-          STATUS_COUNT=$(echo "$STATUS_LABELS" | wc -l)
-          
-          echo "Found status labels: $STATUS_LABELS"
-          echo "Count of status labels: $STATUS_COUNT"
-          
-          if [ "$STATUS_COUNT" -ne 1 ]
-          then
-            echo "PR must have exactly one valid label starting with 'status:'. Found $STATUS_COUNT."
-            exit 1
-          fi
+          echo "PR must have exactly one of these labels: ['status: in progress', 'status: pending review']."
+          exit 1        

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -50,5 +50,15 @@ jobs:
           LABEL_NAMES: ${{ toJson(github.event.pull_request.labels.*.name) }}
         if: contains(env.LABEL_NAMES, 'under review') == contains(env.LABEL_NAMES, 'in progress')
         run: |
-          echo "PR must have "exactly one" of these labels: ['under review', 'in progress']."
-          exit 1
+          # Filter labels starting with "status:"
+          STATUS_LABELS=$(echo $LABEL_NAMES | jq -r '.[] | select(startswith("status:"))')
+          STATUS_COUNT=$(echo "$STATUS_LABELS" | wc -l)
+          
+          echo "Found status labels: $STATUS_LABELS"
+          echo "Count of status labels: $STATUS_COUNT"
+          
+          if [ "$STATUS_COUNT" -ne 1 ]
+          then
+            echo "PR must have exactly one label starting with 'status:'. Found $STATUS_COUNT."
+            exit 1
+          fi

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -48,7 +48,6 @@ jobs:
       - name: Check PR labels
         env:
           LABEL_NAMES: ${{ toJson(github.event.pull_request.labels.*.name) }}
-        if: contains(env.LABEL_NAMES, 'under review') == contains(env.LABEL_NAMES, 'in progress')
         run: |
           # Filter labels starting with "status:"
           STATUS_LABELS=$(echo $LABEL_NAMES | jq -r '.[] | select(startswith("status:"))')

--- a/mm2src/mm2_bin_lib/Cargo.toml
+++ b/mm2src/mm2_bin_lib/Cargo.toml
@@ -15,6 +15,7 @@ custom-swap-locktime = ["mm2_main/custom-swap-locktime"] # only for testing purp
 native = ["mm2_main/native"] # Deprecated
 track-ctx-pointer = ["mm2_main/track-ctx-pointer"]
 zhtlc-native-tests = ["mm2_main/zhtlc-native-tests"]
+test-ext-api = ["mm2_main/test-ext-api"]
 
 [[bin]]
 name = "mm2"

--- a/mm2src/mm2_main/Cargo.toml
+++ b/mm2src/mm2_main/Cargo.toml
@@ -24,6 +24,7 @@ run-device-tests = []
 enable-sia = ["coins/enable-sia", "coins_activation/enable-sia"]
 sepolia-maker-swap-v2-tests = []
 sepolia-taker-swap-v2-tests = []
+test-ext-api = ["trading_api/test-ext-api"]
 
 [dependencies]
 async-std = { version = "1.5", features = ["unstable"] }


### PR DESCRIPTION
Fixes wasm build with feature flag `test-ext-api`

```
hound@hound:~/komodo-defi-framework$ docker run -v "$(pwd)":/app -w /app kdf-build-container wasm-pack build mm2src/mm2_bin_lib --target web --out-dir wasm_build/deps/pkg/ --features  test-ext-api
[INFO]: Checking for the Wasm target...
info: downloading component 'rust-std' for 'wasm32-unknown-unknown'
info: installing component 'rust-std' for 'wasm32-unknown-unknown'
[INFO]: Compiling to Wasm...
warning: /app/mm2src/mm2_bin_lib/Cargo.toml: file `/app/mm2src/mm2_bin_lib/src/mm2_bin.rs` found to be present in multiple build targets:
  * `bin` target `mm2`
  * `bin` target `kdf`
error: none of the selected packages contains these features: test-ext-api
Error: Compiling your crate to WebAssembly failed
Caused by: Compiling your crate to WebAssembly failed
Caused by: failed to execute `cargo build`: exited with exit status: 101
  full command: cd "mm2src/mm2_bin_lib" && "cargo" "build" "--lib" "--release" "--target" "wasm32-unknown-unknown" "--features" "test-ext-api"
```


also fixes CI PR lint, checking new `status:` labels 