### PR TITLE
refactor(build script): rewrite the main build script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,5 +24,4 @@ cmake-build-debug
 /wasm-build.log
 
 # Opt out from history in order to speed the `COPY .` up.
-# Note that we should create and/or update the MM_VERSION file when using `COPY .` to build a custom version.
 /.git

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -10,7 +10,6 @@ concurrency:
 
 env:
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-  MANUAL_MM_VERSION: true
   JEMALLOC_SYS_WITH_MALLOC_CONF: "background_thread:true,narenas:1,tcache:false,dirty_decay_ms:0,muzzy_decay_ms:0,metadata_thp:auto"
 
 jobs:
@@ -38,29 +37,26 @@ jobs:
         with:
           deps: ('protoc')
 
-      - name: Calculate commit hash for PR commit
+      - name: Calculate build tag (commit hash) for PR commit
         if: github.event_name == 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
 
-      - name: Calculate commit hash for merge commit
+      - name: Calculate build tag (commit hash) for merge commit
         if: github.event_name != 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
 
       - name: Build cache
         uses: ./.github/actions/build-cache
 
       - name: Build
-        run: |
-          rm -f ./MM_VERSION
-          echo $COMMIT_HASH > ./MM_VERSION
-          cargo build --release
+        run: cargo build --release
 
       - name: Compress mm2 build output
         env:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
         if: ${{ env.AVAILABLE != '' }}
         run: |
-          NAME="mm2_$COMMIT_HASH-linux-x86-64.zip"
+          NAME="mm2_$KDF_BUILD_TAG-linux-x86-64.zip"
           zip $NAME target/release/mm2 -j
           mkdir $BRANCH_NAME
           mv $NAME ./$BRANCH_NAME/
@@ -70,7 +66,7 @@ jobs:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
         if: ${{ env.AVAILABLE != '' }}
         run: |
-          NAME="kdf_$COMMIT_HASH-linux-x86-64.zip"
+          NAME="kdf_$KDF_BUILD_TAG-linux-x86-64.zip"
           zip $NAME target/release/kdf -j
           mv $NAME ./$BRANCH_NAME/
 
@@ -90,7 +86,7 @@ jobs:
       - name: Build and push container image
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/dev'
         run: |
-          CONTAINER_TAG="dev-$COMMIT_HASH"
+          CONTAINER_TAG="dev-$KDF_BUILD_TAG"
           docker build -t komodoofficial/komodo-defi-framework:"$CONTAINER_TAG" -t komodoofficial/komodo-defi-framework:dev-latest -f .docker/Dockerfile.dev-release .
           docker push komodoofficial/komodo-defi-framework:"$CONTAINER_TAG"
           docker push komodoofficial/komodo-defi-framework:dev-latest
@@ -111,29 +107,26 @@ jobs:
         with:
           deps: ('protoc', 'python3', 'paramiko')
 
-      - name: Calculate commit hash for PR commit
+      - name: Calculate build tag (commit hash) for PR commit
         if: github.event_name == 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
 
-      - name: Calculate commit hash for merge commit
+      - name: Calculate build tag (commit hash) for merge commit
         if: github.event_name != 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
 
       - name: Build cache
         uses: ./.github/actions/build-cache
 
       - name: Build
-        run: |
-          rm -f ./MM_VERSION
-          echo $COMMIT_HASH > ./MM_VERSION
-          cargo build --release --target x86_64-apple-darwin
+        run: cargo build --release --target x86_64-apple-darwin
 
       - name: Compress mm2 build output
         env:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
         if: ${{ env.AVAILABLE != '' }}
         run: |
-          NAME="mm2_$COMMIT_HASH-mac-x86-64.zip"
+          NAME="mm2_$KDF_BUILD_TAG-mac-x86-64.zip"
           zip $NAME target/x86_64-apple-darwin/release/mm2 -j
           mkdir $BRANCH_NAME
           mv $NAME ./$BRANCH_NAME/
@@ -143,7 +136,7 @@ jobs:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
         if: ${{ env.AVAILABLE != '' }}
         run: |
-          NAME="kdf_$COMMIT_HASH-mac-x86-64.zip"
+          NAME="kdf_$KDF_BUILD_TAG-mac-x86-64.zip"
           zip $NAME target/x86_64-apple-darwin/release/kdf -j
           mv $NAME ./$BRANCH_NAME/
 
@@ -172,29 +165,26 @@ jobs:
         with:
           deps: ('protoc', 'python3', 'paramiko')
 
-      - name: Calculate commit hash for PR commit
+      - name: Calculate build tag (commit hash) for PR commit
         if: github.event_name == 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
 
-      - name: Calculate commit hash for merge commit
+      - name: Calculate build tag (commit hash) for merge commit
         if: github.event_name != 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
 
       - name: Build cache
         uses: ./.github/actions/build-cache
 
       - name: Build
-        run: |
-          rm -f ./MM_VERSION
-          echo $COMMIT_HASH > ./MM_VERSION
-          cargo build --release --target aarch64-apple-darwin
+        run: cargo build --release --target aarch64-apple-darwin
 
       - name: Compress mm2 build output
         env:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
         if: ${{ env.AVAILABLE != '' }}
         run: |
-          NAME="mm2_$COMMIT_HASH-mac-arm64.zip"
+          NAME="mm2_$KDF_BUILD_TAG-mac-arm64.zip"
           zip $NAME target/aarch64-apple-darwin/release/mm2 -j
           mkdir $BRANCH_NAME
           mv $NAME ./$BRANCH_NAME/
@@ -204,7 +194,7 @@ jobs:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
         if: ${{ env.AVAILABLE != '' }}
         run: |
-          NAME="kdf_$COMMIT_HASH-mac-arm64.zip"
+          NAME="kdf_$KDF_BUILD_TAG-mac-arm64.zip"
           zip $NAME target/aarch64-apple-darwin/release/kdf -j
           mv $NAME ./$BRANCH_NAME/
 
@@ -232,31 +222,26 @@ jobs:
         with:
           deps: ('protoc', 'python3', 'paramiko')
 
-      - name: Calculate commit hash for PR commit
+      - name: Calculate build tag (commit hash) for PR commit
         if: github.event_name == 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $Env:GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $Env:GITHUB_ENV
 
