### PR TITLE
feat(tendermint): staking/delegation

### DIFF
--- a/mm2src/coins/hd_wallet/withdraw_ops.rs
+++ b/mm2src/coins/hd_wallet/withdraw_ops.rs
@@ -10,7 +10,7 @@ type HDCoinPubKey<T> =
     <<<<T as HDWalletCoinOps>::HDWallet as HDWalletOps>::HDAccount as HDAccountOps>::HDAddress as HDAddressOps>::Pubkey;
 
 /// Represents the source of the funds for a withdrawal operation.
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum WithdrawFrom {
     /// The address id of the sender address which is specified by the account id, chain, and address id.

--- a/mm2src/coins/rpc_command/tendermint/staking.rs
+++ b/mm2src/coins/rpc_command/tendermint/staking.rs
@@ -152,13 +152,12 @@ pub async fn validators_rpc(
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct DelegatePayload {
-    pub coin: String,
     pub validator_address: String,
-    #[serde(default)]
-    pub amount: BigDecimal,
-    pub withdraw_from: Option<WithdrawFrom>,
-    #[serde(default)]
-    pub max: bool,
     pub fee: Option<WithdrawFee>,
     pub memo: Option<String>,
+    pub withdraw_from: Option<WithdrawFrom>,
+    #[serde(default)]
+    pub amount: BigDecimal,
+    #[serde(default)]
+    pub max: bool,
 }

--- a/mm2src/coins/rpc_command/tendermint/staking.rs
+++ b/mm2src/coins/rpc_command/tendermint/staking.rs
@@ -4,8 +4,7 @@ use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::prelude::MmError;
 use mm2_number::BigDecimal;
 
-use crate::{hd_wallet::WithdrawFrom, lp_coinfind_or_err, tendermint::TendermintCoinRpcError, MmCoinEnum,
-            TransactionDetails, WithdrawFee};
+use crate::{hd_wallet::WithdrawFrom, lp_coinfind_or_err, tendermint::TendermintCoinRpcError, MmCoinEnum, WithdrawFee};
 
 /// Represents current status of the validator.
 #[derive(Default, Deserialize)]
@@ -151,8 +150,8 @@ pub async fn validators_rpc(
     })
 }
 
