### PR TITLE
fix(deps): add the web-time package to Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6963,6 +6963,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b102d4d896895d697f1dff4141dff28307532dac57a376b2b5665a55b280dc6"
 dependencies = [
  "rustc-hash",
+ "web-time",
 ]
 
 [[package]]
@@ -7779,6 +7780,16 @@ name = "web-sys"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",


### PR DESCRIPTION
Cargo.lock needs `web-time` package for `timed-map` after adding `wasm` feature in deps