-      - name: Calculate commit hash for merge commit
+      - name: Calculate build tag (commit hash) for merge commit
         if: github.event_name != 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 HEAD)" >> $Env:GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 HEAD)" >> $Env:GITHUB_ENV
 
       - name: Build cache
         uses: ./.github/actions/build-cache
 
       - name: Build
-        run: |
-          if (test-path "./MM_VERSION") {
-            remove-item "./MM_VERSION"
-          }
-          echo $Env:COMMIT_HASH > ./MM_VERSION
-          cargo build --release
+        run: cargo build --release
 
       - name: Compress mm2 build output
         env:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
         if: ${{ env.AVAILABLE != '' }}
         run: |
-          $NAME="mm2_$Env:COMMIT_HASH-win-x86-64.zip"
+          $NAME="mm2_$Env:KDF_BUILD_TAG-win-x86-64.zip"
           7z a $NAME .\target\release\mm2.exe .\target\release\*.dll
           mkdir $Env:BRANCH_NAME
           mv $NAME ./$Env:BRANCH_NAME/
@@ -266,7 +251,7 @@ jobs:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
         if: ${{ env.AVAILABLE != '' }}
         run: |
-          $NAME="kdf_$Env:COMMIT_HASH-win-x86-64.zip"
+          $NAME="kdf_$Env:KDF_BUILD_TAG-win-x86-64.zip"
           7z a $NAME .\target\release\kdf.exe .\target\release\*.dll
           mv $NAME ./$Env:BRANCH_NAME/
 
@@ -295,29 +280,26 @@ jobs:
         with:
           deps: ('protoc', 'python3', 'paramiko')
 
-      - name: Calculate commit hash for PR commit
+      - name: Calculate build tag (commit hash) for PR commit
         if: github.event_name == 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
 
-      - name: Calculate commit hash for merge commit
+      - name: Calculate build tag (commit hash) for merge commit
         if: github.event_name != 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
 
       - name: Build cache
         uses: ./.github/actions/build-cache
 
       - name: Build
-        run: |
-          rm -f ./MM_VERSION
-          echo $COMMIT_HASH > ./MM_VERSION
-          cargo rustc --target x86_64-apple-darwin --lib --release --package mm2_bin_lib --crate-type=staticlib
+        run: cargo rustc --target x86_64-apple-darwin --lib --release --package mm2_bin_lib --crate-type=staticlib
 
       - name: Compress mm2 build output
         env:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
         if: ${{ env.AVAILABLE != '' }}
         run: |
-          NAME="mm2_$COMMIT_HASH-mac-dylib-x86-64.zip"
+          NAME="mm2_$KDF_BUILD_TAG-mac-dylib-x86-64.zip"
           cp target/x86_64-apple-darwin/release/libkdflib.a target/x86_64-apple-darwin/release/libmm2.a
           zip $NAME target/x86_64-apple-darwin/release/libmm2.a -j
           mkdir $BRANCH_NAME
@@ -328,7 +310,7 @@ jobs:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
         if: ${{ env.AVAILABLE != '' }}
         run: |
-          NAME="kdf_$COMMIT_HASH-mac-dylib-x86-64.zip"
+          NAME="kdf_$KDF_BUILD_TAG-mac-dylib-x86-64.zip"
           mv target/x86_64-apple-darwin/release/libkdflib.a target/x86_64-apple-darwin/release/libkdf.a
           zip $NAME target/x86_64-apple-darwin/release/libkdf.a -j
           mv $NAME ./$BRANCH_NAME/
@@ -371,29 +353,26 @@ jobs:
         # TODO: Lock wasm-pack version
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
-      - name: Calculate commit hash for PR commit
+      - name: Calculate build tag (commit hash) for PR commit
         if: github.event_name == 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
 
-      - name: Calculate commit hash for merge commit
+      - name: Calculate build tag (commit hash) for merge commit
         if: github.event_name != 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
 
       - name: Build cache
         uses: ./.github/actions/build-cache
 
       - name: Build
-        run: |
-          rm -f ./MM_VERSION
-          echo $COMMIT_HASH > ./MM_VERSION
-          wasm-pack build --release mm2src/mm2_bin_lib --target web --out-dir ../../target/target-wasm-release
+        run: wasm-pack build --release mm2src/mm2_bin_lib --target web --out-dir ../../target/target-wasm-release
 
       - name: Compress build output
         env:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
         if: ${{ env.AVAILABLE != '' }}
         run: |
-          NAME="kdf_$COMMIT_HASH-wasm.zip"
+          NAME="kdf_$KDF_BUILD_TAG-wasm.zip"
           (cd ./target/target-wasm-release && zip -r - .) > $NAME
           mkdir $BRANCH_NAME
           mv $NAME ./$BRANCH_NAME/
@@ -423,29 +402,26 @@ jobs:
         with:
           deps: ('protoc', 'python3', 'paramiko')
 
-      - name: Calculate commit hash for PR commit
+      - name: Calculate build tag (commit hash) for PR commit
         if: github.event_name == 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
 
-      - name: Calculate commit hash for merge commit
+      - name: Calculate build tag (commit hash) for merge commit
         if: github.event_name != 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
 
       - name: Build cache
         uses: ./.github/actions/build-cache
 
       - name: Build
-        run: |
-          rm -f ./MM_VERSION
-          echo $COMMIT_HASH > ./MM_VERSION
-          cargo rustc --target aarch64-apple-ios --lib --release --package mm2_bin_lib --crate-type=staticlib
+        run: cargo rustc --target aarch64-apple-ios --lib --release --package mm2_bin_lib --crate-type=staticlib
 
       - name: Compress mm2 build output
         env:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
         if: ${{ env.AVAILABLE != '' }}
         run: |
-          NAME="mm2_$COMMIT_HASH-ios-aarch64.zip"
+          NAME="mm2_$KDF_BUILD_TAG-ios-aarch64.zip"
           cp target/aarch64-apple-ios/release/libkdflib.a target/aarch64-apple-ios/release/libmm2.a
           zip $NAME target/aarch64-apple-ios/release/libmm2.a -j
           mkdir $BRANCH_NAME
@@ -456,7 +432,7 @@ jobs:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
         if: ${{ env.AVAILABLE != '' }}
         run: |
-          NAME="kdf_$COMMIT_HASH-ios-aarch64.zip"
+          NAME="kdf_$KDF_BUILD_TAG-ios-aarch64.zip"
           mv target/aarch64-apple-ios/release/libkdflib.a target/aarch64-apple-ios/release/libkdf.a
           zip $NAME target/aarch64-apple-ios/release/libkdf.a -j
           mv $NAME ./$BRANCH_NAME/