-#[derive(Clone, Deserialize)]
-pub struct DelegationRPC {
+#[derive(Clone, Debug, Deserialize)]
+pub struct DelegatePayload {
     pub coin: String,
     pub validator_address: String,
     #[serde(default)]
@@ -162,66 +161,4 @@ pub struct DelegationRPC {
     pub max: bool,
     pub fee: Option<WithdrawFee>,
     pub memo: Option<String>,
-}
-
-#[derive(Clone, Debug, Display, Serialize, SerializeErrorType, PartialEq)]
-#[serde(tag = "error_type", content = "error_data")]
-pub enum DelegationRPCError {
-    #[display(fmt = "Coin '{ticker}' could not be found in coins configuration.")]
-    CoinNotFound { ticker: String },
-    #[display(fmt = "'{ticker}' is not a native staking token.")]
-    UnexpectedCoinType { ticker: String },
-    #[display(fmt = "Invalid validator address '{}'", address)]
-    InvalidValidatorAddress { address: String },
-    #[display(
-        fmt = "Not enough {} to withdraw: available {}, required at least {}",
-        coin,
-        available,
-        required
-    )]
-    NotSufficientBalance {
-        coin: String,
-        available: BigDecimal,
-        required: BigDecimal,
-    },
-    #[display(fmt = "Transport error: {}", _0)]
-    Transport(String),
-    #[display(fmt = "Internal error: {}", _0)]
-    InternalError(String),
-}
-
-impl HttpStatusCode for DelegationRPCError {
-    fn status_code(&self) -> common::StatusCode {
-        match self {
-            DelegationRPCError::CoinNotFound { .. } => StatusCode::NOT_FOUND,
-            DelegationRPCError::UnexpectedCoinType { .. }
-            | DelegationRPCError::InvalidValidatorAddress { .. }
-            | DelegationRPCError::NotSufficientBalance { .. } => StatusCode::BAD_REQUEST,
-            DelegationRPCError::Transport(_) => StatusCode::SERVICE_UNAVAILABLE,
-            DelegationRPCError::InternalError(_) => StatusCode::INTERNAL_SERVER_ERROR,
-        }
-    }
-}
-
-impl From<TendermintCoinRpcError> for DelegationRPCError {
-    fn from(e: TendermintCoinRpcError) -> Self {
-        match e {
-            TendermintCoinRpcError::InvalidResponse(e)
-            | TendermintCoinRpcError::PerformError(e)
-            | TendermintCoinRpcError::RpcClientError(e) => DelegationRPCError::Transport(e),
-            TendermintCoinRpcError::Prost(e) | TendermintCoinRpcError::InternalError(e) => DelegationRPCError::InternalError(e),
-            TendermintCoinRpcError::UnexpectedAccountType { .. } => DelegationRPCError::InternalError(
-                "RPC client got an unexpected error 'TendermintCoinRpcError::UnexpectedAccountType', this isn't normal."
-                    .into(),
-            ),
-        }
-    }
-}
-
-pub async fn delegation_rpc(ctx: MmArc, req: DelegationRPC) -> Result<TransactionDetails, MmError<DelegationRPCError>> {
-    match lp_coinfind_or_err(&ctx, &req.coin).await {
-        Ok(MmCoinEnum::Tendermint(coin)) => coin.delegate(req).await,
-        Ok(_) => MmError::err(DelegationRPCError::UnexpectedCoinType { ticker: req.coin }),
-        Err(_) => MmError::err(DelegationRPCError::CoinNotFound { ticker: req.coin }),
-    }
 }

