### PR TITLE
fix(crypto): allow non bip39 mnemonics storage

### DIFF
--- a/mm2src/crypto/src/mnemonic.rs
+++ b/mm2src/crypto/src/mnemonic.rs
@@ -157,7 +157,7 @@ mod tests {
         assert_eq!(decrypted_mnemonic, mnemonic);
     });
 
-    cross_test!(test_encrypt_decrypt_words, {
+    cross_test!(test_encrypt_decrypt_non_bip39_mnemonic, {
         let mnemonic = "Helloworld";
         let password = "Helloworld";
 

--- a/mm2src/crypto/src/mnemonic.rs
+++ b/mm2src/crypto/src/mnemonic.rs
@@ -174,4 +174,26 @@ mod tests {
         // Verify if decrypted mnemonic matches the original
         assert_eq!(decrypted_mnemonic, mnemonic);
     });
+
+    cross_test!(test_mnemonic_with_last_byte_zero, {
+        let mnemonic = "tank abandon bind salon remove wisdom net size aspect direct source fossil\0".to_string();
+        let password = "password";
+
+        // Encrypt the mnemonic
+        let encrypted_data = encrypt_mnemonic(&mnemonic, password);
+        assert!(encrypted_data.is_ok());
+        let encrypted_data = encrypted_data.unwrap();
+
+        // Decrypt the mnemonic
+        let decrypted_mnemonic_str = decrypt_mnemonic(&encrypted_data, password);
+        assert!(decrypted_mnemonic_str.is_ok());
+        let decrypted_mnemonic = Mnemonic::parse_normalized(&decrypted_mnemonic_str.unwrap());
+        assert!(decrypted_mnemonic.is_err());
+
+        // Verify that the error is due to parsing and not padding
+        assert!(decrypted_mnemonic
+            .unwrap_err()
+            .to_string()
+            .contains("mnemonic contains an unknown word (word 11)"));
+    });
 }

--- a/mm2src/crypto/src/mnemonic.rs
+++ b/mm2src/crypto/src/mnemonic.rs
@@ -104,7 +104,7 @@ pub fn encrypt_mnemonic(mnemonic: &str, password: &str) -> MmResult<EncryptedDat
 ///
 /// # Errors
 /// This function can return various errors related to decoding, key derivation, encryption, and HMAC verification.
-pub fn decrypt_mnemonic(encrypted_data: &EncryptedData, password: &str) -> MmResult<Mnemonic, MnemonicError> {
+pub fn decrypt_mnemonic(encrypted_data: &EncryptedData, password: &str) -> MmResult<String, MnemonicError> {
     // Re-create the salts from Base64-encoded strings
     let (salt_aes, salt_hmac) = match &encrypted_data.key_derivation_details {
         KeyDerivationDetails::Argon2 {
@@ -126,8 +126,7 @@ pub fn decrypt_mnemonic(encrypted_data: &EncryptedData, password: &str) -> MmRes
 
     // Convert decrypted data back to a string
     let mnemonic_str = String::from_utf8(decrypted_data).map_to_mm(|e| MnemonicError::DecodeError(e.to_string()))?;
-    let mnemonic = Mnemonic::parse_normalized(&mnemonic_str)?;
-    Ok(mnemonic)
+    Ok(mnemonic_str)
 }
 
 #[cfg(any(test, target_arch = "wasm32"))]
@@ -144,10 +143,23 @@ mod tests {
         let mnemonic = "tank abandon bind salon remove wisdom net size aspect direct source fossil";
         let password = "password";
 
-        // Verify that the mnemonic is valid
-        let parsed_mnemonic = Mnemonic::parse_normalized(mnemonic);
-        assert!(parsed_mnemonic.is_ok());
-        let parsed_mnemonic = parsed_mnemonic.unwrap();
+        // Encrypt the mnemonic
+        let encrypted_data = encrypt_mnemonic(mnemonic, password);
+        assert!(encrypted_data.is_ok());
+        let encrypted_data = encrypted_data.unwrap();
+
+        // Decrypt the mnemonic
+        let decrypted_mnemonic = decrypt_mnemonic(&encrypted_data, password);
+        assert!(decrypted_mnemonic.is_ok());
+        let decrypted_mnemonic = decrypted_mnemonic.unwrap();
+
+        // Verify if decrypted mnemonic matches the original
+        assert_eq!(decrypted_mnemonic, mnemonic);
+    });
+
+    cross_test!(test_encrypt_decrypt_words, {
+        let mnemonic = "Helloworld";
+        let password = "Helloworld";
 
         // Encrypt the mnemonic
         let encrypted_data = encrypt_mnemonic(mnemonic, password);
@@ -160,26 +172,6 @@ mod tests {
         let decrypted_mnemonic = decrypted_mnemonic.unwrap();
 
         // Verify if decrypted mnemonic matches the original
-        assert_eq!(decrypted_mnemonic, parsed_mnemonic);
-    });
-
-    cross_test!(test_mnemonic_with_last_byte_zero, {
-        let mnemonic = "tank abandon bind salon remove wisdom net size aspect direct source fossil\0".to_string();
-        let password = "password";
-
-        // Encrypt the mnemonic
-        let encrypted_data = encrypt_mnemonic(&mnemonic, password);
-        assert!(encrypted_data.is_ok());
-        let encrypted_data = encrypted_data.unwrap();
-
-        // Decrypt the mnemonic
-        let decrypted_mnemonic = decrypt_mnemonic(&encrypted_data, password);
-        assert!(decrypted_mnemonic.is_err());
-
-        // Verify that the error is due to parsing and not padding
-        assert!(decrypted_mnemonic
-            .unwrap_err()
-            .to_string()
-            .contains("mnemonic contains an unknown word (word 11)"));
+        assert_eq!(decrypted_mnemonic, mnemonic);
     });
 }

--- a/mm2src/mm2_main/src/lp_wallet.rs
+++ b/mm2src/mm2_main/src/lp_wallet.rs
@@ -139,7 +139,7 @@ async fn read_and_decrypt_passphrase_if_available(
         Some(encrypted_passphrase) => {
             let mnemonic = decrypt_mnemonic(&encrypted_passphrase, wallet_password)
                 .mm_err(|e| ReadPassphraseError::DecryptionError(e.to_string()))?;
-            Ok(Some(mnemonic.to_string()))
+            Ok(Some(mnemonic))
         },
         None => Ok(None),
     }
@@ -214,7 +214,7 @@ async fn decrypt_validate_or_save_passphrase(
     wallet_password: &str,
 ) -> WalletInitResult<Option<String>> {
     // Decrypt the provided encrypted passphrase
-    let decrypted_passphrase = decrypt_mnemonic(&encrypted_passphrase_data, wallet_password)?.to_string();
+    let decrypted_passphrase = decrypt_mnemonic(&encrypted_passphrase_data, wallet_password)?;
 
     match read_and_decrypt_passphrase_if_available(ctx, wallet_password).await? {
         Some(passphrase_from_file) if decrypted_passphrase == passphrase_from_file => {


### PR DESCRIPTION
Fixes an issue where passphrases were incorrectly validated as BIP39 mnemonics during storage decryption. Now, passphrases no longer require mnemonic validation.