@@ -498,22 +474,19 @@ jobs:
       - name: Setup NDK
         run: ./scripts/ci/android-ndk.sh x86 23
 
-      - name: Calculate commit hash for PR commit
+      - name: Calculate build tag (commit hash) for PR commit
         if: github.event_name == 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
 
-      - name: Calculate commit hash for merge commit
+      - name: Calculate build tag (commit hash) for merge commit
         if: github.event_name != 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
 
       - name: Build cache
         uses: ./.github/actions/build-cache
 
       - name: Build
         run: |
-          rm -f ./MM_VERSION
-          echo $COMMIT_HASH > ./MM_VERSION
-
           export PATH=$PATH:/android-ndk/bin
           CC_aarch64_linux_android=aarch64-linux-android21-clang CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=aarch64-linux-android21-clang cargo rustc --target=aarch64-linux-android --lib --release --crate-type=staticlib --package mm2_bin_lib
 
@@ -522,7 +495,7 @@ jobs:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
         if: ${{ env.AVAILABLE != '' }}
         run: |
-          NAME="mm2_$COMMIT_HASH-android-aarch64.zip"
+          NAME="mm2_$KDF_BUILD_TAG-android-aarch64.zip"
           cp target/aarch64-linux-android/release/libkdflib.a target/aarch64-linux-android/release/libmm2.a
           zip $NAME target/aarch64-linux-android/release/libmm2.a -j
           mkdir $BRANCH_NAME
@@ -533,7 +506,7 @@ jobs:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
         if: ${{ env.AVAILABLE != '' }}
         run: |
-          NAME="kdf_$COMMIT_HASH-android-aarch64.zip"
+          NAME="kdf_$KDF_BUILD_TAG-android-aarch64.zip"
           mv target/aarch64-linux-android/release/libkdflib.a target/aarch64-linux-android/release/libkdf.a
           zip $NAME target/aarch64-linux-android/release/libkdf.a -j
           mv $NAME ./$BRANCH_NAME/
@@ -575,22 +548,19 @@ jobs:
       - name: Setup NDK
         run: ./scripts/ci/android-ndk.sh x86 23
 
-      - name: Calculate commit hash for PR commit
+      - name: Calculate build tag (commit hash) for PR commit
         if: github.event_name == 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
 
-      - name: Calculate commit hash for merge commit
+      - name: Calculate build tag (commit hash) for merge commit
         if: github.event_name != 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
 
       - name: Build cache
         uses: ./.github/actions/build-cache
 
       - name: Build
         run: |
-          rm -f ./MM_VERSION
-          echo $COMMIT_HASH > ./MM_VERSION
-
           export PATH=$PATH:/android-ndk/bin
           CC_armv7_linux_androideabi=armv7a-linux-androideabi21-clang CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=armv7a-linux-androideabi21-clang cargo rustc --target=armv7-linux-androideabi --lib --release --crate-type=staticlib --package mm2_bin_lib
 
@@ -599,7 +569,7 @@ jobs:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
         if: ${{ env.AVAILABLE != '' }}
         run: |
-          NAME="mm2_$COMMIT_HASH-android-armv7.zip"
+          NAME="mm2_$KDF_BUILD_TAG-android-armv7.zip"
           cp target/armv7-linux-androideabi/release/libkdflib.a target/armv7-linux-androideabi/release/libmm2.a
           zip $NAME target/armv7-linux-androideabi/release/libmm2.a -j
           mkdir $BRANCH_NAME
@@ -610,7 +580,7 @@ jobs:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
         if: ${{ env.AVAILABLE != '' }}
         run: |
-          NAME="kdf_$COMMIT_HASH-android-armv7.zip"
+          NAME="kdf_$KDF_BUILD_TAG-android-armv7.zip"
           mv target/armv7-linux-androideabi/release/libkdflib.a target/armv7-linux-androideabi/release/libkdf.a
           zip $NAME target/armv7-linux-androideabi/release/libkdf.a -j
           mv $NAME ./$BRANCH_NAME/
@@ -640,13 +610,13 @@ jobs:
           echo "/usr/bin" >> $GITHUB_PATH
           echo "/root/.cargo/bin" >> $GITHUB_PATH
 
-      - name: Calculate commit hash for PR commit
+      - name: Calculate build tag (commit hash) for PR commit
         if: github.event_name == 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
 
-      - name: Calculate commit hash for merge commit
+      - name: Calculate build tag (commit hash) for merge commit
         if: github.event_name != 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
 
       - name: Activate SSH
         uses: webfactory/ssh-agent@v0.5.4
@@ -658,10 +628,10 @@ jobs:
           git clone git@github.com:KomodoPlatform/atomicdex-deployments.git
           if [ -d "atomicdex-deployments/atomicDEX-API" ]; then
             cd atomicdex-deployments/atomicDEX-API
-            sed -i "1s/^.*$/$COMMIT_HASH/" .commit
+            sed -i "1s/^.*$/$KDF_BUILD_TAG/" .commit
             git config --global user.email "linuxci@komodoplatform.com"
             git config --global user.name "linuxci"
             git add .commit
-            git commit -m "[atomicDEX-API] $COMMIT_HASH is committed for git & container registry"
+            git commit -m "[atomicDEX-API] $KDF_BUILD_TAG is committed for git & container registry"
             git push
           fi

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -10,7 +10,6 @@ concurrency:
 
 env:
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-  MANUAL_MM_VERSION: true
   JEMALLOC_SYS_WITH_MALLOC_CONF: "background_thread:true,narenas:1,tcache:false,dirty_decay_ms:0,muzzy_decay_ms:0,metadata_thp:auto"
 
 jobs:
@@ -38,33 +37,30 @@ jobs:
         with:
           deps: ('protoc')
 
-      - name: Calculate commit hash for PR commit
+      - name: Calculate build tag (commit hash) for PR commit
         if: github.event_name == 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
 
-      - name: Calculate commit hash for merge commit
+      - name: Calculate build tag (commit hash) for merge commit
         if: github.event_name != 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
 
       - name: Build cache
         uses: ./.github/actions/build-cache
 
       - name: Build