--- a/mm2src/coins/rpc_command/tendermint/staking.rs
+++ b/mm2src/coins/rpc_command/tendermint/staking.rs
@@ -154,8 +154,9 @@ pub async fn validators_rpc(
 pub struct DelegatePayload {
     pub validator_address: String,
     pub fee: Option<WithdrawFee>,
-    pub memo: Option<String>,
     pub withdraw_from: Option<WithdrawFrom>,
+    #[serde(default)]
+    pub memo: String,
     #[serde(default)]
     pub amount: BigDecimal,
     #[serde(default)]

--- a/mm2src/coins/tendermint/tendermint_token.rs
+++ b/mm2src/coins/tendermint/tendermint_token.rs
@@ -511,7 +511,9 @@ impl MmCoin for TendermintToken {
 
             let is_ibc_transfer = to_address.prefix() != platform.account_prefix || req.ibc_source_channel.is_some();
 
-            let (account_id, maybe_pk) = platform.account_id_and_pk_for_withdraw(req.from)?;
+            let (account_id, maybe_pk) = platform
+                .account_id_and_pk_for_withdraw(req.from)
+                .map_err(WithdrawError::InternalError)?;
 
             let (base_denom_balance, base_denom_balance_dec) = platform
                 .get_balance_as_unsigned_and_decimal(&account_id, &platform.denom, token.decimals())

--- a/mm2src/coins/tendermint/tendermint_token.rs
+++ b/mm2src/coins/tendermint/tendermint_token.rs
@@ -513,7 +513,7 @@ impl MmCoin for TendermintToken {
 
             let (account_id, maybe_priv_key) = platform
                 .extract_account_id_and_private_key(req.from)
-                .map_err(WithdrawError::InternalError)?;
+                .map_err(|e| WithdrawError::InternalError(e.to_string()))?;
 
             let (base_denom_balance, base_denom_balance_dec) = platform
                 .get_balance_as_unsigned_and_decimal(&account_id, &platform.denom, token.decimals())

--- a/mm2src/coins/tendermint/tendermint_token.rs
+++ b/mm2src/coins/tendermint/tendermint_token.rs
@@ -597,7 +597,7 @@ impl MmCoin for TendermintToken {
                     maybe_priv_key,
                     msg_payload.clone(),
                     timeout_height,
-                    memo.clone(),
+                    &memo,
                     req.fee,
                 )
                 .await?;
@@ -622,14 +622,7 @@ impl MmCoin for TendermintToken {
             let account_info = platform.account_info(&account_id).await?;
 
             let tx = platform
-                .any_to_transaction_data(
-                    maybe_priv_key,
-                    msg_payload,
-                    &account_info,
-                    fee,
-                    timeout_height,
-                    memo.clone(),
-                )
+                .any_to_transaction_data(maybe_priv_key, msg_payload, &account_info, fee, timeout_height, &memo)
                 .map_to_mm(|e| WithdrawError::InternalError(e.to_string()))?;
 
             let internal_id = {

--- a/mm2src/coins/tendermint/tendermint_tx_history_v2.rs
+++ b/mm2src/coins/tendermint/tendermint_tx_history_v2.rs
@@ -37,6 +37,7 @@ const CLAIM_HTLC_EVENT: &str = "claim_htlc";
 const IBC_SEND_EVENT: &str = "ibc_transfer";
 const IBC_RECEIVE_EVENT: &str = "fungible_token_packet";
 const IBC_NFT_RECEIVE_EVENT: &str = "non_fungible_token_packet";
+const DELEGATE_EVENT: &str = "delegate";
 
 const ACCEPTED_EVENTS: &[&str] = &[
     TRANSFER_EVENT,
@@ -45,6 +46,7 @@ const ACCEPTED_EVENTS: &[&str] = &[
     IBC_SEND_EVENT,
     IBC_RECEIVE_EVENT,
     IBC_NFT_RECEIVE_EVENT,
+    DELEGATE_EVENT,
 ];
 
 const RECEIVER_TAG_KEY: &str = "receiver";
@@ -55,6 +57,12 @@ const RECIPIENT_TAG_KEY_BASE64: &str = "cmVjaXBpZW50";
 
 const SENDER_TAG_KEY: &str = "sender";
 const SENDER_TAG_KEY_BASE64: &str = "c2VuZGVy";
+
+const DELEGATOR_TAG_KEY: &str = "delegator";
+const DELEGATOR_TAG_KEY_BASE64: &str = "ZGVsZWdhdG9y";
+
+const VALIDATOR_TAG_KEY: &str = "validator";
+const VALIDATOR_TAG_KEY_BASE64: &str = "dmFsaWRhdG9y";
 
 const AMOUNT_TAG_KEY: &str = "amount";
 const AMOUNT_TAG_KEY_BASE64: &str = "YW1vdW50";
@@ -403,6 +411,7 @@ where
             ClaimHtlc,
             IBCSend,
             IBCReceive,
+            Delegate,
         }
 
         #[derive(Clone)]
@@ -470,75 +479,107 @@ where
             let mut transfer_details_list: Vec<TransferDetails> = vec![];
 
             for event in tx_events.iter() {
-                if event.kind.as_str() == TRANSFER_EVENT {
-                    let amount_with_denoms = some_or_continue!(get_value_from_event_attributes(
-                        &event.attributes,
-                        AMOUNT_TAG_KEY,
-                        AMOUNT_TAG_KEY_BASE64
-                    ));
+                let amount_with_denoms = some_or_continue!(get_value_from_event_attributes(
+                    &event.attributes,
+                    AMOUNT_TAG_KEY,
+                    AMOUNT_TAG_KEY_BASE64
+                ));
 
-                    let amount_with_denoms = amount_with_denoms.split(',');
+                let amount_with_denoms = amount_with_denoms.split(',');
+                for amount_with_denom in amount_with_denoms {
+                    let extracted_amount: String = amount_with_denom.chars().take_while(|c| c.is_numeric()).collect();
+                    let denom = &amount_with_denom[extracted_amount.len()..];
+                    let amount = some_or_continue!(extracted_amount.parse().ok());
 
-                    for amount_with_denom in amount_with_denoms {
-                        let extracted_amount: String =
-                            amount_with_denom.chars().take_while(|c| c.is_numeric()).collect();
-                        let denom = &amount_with_denom[extracted_amount.len()..];
-                        let amount = some_or_continue!(extracted_amount.parse().ok());
+                    match event.kind.as_str() {
+                        TRANSFER_EVENT => {
+                            let from = some_or_continue!(get_value_from_event_attributes(
+                                &event.attributes,
+                                SENDER_TAG_KEY,
+                                SENDER_TAG_KEY_BASE64
+                            ));
 
-                        let from = some_or_continue!(get_value_from_event_attributes(
-                            &event.attributes,
-                            SENDER_TAG_KEY,
-                            SENDER_TAG_KEY_BASE64
-                        ));
+                            let to = some_or_continue!(get_value_from_event_attributes(
+                                &event.attributes,
+                                RECIPIENT_TAG_KEY,
+                                RECIPIENT_TAG_KEY_BASE64,
+                            ));
 
-                        let to = some_or_continue!(get_value_from_event_attributes(
-                            &event.attributes,
-                            RECIPIENT_TAG_KEY,
-                            RECIPIENT_TAG_KEY_BASE64,
-                        ));
+                            let mut tx_details = TransferDetails {
+                                from,
+                                to,
+                                denom: denom.to_owned(),
+                                amount,
+                                // Default is Standard, can be changed later in read_real_htlc_addresses
+                                transfer_event_type: TransferEventType::default(),
+                            };
 
-                        let mut tx_details = TransferDetails {
-                            from,
-                            to,
-                            denom: denom.to_owned(),
-                            amount,
-                            // Default is Standard, can be changed later in read_real_htlc_addresses
-                            transfer_event_type: TransferEventType::default(),
-                        };
+                            // For HTLC transactions, the sender and receiver addresses in the "transfer" event will be incorrect.
+                            // Use `read_real_htlc_addresses` to handle them properly.
+                            if let Some(htlc_event) = tx_events
+                                .iter()
+                                .find(|e| [CREATE_HTLC_EVENT, CLAIM_HTLC_EVENT].contains(&e.kind.as_str()))
+                            {
+                                read_real_htlc_addresses(&mut tx_details, htlc_event);
+                            }
+                            // For IBC transactions, the sender and receiver addresses in the "transfer" event will be incorrect.
+                            // Use `read_real_ibc_addresses` to handle them properly.
+                            else if let Some(ibc_event) = tx_events.iter().find(|e| {
+                                [IBC_SEND_EVENT, IBC_RECEIVE_EVENT, IBC_NFT_RECEIVE_EVENT].contains(&e.kind.as_str())
+                            }) {
+                                read_real_ibc_addresses(&mut tx_details, ibc_event);
+                            }
 
-                        // For HTLC transactions, the sender and receiver addresses in the "transfer" event will be incorrect.
-                        // Use `read_real_htlc_addresses` to handle them properly.
-                        if let Some(htlc_event) = tx_events
-                            .iter()
-                            .find(|e| [CREATE_HTLC_EVENT, CLAIM_HTLC_EVENT].contains(&e.kind.as_str()))
-                        {
-                            read_real_htlc_addresses(&mut tx_details, htlc_event);
-                        }
-                        // For IBC transactions, the sender and receiver addresses in the "transfer" event will be incorrect.
-                        // Use `read_real_ibc_addresses` to handle them properly.
-                        else if let Some(ibc_event) = tx_events.iter().find(|e| {
-                            [IBC_SEND_EVENT, IBC_RECEIVE_EVENT, IBC_NFT_RECEIVE_EVENT].contains(&e.kind.as_str())
-                        }) {
-                            read_real_ibc_addresses(&mut tx_details, ibc_event);
-                        }
+                            handle_new_transfer_event(&mut transfer_details_list, tx_details);
+                        },
 
-                        // sum the amounts coins and pairs are same
-                        let mut duplicated_details = transfer_details_list.iter_mut().find(|details| {
-                            details.from == tx_details.from
-                                && details.to == tx_details.to
-                                && details.denom == tx_details.denom
-                        });
+                        DELEGATE_EVENT => {
+                            let from = some_or_continue!(get_value_from_event_attributes(
+                                &event.attributes,
+                                DELEGATOR_TAG_KEY,
+                                DELEGATOR_TAG_KEY_BASE64,
+                            ));
 
-                        if let Some(duplicated_details) = &mut duplicated_details {
-                            duplicated_details.amount += tx_details.amount;
-                        } else {
-                            transfer_details_list.push(tx_details);
-                        }
-                    }
+                            let to = some_or_continue!(get_value_from_event_attributes(
+                                &event.attributes,
+                                VALIDATOR_TAG_KEY,
+                                VALIDATOR_TAG_KEY_BASE64,
+                            ));
+
+                            let tx_details = TransferDetails {
+                                from,
+                                to,
+                                denom: denom.to_owned(),
+                                amount,
+                                transfer_event_type: TransferEventType::Delegate,
+                            };
+
+                            handle_new_transfer_event(&mut transfer_details_list, tx_details);
+                        },
+
+                        _ => {
+                            todo!()
+                        },
+                    };
                 }
             }
 
             transfer_details_list
+        }
+
+        fn handle_new_transfer_event(transfer_details_list: &mut Vec<TransferDetails>, new_transfer: TransferDetails) {
+            let mut existing_transfer = transfer_details_list.iter_mut().find(|details| {
+                details.from == new_transfer.from
+                    && details.to == new_transfer.to
+                    && details.denom == new_transfer.denom
+            });
+
+            if let Some(existing_transfer) = &mut existing_transfer {
+                // Handle multi-amount transfer events
+                existing_transfer.amount += new_transfer.amount;
+            } else {
+                transfer_details_list.push(new_transfer);
+            }
         }
 
         fn get_transfer_details(tx_events: Vec<Event>, fee_amount_with_denom: String) -> Vec<TransferDetails> {
@@ -584,6 +625,7 @@ where
                     },
                     token_id,
                 },
+                (TransferEventType::Delegate, _) => TransactionType::StakingDelegation,
                 (_, Some(token_id)) => TransactionType::TokenTransfer(token_id),
                 _ => TransactionType::StandardTransfer,
             }
@@ -604,7 +646,10 @@ where
                     }
                 },
                 TransferEventType::ClaimHtlc => Some((vec![my_address], vec![])),
-                TransferEventType::Standard | TransferEventType::IBCSend | TransferEventType::IBCReceive => {
+                TransferEventType::Standard
+                | TransferEventType::IBCSend
+                | TransferEventType::IBCReceive
+                | TransferEventType::Delegate => {
                     Some((vec![transfer_details.from.clone()], vec![transfer_details.to.clone()]))
                 },
             }

--- a/mm2src/coins/tendermint/tendermint_tx_history_v2.rs
+++ b/mm2src/coins/tendermint/tendermint_tx_history_v2.rs
@@ -557,8 +557,10 @@ where
                             handle_new_transfer_event(&mut transfer_details_list, tx_details);
                         },
 
-                        _ => {
-                            todo!()
+                        unrecognized => {
+                            log::warn!(
+                                "Found an unrecognized event '{unrecognized}' in transaction history processing."
+                            );
                         },
                     };
                 }