-        run: |
-          rm -f ./MM_VERSION
-          echo $COMMIT_HASH > ./MM_VERSION
-          cargo build --release
+        run: cargo build --release
 
       - name: Compress mm2 build output
         run: |
-          NAME="mm2_$COMMIT_HASH-linux-x86-64.zip"
+          NAME="mm2_$KDF_BUILD_TAG-linux-x86-64.zip"
           zip $NAME target/release/mm2 -j
           mkdir $BRANCH_NAME
           mv $NAME ./$BRANCH_NAME/
 
       - name: Compress kdf build output
         run: |
-          NAME="kdf_$COMMIT_HASH-linux-x86-64.zip"
+          NAME="kdf_$KDF_BUILD_TAG-linux-x86-64.zip"
           zip $NAME target/release/kdf -j
           mv $NAME ./$BRANCH_NAME/
 
@@ -102,33 +98,30 @@ jobs:
         with:
           deps: ('protoc', 'python3', 'paramiko')
 
-      - name: Calculate commit hash for PR commit
+      - name: Calculate build tag (commit hash) for PR commit
         if: github.event_name == 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
 
-      - name: Calculate commit hash for merge commit
+      - name: Calculate build tag (commit hash) for merge commit
         if: github.event_name != 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
 
       - name: Build cache
         uses: ./.github/actions/build-cache
 
       - name: Build
-        run: |
-          rm -f ./MM_VERSION
-          echo $COMMIT_HASH > ./MM_VERSION
-          cargo build --release --target x86_64-apple-darwin
+        run: cargo build --release --target x86_64-apple-darwin
 
       - name: Compress mm2 build output
         run: |
-          NAME="mm2_$COMMIT_HASH-mac-x86-64.zip"
+          NAME="mm2_$KDF_BUILD_TAG-mac-x86-64.zip"
           zip $NAME target/x86_64-apple-darwin/release/mm2 -j
           mkdir $BRANCH_NAME
           mv $NAME ./$BRANCH_NAME/
 
       - name: Compress kdf build output
         run: |
-          NAME="kdf_$COMMIT_HASH-mac-x86-64.zip"
+          NAME="kdf_$KDF_BUILD_TAG-mac-x86-64.zip"
           zip $NAME target/x86_64-apple-darwin/release/kdf -j
           mv $NAME ./$BRANCH_NAME/
 
@@ -157,33 +150,30 @@ jobs:
         with:
           deps: ('protoc', 'python3', 'paramiko')
 
-      - name: Calculate commit hash for PR commit
+      - name: Calculate build tag (commit hash) for PR commit
         if: github.event_name == 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
 
-      - name: Calculate commit hash for merge commit
+      - name: Calculate build tag (commit hash) for merge commit
         if: github.event_name != 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
 
       - name: Build cache
         uses: ./.github/actions/build-cache
 
       - name: Build
-        run: |
-          rm -f ./MM_VERSION
-          echo $COMMIT_HASH > ./MM_VERSION
-          cargo build --release --target aarch64-apple-darwin
+        run: cargo build --release --target aarch64-apple-darwin
 
       - name: Compress mm2 build output
         run: |
-          NAME="mm2_$COMMIT_HASH-mac-arm64.zip"
+          NAME="mm2_$KDF_BUILD_TAG-mac-arm64.zip"
           zip $NAME target/aarch64-apple-darwin/release/mm2 -j
           mkdir $BRANCH_NAME
           mv $NAME ./$BRANCH_NAME/
 
       - name: Compress kdf build output
         run: |
-          NAME="kdf_$COMMIT_HASH-mac-arm64.zip"
+          NAME="kdf_$KDF_BUILD_TAG-mac-arm64.zip"
           zip $NAME target/aarch64-apple-darwin/release/kdf -j
           mv $NAME ./$BRANCH_NAME/
 
@@ -211,35 +201,30 @@ jobs:
         with:
           deps: ('protoc', 'python3', 'paramiko')
 
-      - name: Calculate commit hash for PR commit
+      - name: Calculate build tag (commit hash) for PR commit
         if: github.event_name == 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $Env:GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $Env:GITHUB_ENV
 
-      - name: Calculate commit hash for merge commit
+      - name: Calculate build tag (commit hash) for merge commit
         if: github.event_name != 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 HEAD)" >> $Env:GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 HEAD)" >> $Env:GITHUB_ENV
 
       - name: Build cache
         uses: ./.github/actions/build-cache
 
       - name: Build
-        run: |
-          if (test-path "./MM_VERSION") {
-            remove-item "./MM_VERSION"
-          }
-          echo $Env:COMMIT_HASH > ./MM_VERSION
-          cargo build --release
+        run: cargo build --release
 
       - name: Compress mm2 build output
         run: |
-          $NAME="mm2_$Env:COMMIT_HASH-win-x86-64.zip"
+          $NAME="mm2_$Env:KDF_BUILD_TAG-win-x86-64.zip"
           7z a $NAME .\target\release\mm2.exe .\target\release\*.dll
           mkdir $Env:BRANCH_NAME
           mv $NAME ./$Env:BRANCH_NAME/
 
       - name: Compress kdf build output
         run: |
-          $NAME="kdf_$Env:COMMIT_HASH-win-x86-64.zip"
+          $NAME="kdf_$Env:KDF_BUILD_TAG-win-x86-64.zip"
           7z a $NAME .\target\release\kdf.exe .\target\release\*.dll
           mv $NAME ./$Env:BRANCH_NAME/
 
@@ -267,26 +252,23 @@ jobs:
         with:
           deps: ('protoc', 'python3', 'paramiko')
 
-      - name: Calculate commit hash for PR commit
+      - name: Calculate build tag (commit hash) for PR commit
         if: github.event_name == 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
 
-      - name: Calculate commit hash for merge commit
+      - name: Calculate build tag (commit hash) for merge commit
         if: github.event_name != 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
 
       - name: Build cache
         uses: ./.github/actions/build-cache
 
       - name: Build
-        run: |
-          rm -f ./MM_VERSION
-          echo $COMMIT_HASH > ./MM_VERSION
-          cargo rustc --target x86_64-apple-darwin --lib --release --package mm2_bin_lib --crate-type=staticlib
+        run: cargo rustc --target x86_64-apple-darwin --lib --release --package mm2_bin_lib --crate-type=staticlib
 
       - name: Compress mm2 build output
         run: |
-          NAME="mm2_$COMMIT_HASH-mac-dylib-x86-64.zip"
+          NAME="mm2_$KDF_BUILD_TAG-mac-dylib-x86-64.zip"
           cp target/x86_64-apple-darwin/release/libkdflib.a target/x86_64-apple-darwin/release/libmm2.a
           zip $NAME target/x86_64-apple-darwin/release/libmm2.a -j
           mkdir $BRANCH_NAME
@@ -294,7 +276,7 @@ jobs:
 
       - name: Compress kdf build output
         run: |
-          NAME="kdf_$COMMIT_HASH-mac-dylib-x86-64.zip"
+          NAME="kdf_$KDF_BUILD_TAG-mac-dylib-x86-64.zip"
           mv target/x86_64-apple-darwin/release/libkdflib.a target/x86_64-apple-darwin/release/libkdf.a
           zip $NAME target/x86_64-apple-darwin/release/libkdf.a -j
           mv $NAME ./$BRANCH_NAME/
@@ -337,26 +319,23 @@ jobs:
         # TODO: Lock wasm-pack version
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
-      - name: Calculate commit hash for PR commit
+      - name: Calculate build tag (commit hash) for PR commit
         if: github.event_name == 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
 
-      - name: Calculate commit hash for merge commit
+      - name: Calculate build tag (commit hash) for merge commit
         if: github.event_name != 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
 
       - name: Build cache
         uses: ./.github/actions/build-cache
 
       - name: Build
-        run: |
-          rm -f ./MM_VERSION
-          echo $COMMIT_HASH > ./MM_VERSION
-          wasm-pack build --release mm2src/mm2_bin_lib --target web --out-dir ../../target/target-wasm-release
+        run: wasm-pack build --release mm2src/mm2_bin_lib --target web --out-dir ../../target/target-wasm-release
 
       - name: Compress build output
         run: |
-          NAME="kdf_$COMMIT_HASH-wasm.zip"
+          NAME="kdf_$KDF_BUILD_TAG-wasm.zip"
           (cd ./target/target-wasm-release && zip -r - .) > $NAME
           mkdir $BRANCH_NAME
           mv $NAME ./$BRANCH_NAME/
@@ -386,26 +365,23 @@ jobs:
         with:
           deps: ('protoc', 'python3', 'paramiko')
 
-      - name: Calculate commit hash for PR commit
+      - name: Calculate build tag (commit hash) for PR commit
         if: github.event_name == 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
 
-      - name: Calculate commit hash for merge commit
+      - name: Calculate build tag (commit hash) for merge commit
         if: github.event_name != 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
 
       - name: Build cache
         uses: ./.github/actions/build-cache
 
       - name: Build
-        run: |
-          rm -f ./MM_VERSION
-          echo $COMMIT_HASH > ./MM_VERSION
-          cargo rustc --target aarch64-apple-ios --lib --release --package mm2_bin_lib --crate-type=staticlib
+        run: cargo rustc --target aarch64-apple-ios --lib --release --package mm2_bin_lib --crate-type=staticlib
 
       - name: Compress mm2 build output
         run: |
-          NAME="mm2_$COMMIT_HASH-ios-aarch64.zip"
+          NAME="mm2_$KDF_BUILD_TAG-ios-aarch64.zip"
           mv target/aarch64-apple-ios/release/libkdflib.a target/aarch64-apple-ios/release/libmm2.a
           zip $NAME target/aarch64-apple-ios/release/libmm2.a -j
           mkdir $BRANCH_NAME
@@ -413,7 +389,7 @@ jobs:
 
       - name: Compress kdf build output
         run: |
-          NAME="kdf_$COMMIT_HASH-ios-aarch64.zip"
+          NAME="kdf_$KDF_BUILD_TAG-ios-aarch64.zip"
           mv target/aarch64-apple-ios/release/libkdflib.a target/aarch64-apple-ios/release/libkdf.a
           zip $NAME target/aarch64-apple-ios/release/libkdf.a -j
           mv $NAME ./$BRANCH_NAME/
@@ -455,28 +431,25 @@ jobs:
       - name: Setup NDK
         run: ./scripts/ci/android-ndk.sh x86 23
 
-      - name: Calculate commit hash for PR commit
+      - name: Calculate build tag (commit hash) for PR commit
         if: github.event_name == 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
 
-      - name: Calculate commit hash for merge commit
+      - name: Calculate build tag (commit hash) for merge commit
         if: github.event_name != 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
 
       - name: Build cache
         uses: ./.github/actions/build-cache
 
       - name: Build
         run: |
-          rm -f ./MM_VERSION
-          echo $COMMIT_HASH > ./MM_VERSION
-
           export PATH=$PATH:/android-ndk/bin
           CC_aarch64_linux_android=aarch64-linux-android21-clang CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=aarch64-linux-android21-clang cargo rustc --target=aarch64-linux-android --lib --release --crate-type=staticlib --package mm2_bin_lib
 
       - name: Compress mm2 build output
         run: |
-          NAME="mm2_$COMMIT_HASH-android-aarch64.zip"
+          NAME="mm2_$KDF_BUILD_TAG-android-aarch64.zip"
           mv target/aarch64-linux-android/release/libkdflib.a target/aarch64-linux-android/release/libmm2.a
           zip $NAME target/aarch64-linux-android/release/libmm2.a -j
           mkdir $BRANCH_NAME
@@ -484,7 +457,7 @@ jobs:
 
       - name: Compress kdf build output
         run: |
-          NAME="kdf_$COMMIT_HASH-android-aarch64.zip"
+          NAME="kdf_$KDF_BUILD_TAG-android-aarch64.zip"
           mv target/aarch64-linux-android/release/libkdflib.a target/aarch64-linux-android/release/libkdf.a
           zip $NAME target/aarch64-linux-android/release/libkdf.a  -j
           mv $NAME ./$BRANCH_NAME/
@@ -526,28 +499,25 @@ jobs:
       - name: Setup NDK
         run: ./scripts/ci/android-ndk.sh x86 23
 
-      - name: Calculate commit hash for PR commit
+      - name: Calculate build tag (commit hash) for PR commit
         if: github.event_name == 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})" >> $GITHUB_ENV
 
-      - name: Calculate commit hash for merge commit
+      - name: Calculate build tag (commit hash) for merge commit
         if: github.event_name != 'pull_request'