--- a/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
+++ b/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
@@ -23,7 +23,7 @@ use crate::rpc::lp_commands::trezor::trezor_connection_status;
 use crate::rpc::rate_limiter::{process_rate_limit, RateLimitContext};
 use coins::eth::EthCoin;
 use coins::my_tx_history_v2::my_tx_history_v2_rpc;
-use coins::rpc_command::tendermint::staking::validators_rpc;
+use coins::rpc_command::tendermint::staking::{validators_rpc, delegation_rpc};
 use coins::rpc_command::tendermint::{ibc_chains, ibc_transfer_channels};
 use coins::rpc_command::{account_balance::account_balance,
                          get_current_mtp::get_current_mtp_rpc,
@@ -214,6 +214,7 @@ async fn dispatcher_v2(request: MmRpcRequest, ctx: MmArc) -> DispatcherResult<Re
         "stop_simple_market_maker_bot" => handle_mmrpc(ctx, request, stop_simple_market_maker_bot).await,
         "stop_version_stat_collection" => handle_mmrpc(ctx, request, stop_version_stat_collection).await,
         "tendermint_validators" => handle_mmrpc(ctx, request, validators_rpc).await,
+        "tendermint_delegation" => handle_mmrpc(ctx, request, delegation_rpc).await,
         "trade_preimage" => handle_mmrpc(ctx, request, trade_preimage_rpc).await,
         "trezor_connection_status" => handle_mmrpc(ctx, request, trezor_connection_status).await,
         "update_nft" => handle_mmrpc(ctx, request, update_nft).await,

--- a/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
+++ b/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
@@ -23,7 +23,7 @@ use crate::rpc::lp_commands::trezor::trezor_connection_status;
 use crate::rpc::rate_limiter::{process_rate_limit, RateLimitContext};
 use coins::eth::EthCoin;
 use coins::my_tx_history_v2::my_tx_history_v2_rpc;
-use coins::rpc_command::tendermint::staking::{delegation_rpc, validators_rpc};
+use coins::rpc_command::tendermint::staking::validators_rpc;
 use coins::rpc_command::tendermint::{ibc_chains, ibc_transfer_channels};
 use coins::rpc_command::{account_balance::account_balance,
                          get_current_mtp::get_current_mtp_rpc,
@@ -214,7 +214,6 @@ async fn dispatcher_v2(request: MmRpcRequest, ctx: MmArc) -> DispatcherResult<Re
         "stop_simple_market_maker_bot" => handle_mmrpc(ctx, request, stop_simple_market_maker_bot).await,
         "stop_version_stat_collection" => handle_mmrpc(ctx, request, stop_version_stat_collection).await,
         "tendermint_validators" => handle_mmrpc(ctx, request, validators_rpc).await,
-        "tendermint_delegation" => handle_mmrpc(ctx, request, delegation_rpc).await,
         "trade_preimage" => handle_mmrpc(ctx, request, trade_preimage_rpc).await,
         "trezor_connection_status" => handle_mmrpc(ctx, request, trezor_connection_status).await,
         "update_nft" => handle_mmrpc(ctx, request, update_nft).await,

--- a/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
+++ b/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
@@ -23,7 +23,7 @@ use crate::rpc::lp_commands::trezor::trezor_connection_status;
 use crate::rpc::rate_limiter::{process_rate_limit, RateLimitContext};
 use coins::eth::EthCoin;
 use coins::my_tx_history_v2::my_tx_history_v2_rpc;
-use coins::rpc_command::tendermint::staking::{validators_rpc, delegation_rpc};
+use coins::rpc_command::tendermint::staking::{delegation_rpc, validators_rpc};
 use coins::rpc_command::tendermint::{ibc_chains, ibc_transfer_channels};
 use coins::rpc_command::{account_balance::account_balance,
                          get_current_mtp::get_current_mtp_rpc,

--- a/mm2src/mm2_main/tests/docker_tests/tendermint_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/tendermint_tests.rs
@@ -5,9 +5,10 @@ use mm2_test_helpers::for_tests::{atom_testnet_conf, disable_coin, disable_coin_
                                   enable_tendermint_token, enable_tendermint_without_balance,
                                   get_tendermint_my_tx_history, ibc_withdraw, iris_ibc_nucleus_testnet_conf,
                                   my_balance, nucleus_testnet_conf, orderbook, orderbook_v2, send_raw_transaction,
-                                  set_price, tendermint_validators, withdraw_v1, MarketMakerIt, Mm2TestConf};
+                                  set_price, tendermint_add_delegation, tendermint_validators, withdraw_v1,
+                                  MarketMakerIt, Mm2TestConf};
 use mm2_test_helpers::structs::{Bip44Chain, HDAccountAddressId, OrderbookAddress, OrderbookV2Response, RpcV2Response,
-                                TendermintActivationResult, TransactionDetails};
+                                TendermintActivationResult, TransactionDetails, TransactionType};
 use serde_json::json;
 use std::collections::HashSet;
 use std::iter::FromIterator;
@@ -675,6 +676,40 @@ fn test_tendermint_validators_rpc() {
         "nucvaloper15d4sf4z6y0vk9dnum8yzkvr9c3wq4q897vefpu"
     );
     assert_eq!(validators_raw_response["result"]["validators"][0]["jailed"], false);
+}
+
+#[test]
+fn test_tendermint_add_delegation() {
+    const MY_ADDRESS: &str = "nuc150evuj4j7k9kgu38e453jdv9m3u0ft2n4fgzfr";
+    const VALIDATOR_ADDRESS: &str = "nucvaloper15d4sf4z6y0vk9dnum8yzkvr9c3wq4q897vefpu";
+
+    let coins = json!([nucleus_testnet_conf()]);
+    let coin_ticker = coins[0]["coin"].as_str().unwrap();
+
+    let conf = Mm2TestConf::seednode(TENDERMINT_TEST_SEED, &coins);
+    let mm = MarketMakerIt::start(conf.conf, conf.rpc_password, None).unwrap();
+
+    let activation_res = block_on(enable_tendermint(
+        &mm,
+        coin_ticker,
+        &[],
+        NUCLEUS_TESTNET_RPC_URLS,
+        false,
+    ));
+
+    log!(
+        "Activation with assets {}",
+        serde_json::to_string(&activation_res).unwrap()
+    );
+
+    let tx_details = block_on(tendermint_add_delegation(&mm, coin_ticker, VALIDATOR_ADDRESS, "0.5"));
+
+    assert_eq!(tx_details.to, vec![VALIDATOR_ADDRESS.to_owned()]);
+    assert_eq!(tx_details.from, vec![MY_ADDRESS.to_owned()]);
+    assert_eq!(tx_details.transaction_type, TransactionType::StakingDelegation);
+
+    let send_raw_tx = block_on(send_raw_transaction(&mm, coin_ticker, &tx_details.tx_hex));
+    log!("Send raw tx {}", serde_json::to_string(&send_raw_tx).unwrap());
 }
 
 mod swap {

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -3118,6 +3118,36 @@ pub async fn tendermint_validators(
     json::from_str(&response.1).unwrap()
 }
 
+pub async fn tendermint_add_delegation(
+    mm: &MarketMakerIt,
+    coin: &str,
+    validator_address: &str,
+    amount: &str,
+) -> TransactionDetails {
+    let rpc_endpoint = "add_delegation";
+    let request = json!({
+        "userpass": mm.userpass,
+        "method": rpc_endpoint,
+        "mmrpc": "2.0",
+        "params": {
+            "coin": coin,
+            "staking_details": {
+                "type": "Cosmos",
+                "validator_address": validator_address,
+                "amount": amount,
+            }
+        }
+    });
+    log!("{rpc_endpoint} request {}", json::to_string(&request).unwrap());
+
+    let response = mm.rpc(&request).await.unwrap();
+    assert_eq!(response.0, StatusCode::OK, "{rpc_endpoint} failed: {}", response.1);
+    log!("{rpc_endpoint} response {}", response.1);
+
+    let json: Json = json::from_str(&response.1).unwrap();
+    json::from_value(json["result"].clone()).unwrap()
+}
+
 pub async fn init_utxo_electrum(
     mm: &MarketMakerIt,
     coin: &str,


### PR DESCRIPTION
Adds tendermint protocol support on `add_delegation` RPC, and extends tendermint transaction history implementation to support delegation transactions.

Next is to do the same for undelegation on `remove_delegation`.


TODO: File a documentation issue on https://github.com/KomodoPlatform/komodo-docs-mdx