-        run: echo "COMMIT_HASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
+        run: echo "KDF_BUILD_TAG=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
 
       - name: Build cache
         uses: ./.github/actions/build-cache
 
       - name: Build
         run: |
-          rm -f ./MM_VERSION
-          echo $COMMIT_HASH > ./MM_VERSION
-
           export PATH=$PATH:/android-ndk/bin
           CC_armv7_linux_androideabi=armv7a-linux-androideabi21-clang CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=armv7a-linux-androideabi21-clang cargo rustc --target=armv7-linux-androideabi --lib --release --crate-type=staticlib --package mm2_bin_lib
 
       - name: Compress mm2 build output
         run: |
-          NAME="mm2_$COMMIT_HASH-android-armv7.zip"
+          NAME="mm2_$KDF_BUILD_TAG-android-armv7.zip"
           mv target/armv7-linux-androideabi/release/libkdflib.a target/armv7-linux-androideabi/release/libmm2.a
           zip $NAME target/armv7-linux-androideabi/release/libmm2.a -j
           mkdir $BRANCH_NAME
@@ -555,7 +525,7 @@ jobs:
 
       - name: Compress kdf build output
         run: |
-          NAME="kdf_$COMMIT_HASH-android-armv7.zip"
+          NAME="kdf_$KDF_BUILD_TAG-android-armv7.zip"
           mv target/armv7-linux-androideabi/release/libkdflib.a target/armv7-linux-androideabi/release/libkdf.a
           zip $NAME target/armv7-linux-androideabi/release/libkdf.a   -j
           mv $NAME ./$BRANCH_NAME/

--- a/.gitignore
+++ b/.gitignore
@@ -37,10 +37,6 @@ scripts/mm2/seed/unparsed.txt
 /js/.kdf.*
 
 # Rust artefacts
-/MM_DATETIME
-/MM_DATETIME.tmp
-/MM_VERSION
-/MM_VERSION.tmp
 /target
 /targettest
 /clippytarget

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -6,20 +6,14 @@ We need a Unix operating system (the build has been tested on Linux and Mac).
 
 We need a free access to the Docker (`docker run hello-world` should work).
 
-We need the Nightly revision of Rust, such as
-
-    rustup default nightly-2021-05-17
-
 ### Install cross
 
     cargo install cross
 
 ### Get the source code
 
-    git clone --depth=1 git@gitlab.com:KomodoPlatform/supernet.git -b mm2.1-cross
-    cd supernet
-    git log --pretty=format:'%h' -n 1 > MM_VERSION
-    git log --pretty=format:'%cI' -n 1 > MM_DATETIME
+    git clone --depth=1 https://github.com/KomodoPlatform/komodo-defi-framework
+    cd komodo-defi-framework
 
 ### Install extra packages into the Docker image
 
@@ -27,19 +21,19 @@ The [Android NDK installer](https://github.com/rust-embedded/cross/tree/master/d
 
 #### armeabi-v7a ABI Docker image
 
-    (cd supernet && docker build --tag armv7-linux-androideabi-aga -f .docker/Dockerfile.armv7-linux-androideabi .)
+    (cd komodo-defi-framework && docker build --tag armv7-linux-androideabi-aga -f .docker/Dockerfile.armv7-linux-androideabi .)
 
 #### arm64-v8a ABI Docker image
 
-    (cd supernet && docker build --tag aarch64-linux-android-aga -f .docker/Dockerfile.aarch64-linux-android .)
+    (cd komodo-defi-framework && docker build --tag aarch64-linux-android-aga -f .docker/Dockerfile.aarch64-linux-android .)
 
 ### x86 ABI Docker image
 
-    (cd supernet && docker build --tag i686-linux-android-aga -f .docker/Dockerfile.i686-linux-android .)
+    (cd komodo-defi-framework && docker build --tag i686-linux-android-aga -f .docker/Dockerfile.i686-linux-android .)
 
 ### x86_64 ABI Docker image
 
-    (cd supernet && docker build --tag x86_64-linux-android-aga -f .docker/Dockerfile.x86_64-linux-android .)
+    (cd komodo-defi-framework && docker build --tag x86_64-linux-android-aga -f .docker/Dockerfile.x86_64-linux-android .)
 
 ### Setup the NDK_HOME variable
 

--- a/mm2src/mm2_bin_lib/build.rs
+++ b/mm2src/mm2_bin_lib/build.rs
@@ -1,114 +1,48 @@
-use chrono::DateTime;
-use gstuff::slurp;
+use chrono::Utc;
 use regex::Regex;
-use std::fs;
-use std::io::Write;
-use std::path::{Path, PathBuf};
-use std::process::Command;
-use std::str::from_utf8;
+use std::{env, process::Command};
 
-fn path2s(path: PathBuf) -> String {
-    path.to_str()
-        .unwrap_or_else(|| panic!("Non-stringy path {:?}", path))
-        .into()
+fn crate_version() -> &'static str { env!("CARGO_PKG_VERSION") }
+
+fn version_tag() -> Result<String, String> {
+    if let Ok(tag) = env::var("KDF_BUILD_TAG") {
+        return Ok(tag);
+    }
+
+    let output = Command::new("git")
+        .args(&["log", "--pretty=format:%h", "-n1"])
+        .output()
+        .map_err(|e| format!("Failed to run git command: {e}\nSet `KDF_BUILD_TAG` manually instead.",))?;
+
+    let commit_hash = String::from_utf8(output.stdout)
+        .map_err(|e| format!("Invalid UTF-8 sequence: {e}"))?
+        .trim()
+        .to_string();
+
+    if !Regex::new(r"^\w+$")
+        .expect("Failed to compile regex")
+        .is_match(&commit_hash)
+    {
+        return Err(format!("Invalid tag: {commit_hash}"));
+    }
+
+    Ok(commit_hash)
 }
 
-/// AtomicDEX's root.
-fn root() -> PathBuf {
-    let super_net = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let super_net = match super_net.canonicalize() {
-        Ok(p) => p,
-        Err(err) => panic!("Can't canonicalize {:?}: {}", super_net, err),
-    };
-    // On Windows we're getting these "\\?\" paths from canonicalize but they aren't any good for CMake.
-    if cfg!(windows) {
-        let s = path2s(super_net);
-        let stripped = match s.strip_prefix(r"\\?\") {
-            Some(stripped) => stripped,
-            None => &s,
-        };
-        Path::new(stripped).into()
-    } else {
-        super_net
-    }
-}
+fn version() -> Result<String, String> { version_tag().map(|tag| format!("{}_{}", crate_version(), tag)) }
 
-/// This function ensures that we have the “MM_VERSION” and “MM_DATETIME” variables during the build.
-///
-/// The build script will usually help us by putting the MarketMaker version into the “MM_VERSION” file
-/// and the corresponding ISO 8601 time into the “MM_DATETIME” file
-///
-/// For the nightly builds the version contains the short commit hash.
-///
-/// We're also trying to get the hash and the time from Git.
-///
-/// Git information isn't always available during the build (for instance, when a build server is used,
-/// we might skip synchronizing the Git repository there),
-/// but if it is, then we're going to check if the “MM_DATETIME” and the Git data match.
-fn mm_version() -> String {
-    // Reading version of `mm2_bin_lib` from cargo manifest
-    let mut version = env!("CARGO_PKG_VERSION").to_owned();
+fn build_datetime() -> String { Utc::now().to_rfc3339() }
 
-    let mm_version_p = root().join("../../MM_VERSION");
-    let v_file = String::from_utf8(slurp(&mm_version_p)).unwrap();
-
-    // if there is MM_VERSION file, that means CI wants to put a tag to version
-    if !v_file.is_empty() {
-        version = format!("{}_{}", version, v_file.trim());
-    }
-    // put commit tag to the version
-    else {
-        let mut command = Command::new("git");
-        command.arg("log").arg("--pretty=format:%h").arg("-n1");
-        if let Ok(go) = command.output() {
-            if go.status.success() {
-                let commit_hash = from_utf8(&go.stdout).unwrap().trim().to_string();
-                if !Regex::new(r"^\w+$").unwrap().is_match(&commit_hash) {
-                    panic!("{}", commit_hash)
-                }
-
-                version = format!("{version}_{commit_hash}");
-            }
-        }
-    }
-
-    println!("cargo:rustc-env=MM_VERSION={}", version);
-
-    let mut dt_git = None;
-    let mut command = Command::new("git");
-    command.arg("log").arg("--pretty=format:%cI").arg("-n1"); // ISO 8601
-    if let Ok(go) = command.output() {
-        if go.status.success() {
-            let got = from_utf8(&go.stdout).unwrap().trim();
-            let _dt_check = DateTime::parse_from_rfc3339(got).unwrap();
-            dt_git = Some(got.to_string());
-        }
-    }
-
-    let mm_datetime_p = root().join("../../MM_DATETIME");
-    let dt_file = String::from_utf8(slurp(&mm_datetime_p)).unwrap();
-    let mut dt_file = dt_file.trim().to_string();
-    if let Some(ref dt_git) = dt_git {
-        if dt_git[..] != dt_file[..] {
-            // Create or update the “MM_DATETIME” file in order to appease the Cargo dependency management.
-            let mut mm_datetime_f = fs::File::create(&mm_datetime_p).unwrap();
-            mm_datetime_f.write_all(dt_git.as_bytes()).unwrap();
-            dt_file = dt_git.to_string();
-        }
-    }
-
-    println!("cargo:rustc-env=MM_DATETIME={}", dt_file);
-
-    version
+fn set_build_variables() -> Result<(), String> {
+    println!("cargo:rustc-env=KDF_VERSION={}", version()?);
+    println!("cargo:rustc-env=KDF_DATETIME={}", build_datetime());
+    Ok(())
 }
 
 fn main() {
-    println!("cargo:rerun-if-env-changed=MANUAL_MM_VERSION");
-    println!("cargo:rerun-if-changed=../../MM_VERSION");
-    println!("cargo:rerun-if-changed=../../MM_DATETIME");
-    if std::env::var("MANUAL_MM_VERSION").is_err() {
-        // This allows build script to run even if no source code files change as rerun-if-changed checks for a file that doesn't exist
-        println!("cargo:rerun-if-changed=NON_EXISTING_FILE");
-    }
-    mm_version();
+    println!("cargo:rerun-if-env-changed=CARGO_PKG_VERSION");
+    println!("cargo:rerun-if-env-changed=KDF_BUILD_TAG");
+
+    set_build_variables().expect("Failed to set build variables");
 }
+

--- a/mm2src/mm2_bin_lib/build.rs
+++ b/mm2src/mm2_bin_lib/build.rs
@@ -42,6 +42,7 @@ fn set_build_variables() -> Result<(), String> {
 fn main() {
     println!("cargo:rerun-if-env-changed=CARGO_PKG_VERSION");
     println!("cargo:rerun-if-env-changed=KDF_BUILD_TAG");
+    println!("cargo::rerun-if-changed=.git/HEAD");
 
     set_build_variables().expect("Failed to set build variables");
 }

--- a/mm2src/mm2_bin_lib/build.rs
+++ b/mm2src/mm2_bin_lib/build.rs
@@ -10,7 +10,7 @@ fn version_tag() -> Result<String, String> {
     }
 
     let output = Command::new("git")
-        .args(&["log", "--pretty=format:%h", "-n1"])
+        .args(["log", "--pretty=format:%h", "-n1"])
         .output()
         .map_err(|e| format!("Failed to run git command: {e}\nSet `KDF_BUILD_TAG` manually instead.",))?;
 
@@ -45,4 +45,3 @@ fn main() {
 
     set_build_variables().expect("Failed to set build variables");
 }
-

--- a/mm2src/mm2_bin_lib/src/lib.rs
+++ b/mm2src/mm2_bin_lib/src/lib.rs
@@ -7,8 +7,8 @@ use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 #[cfg(not(target_arch = "wasm32"))] mod mm2_native_lib;
 #[cfg(target_arch = "wasm32")] mod mm2_wasm_lib;
 
-const MM_VERSION: &str = env!("KDF_VERSION");
-const MM_DATETIME: &str = env!("KDF_DATETIME");
+const KDF_VERSION: &str = env!("KDF_VERSION");
+const KDF_DATETIME: &str = env!("KDF_DATETIME");
 
 static LP_MAIN_RUNNING: AtomicBool = AtomicBool::new(false);
 static CTX: AtomicU32 = AtomicU32::new(0);

--- a/mm2src/mm2_bin_lib/src/lib.rs
+++ b/mm2src/mm2_bin_lib/src/lib.rs
@@ -7,8 +7,8 @@ use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 #[cfg(not(target_arch = "wasm32"))] mod mm2_native_lib;
 #[cfg(target_arch = "wasm32")] mod mm2_wasm_lib;
 
-const MM_VERSION: &str = env!("MM_VERSION");
-const MM_DATETIME: &str = env!("MM_DATETIME");
+const MM_VERSION: &str = env!("KDF_VERSION");
+const MM_DATETIME: &str = env!("KDF_DATETIME");
 
 static LP_MAIN_RUNNING: AtomicBool = AtomicBool::new(false);
 static CTX: AtomicU32 = AtomicU32::new(0);

--- a/mm2src/mm2_bin_lib/src/mm2_bin.rs
+++ b/mm2src/mm2_bin_lib/src/mm2_bin.rs
@@ -1,10 +1,10 @@
 #[cfg(not(target_arch = "wasm32"))] use mm2_main::mm2_main;
 
 #[cfg(not(target_arch = "wasm32"))]
-const MM_VERSION: &str = env!("MM_VERSION");
+const MM_VERSION: &str = env!("KDF_VERSION");
 
 #[cfg(not(target_arch = "wasm32"))]
-const MM_DATETIME: &str = env!("MM_DATETIME");
+const MM_DATETIME: &str = env!("KDF_DATETIME");
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64", target_env = "gnu"))]
 #[global_allocator]

--- a/mm2src/mm2_bin_lib/src/mm2_bin.rs
+++ b/mm2src/mm2_bin_lib/src/mm2_bin.rs
@@ -1,10 +1,10 @@
 #[cfg(not(target_arch = "wasm32"))] use mm2_main::mm2_main;
 
 #[cfg(not(target_arch = "wasm32"))]
-const MM_VERSION: &str = env!("KDF_VERSION");
+const KDF_VERSION: &str = env!("KDF_VERSION");
 
 #[cfg(not(target_arch = "wasm32"))]
-const MM_DATETIME: &str = env!("KDF_DATETIME");
+const KDF_DATETIME: &str = env!("KDF_DATETIME");
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64", target_env = "gnu"))]
 #[global_allocator]
@@ -13,6 +13,6 @@ static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 fn main() {
     #[cfg(not(target_arch = "wasm32"))]
     {
-        mm2_main(MM_VERSION.into(), MM_DATETIME.into())
+        mm2_main(KDF_VERSION.into(), KDF_DATETIME.into())
     }
 }

--- a/mm2src/mm2_bin_lib/src/mm2_native_lib.rs
+++ b/mm2src/mm2_bin_lib/src/mm2_native_lib.rs
@@ -70,7 +70,8 @@ pub unsafe extern "C" fn mm2_main(conf: *const c_char, log_cb: extern "C" fn(lin
             return;
         }
         let ctx_cb = &|ctx| CTX.store(ctx, Ordering::Relaxed);
-        match catch_unwind(move || mm2_main::run_lp_main(Some(&conf), ctx_cb, KDF_VERSION.into(), KDF_DATETIME.into())) {
+        match catch_unwind(move || mm2_main::run_lp_main(Some(&conf), ctx_cb, KDF_VERSION.into(), KDF_DATETIME.into()))
+        {
             Ok(Ok(_)) => log!("run_lp_main finished"),
             Ok(Err(err)) => log!("run_lp_main error: {}", err),
             Err(err) => log!("run_lp_main panic: {:?}", any_to_str(&*err)),

--- a/mm2src/mm2_bin_lib/src/mm2_native_lib.rs
+++ b/mm2src/mm2_bin_lib/src/mm2_native_lib.rs
@@ -70,7 +70,7 @@ pub unsafe extern "C" fn mm2_main(conf: *const c_char, log_cb: extern "C" fn(lin
             return;
         }
         let ctx_cb = &|ctx| CTX.store(ctx, Ordering::Relaxed);
-        match catch_unwind(move || mm2_main::run_lp_main(Some(&conf), ctx_cb, MM_VERSION.into(), MM_DATETIME.into())) {
+        match catch_unwind(move || mm2_main::run_lp_main(Some(&conf), ctx_cb, KDF_VERSION.into(), KDF_DATETIME.into())) {
             Ok(Ok(_)) => log!("run_lp_main finished"),
             Ok(Err(err)) => log!("run_lp_main error: {}", err),
             Err(err) => log!("run_lp_main panic: {:?}", any_to_str(&*err)),

--- a/mm2src/mm2_bin_lib/src/mm2_wasm_lib.rs
+++ b/mm2src/mm2_bin_lib/src/mm2_wasm_lib.rs
@@ -115,7 +115,7 @@ pub fn mm2_main(params: JsValue, log_cb: js_sys::Function) -> Result<(), JsValue
         //     Ok(Err(err)) => console_err!("run_lp_main error: {}", err),
         //     Err(err) => console_err!("run_lp_main panic: {:?}", any_to_str(&*err)),
         // };
-        match mm2_main::lp_main(params, &ctx_cb, MM_VERSION.into(), MM_DATETIME.into()).await {
+        match mm2_main::lp_main(params, &ctx_cb, KDF_VERSION.into(), KDF_DATETIME.into()).await {
             Ok(()) => console_info!("run_lp_main finished"),
             Err(err) => console_err!("run_lp_main error: {}", err),
         };
@@ -242,8 +242,8 @@ pub async fn mm2_rpc(payload: JsValue) -> Result<JsValue, JsValue> {
 #[wasm_bindgen]
 pub fn mm2_version() -> JsValue {
     serialize_to_js(&MmVersionResponse {
-        result: MM_VERSION.into(),
-        datetime: MM_DATETIME.into(),
+        result: KDF_VERSION.into(),
+        datetime: KDF_DATETIME.into(),
     })
     .expect("expected serialization to succeed")
 }


### PR DESCRIPTION
Previous build script were highly unstable and relied on the `MM_DATETIME` and `MM_VERSION` files which was very annoying. These files caused cargo to invalidate the build cache, so even if you ran `cargo build` multiple times without changing anything, it would still rebuild because the build script triggered cache invalidation.

This PR makes the build script straightforward and more stable without causing cache invalidation. The final versioning output remains as is, but the implementation side is robust than ever. 

Major effects:

- No more cache invalidations.
- The `MM_VERSION` and `MM_DATETIME` files are no longer needed in the project root.
- Datetime handling is now more stable. Previously `MM_DATETIME` file could become outdated as it wasn't consistently updated.