### PR TITLE
feat(tpu-v2): provide swap protocol versioning

### DIFF
--- a/mm2src/mm2_main/src/database.rs
+++ b/mm2src/mm2_main/src/database.rs
@@ -121,8 +121,8 @@ fn migration_12() -> Vec<(&'static str, Vec<String>)> {
 
 fn migration_13() -> Vec<(&'static str, Vec<String>)> {
     vec![
-        (my_swaps::ADD_SWAP_VERSION_FIELD, vec![]),   // Step 1: Add new column
-        (my_swaps::SET_DEFAULT_SWAP_VERSION, vec![]), // Step 2: Update old rows
+        (my_swaps::ADD_SWAP_VERSION_FIELD, vec![]),  // Step 1: Add new column
+        (my_swaps::SET_LEGACY_SWAP_VERSION, vec![]), // Step 2: Update old rows
     ]
 }
 

--- a/mm2src/mm2_main/src/database.rs
+++ b/mm2src/mm2_main/src/database.rs
@@ -119,6 +119,8 @@ fn migration_12() -> Vec<(&'static str, Vec<String>)> {
     ]
 }
 
+fn migration_13() -> Vec<(&'static str, Vec<String>)> { vec![(my_swaps::ADD_SWAP_VERSION_FIELD, vec![])] }
+
 async fn statements_for_migration(ctx: &MmArc, current_migration: i64) -> Option<Vec<(&'static str, Vec<String>)>> {
     match current_migration {
         1 => Some(migration_1(ctx).await),
@@ -133,6 +135,7 @@ async fn statements_for_migration(ctx: &MmArc, current_migration: i64) -> Option
         10 => Some(migration_10(ctx).await),
         11 => Some(migration_11()),
         12 => Some(migration_12()),
+        13 => Some(migration_13()),
         _ => None,
     }
 }

--- a/mm2src/mm2_main/src/database.rs
+++ b/mm2src/mm2_main/src/database.rs
@@ -119,7 +119,12 @@ fn migration_12() -> Vec<(&'static str, Vec<String>)> {
     ]
 }
 
-fn migration_13() -> Vec<(&'static str, Vec<String>)> { vec![(my_swaps::ADD_SWAP_VERSION_FIELD, vec![])] }
+fn migration_13() -> Vec<(&'static str, Vec<String>)> {
+    vec![
+        (my_swaps::ADD_SWAP_VERSION_FIELD, vec![]),   // Step 1: Add new column
+        (my_swaps::SET_DEFAULT_SWAP_VERSION, vec![]), // Step 2: Update old rows
+    ]
+}
 
 async fn statements_for_migration(ctx: &MmArc, current_migration: i64) -> Option<Vec<(&'static str, Vec<String>)>> {
     match current_migration {

--- a/mm2src/mm2_main/src/database/my_swaps.rs
+++ b/mm2src/mm2_main/src/database/my_swaps.rs
@@ -55,7 +55,7 @@ pub const TRADING_PROTO_UPGRADE_MIGRATION: &[&str] = &[
 /// Adds Swap Protocol version column to `my_swaps` table
 pub const ADD_SWAP_VERSION_FIELD: &str = "ALTER TABLE my_swaps ADD COLUMN swap_version INTEGER;";
 /// Sets default value for `swap_version` to `1` for existing rows
-pub const SET_DEFAULT_SWAP_VERSION: &str = "UPDATE my_swaps SET swap_version = 1 WHERE swap_version IS NULL;";
+pub const SET_LEGACY_SWAP_VERSION: &str = "UPDATE my_swaps SET swap_version = 1 WHERE swap_version IS NULL;";
 pub const ADD_OTHER_P2P_PUBKEY_FIELD: &str = "ALTER TABLE my_swaps ADD COLUMN other_p2p_pub BLOB;";
 /// Storing rational numbers as text to maintain precision
 pub const ADD_DEX_FEE_BURN_FIELD: &str = "ALTER TABLE my_swaps ADD COLUMN dex_fee_burn TEXT;";

--- a/mm2src/mm2_main/src/database/my_swaps.rs
+++ b/mm2src/mm2_main/src/database/my_swaps.rs
@@ -54,6 +54,8 @@ pub const TRADING_PROTO_UPGRADE_MIGRATION: &[&str] = &[
 
 /// Adds Swap Protocol version column to `my_swaps` table
 pub const ADD_SWAP_VERSION_FIELD: &str = "ALTER TABLE my_swaps ADD COLUMN swap_version INTEGER;";
+/// Sets default value for `swap_version` to `1` for existing rows
+pub const SET_DEFAULT_SWAP_VERSION: &str = "UPDATE my_swaps SET swap_version = 1 WHERE swap_version IS NULL;";
 pub const ADD_OTHER_P2P_PUBKEY_FIELD: &str = "ALTER TABLE my_swaps ADD COLUMN other_p2p_pub BLOB;";
 /// Storing rational numbers as text to maintain precision
 pub const ADD_DEX_FEE_BURN_FIELD: &str = "ALTER TABLE my_swaps ADD COLUMN dex_fee_burn TEXT;";

--- a/mm2src/mm2_main/src/database/my_swaps.rs
+++ b/mm2src/mm2_main/src/database/my_swaps.rs
@@ -52,8 +52,10 @@ pub const TRADING_PROTO_UPGRADE_MIGRATION: &[&str] = &[
     "ALTER TABLE my_swaps ADD COLUMN taker_coin_nota BOOLEAN;",
 ];
 
+/// Adds Swap Protocol version column to `my_swaps` table
+pub const ADD_SWAP_VERSION_FIELD: &str = "ALTER TABLE my_swaps ADD COLUMN swap_version INTEGER;";
 pub const ADD_OTHER_P2P_PUBKEY_FIELD: &str = "ALTER TABLE my_swaps ADD COLUMN other_p2p_pub BLOB;";
-// Storing rational numbers as text to maintain precision
+/// Storing rational numbers as text to maintain precision
 pub const ADD_DEX_FEE_BURN_FIELD: &str = "ALTER TABLE my_swaps ADD COLUMN dex_fee_burn TEXT;";
 
 /// The query to insert swap on migration 1, during this migration swap_type column doesn't exist
@@ -97,7 +99,8 @@ const INSERT_MY_SWAP_V2: &str = r#"INSERT INTO my_swaps (
     maker_coin_nota,
     taker_coin_confs,
     taker_coin_nota,
-    other_p2p_pub
+    other_p2p_pub,
+    swap_version
 ) VALUES (
     :my_coin,
     :other_coin,
@@ -118,7 +121,8 @@ const INSERT_MY_SWAP_V2: &str = r#"INSERT INTO my_swaps (
     :maker_coin_nota,
     :taker_coin_confs,
     :taker_coin_nota,
-    :other_p2p_pub
+    :other_p2p_pub,
+    :swap_version
 );"#;
 
 pub fn insert_new_swap_v2(ctx: &MmArc, params: &[(&str, &dyn ToSql)]) -> SqlResult<()> {
@@ -311,7 +315,8 @@ pub const SELECT_MY_SWAP_V2_FOR_RPC_BY_UUID: &str = r#"SELECT
     maker_coin_confs,
     maker_coin_nota,
     taker_coin_confs,
-    taker_coin_nota
+    taker_coin_nota,
+    swap_version
 FROM my_swaps
 WHERE uuid = :uuid;
 "#;
@@ -337,7 +342,8 @@ pub const SELECT_MY_SWAP_V2_BY_UUID: &str = r#"SELECT
     taker_coin_confs,
     taker_coin_nota,
     p2p_privkey,
-    other_p2p_pub
+    other_p2p_pub,
+    swap_version
 FROM my_swaps
 WHERE uuid = :uuid;
 "#;

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -139,7 +139,7 @@ const TRIE_STATE_HISTORY_TIMEOUT: u64 = 3;
 const TRIE_ORDER_HISTORY_TIMEOUT: u64 = 300;
 #[cfg(test)]
 const TRIE_ORDER_HISTORY_TIMEOUT: u64 = 3;
-/// Swap protocol version
+/// Current swap protocol version
 const SWAP_VERSION: u32 = 2;
 
 pub type OrderbookP2PHandlerResult = Result<(), MmError<OrderbookP2PHandlerError>>;
@@ -1434,7 +1434,7 @@ impl<'a> TakerOrderBuilder<'a> {
     /// In the future alls users will be using TPU V2 by default without "use_trading_proto_v2" configuration.
     pub fn use_trading_proto_v2(mut self, use_trading_proto_v2: bool) -> Self {
         if !use_trading_proto_v2 {
-            self.swap_version = 1;
+            self.swap_version = legacy_swap_version();
         }
         self
     }
@@ -1940,7 +1940,7 @@ impl<'a> MakerOrderBuilder<'a> {
     /// In the future alls users will be using TPU V2 by default without "use_trading_proto_v2" configuration.
     pub fn use_trading_proto_v2(mut self, use_trading_proto_v2: bool) -> Self {
         if !use_trading_proto_v2 {
-            self.swap_version = 1;
+            self.swap_version = legacy_swap_version();
         }
         self
     }

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -141,7 +141,7 @@ const TRIE_ORDER_HISTORY_TIMEOUT: u64 = 300;
 #[cfg(test)]
 const TRIE_ORDER_HISTORY_TIMEOUT: u64 = 3;
 /// Current swap protocol version
-const SWAP_VERSION: u32 = 2;
+const SWAP_VERSION: u8 = 2;
 
 pub type OrderbookP2PHandlerResult = Result<(), MmError<OrderbookP2PHandlerError>>;
 
@@ -1282,7 +1282,7 @@ pub struct TakerOrderBuilder<'a> {
     min_volume: Option<MmNumber>,
     timeout: u64,
     save_in_history: bool,
-    swap_version: u32,
+    swap_version: u8,
 }
 
 pub enum TakerOrderBuildError {
@@ -1738,7 +1738,7 @@ pub struct MakerOrderBuilder<'a> {
     rel_orderbook_ticker: Option<String>,
     conf_settings: Option<OrderConfirmationsSettings>,
     save_in_history: bool,
-    swap_version: u32,
+    swap_version: u8,
 }
 
 pub enum MakerOrderBuildError {

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -1432,7 +1432,7 @@ impl<'a> TakerOrderBuilder<'a> {
     /// However, if user has not specified in the config to use TPU V2,
     /// the TakerOrderBuilder's swap_version is changed to legacy.
     /// In the future alls users will be using TPU V2 by default without "use_trading_proto_v2" configuration.
-    pub fn use_trading_proto_v2(mut self, use_trading_proto_v2: bool) -> Self {
+    pub fn set_swap_protocol_v(mut self, use_trading_proto_v2: bool) -> Self {
         if !use_trading_proto_v2 {
             self.swap_version = legacy_swap_version();
         }
@@ -1938,7 +1938,7 @@ impl<'a> MakerOrderBuilder<'a> {
     /// However, if user has not specified in the config to use TPU V2,
     /// the MakerOrderBuilder's swap_version is changed to legacy.
     /// In the future alls users will be using TPU V2 by default without "use_trading_proto_v2" configuration.
-    pub fn use_trading_proto_v2(mut self, use_trading_proto_v2: bool) -> Self {
+    pub fn set_swap_protocol_v(mut self, use_trading_proto_v2: bool) -> Self {
         if !use_trading_proto_v2 {
             self.swap_version = legacy_swap_version();
         }
@@ -4249,7 +4249,7 @@ pub async fn lp_auto_buy(
         .with_save_in_history(input.save_in_history)
         .with_base_orderbook_ticker(ordermatch_ctx.orderbook_ticker(base_coin.ticker()))
         .with_rel_orderbook_ticker(ordermatch_ctx.orderbook_ticker(rel_coin.ticker()))
-        .use_trading_proto_v2(ctx.use_trading_proto_v2());
+        .set_swap_protocol_v(ctx.use_trading_proto_v2());
     if let Some(timeout) = input.timeout {
         order_builder = order_builder.with_timeout(timeout);
     }
@@ -4995,7 +4995,7 @@ pub async fn create_maker_order(ctx: &MmArc, req: SetPriceReq) -> Result<MakerOr
         .with_save_in_history(req.save_in_history)
         .with_base_orderbook_ticker(ordermatch_ctx.orderbook_ticker(base_coin.ticker()))
         .with_rel_orderbook_ticker(ordermatch_ctx.orderbook_ticker(rel_coin.ticker()))
-        .use_trading_proto_v2(ctx.use_trading_proto_v2());
+        .set_swap_protocol_v(ctx.use_trading_proto_v2());
 
     let new_order = try_s!(builder.build());
 

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -3105,7 +3105,7 @@ fn lp_connect_start_bob(ctx: MmArc, maker_match: MakerMatch, maker_order: MakerO
         let alice_swap_v = maker_match.request.swap_version;
 
         // Start legacy swap if taker uses legacy protocol (version 1) or if conditions for trading_proto_v2 aren't met.
-        if alice_swap_v == 1u32 || !ctx.use_trading_proto_v2() {
+        if alice_swap_v == legacy_swap_version() || !ctx.use_trading_proto_v2() {
             let params = LegacySwapParams {
                 maker_coin: &maker_coin,
                 taker_coin: &taker_coin,
@@ -3329,7 +3329,7 @@ fn lp_connected_alice(ctx: MmArc, taker_order: TakerOrder, taker_match: TakerMat
         let bob_swap_v = taker_match.reserved.swap_version;
 
         // Start legacy swap if maker uses legacy protocol (version 1) or if conditions for trading_proto_v2 aren't met.
-        if bob_swap_v == 1u32 || !ctx.use_trading_proto_v2() {
+        if bob_swap_v == legacy_swap_version() || !ctx.use_trading_proto_v2() {
             let params = LegacySwapParams {
                 maker_coin: &maker_coin,
                 taker_coin: &taker_coin,

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -3084,9 +3084,10 @@ fn lp_connect_start_bob(ctx: MmArc, maker_match: MakerMatch, maker_order: MakerO
         };
 
         let alice_swap_v = maker_match.request.swap_version;
+        let bob_swap_v = maker_order.swap_version;
 
-        // Start legacy swap if taker uses legacy protocol (version 1) or if conditions for trading_proto_v2 aren't met.
-        if alice_swap_v.is_legacy() || !ctx.use_trading_proto_v2() {
+        // Start a legacy swap if either the taker or maker uses the legacy swap protocol (version 1)
+        if alice_swap_v.is_legacy() || bob_swap_v.is_legacy() {
             let params = LegacySwapParams {
                 maker_coin: &maker_coin,
                 taker_coin: &taker_coin,
@@ -3308,9 +3309,10 @@ fn lp_connected_alice(ctx: MmArc, taker_order: TakerOrder, taker_match: TakerMat
         );
 
         let bob_swap_v = taker_match.reserved.swap_version;
+        let alice_swap_v = taker_order.request.swap_version;
 
-        // Start legacy swap if maker uses legacy protocol (version 1) or if conditions for trading_proto_v2 aren't met.
-        if bob_swap_v.is_legacy() || !ctx.use_trading_proto_v2() {
+        // Start a legacy swap if either the maker or taker uses the legacy swap protocol (version 1)
+        if bob_swap_v.is_legacy() || alice_swap_v.is_legacy() {
             let params = LegacySwapParams {
                 maker_coin: &maker_coin,
                 taker_coin: &taker_coin,

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -1267,7 +1267,7 @@ impl TakerRequest {
 }
 
 const fn legacy_swap_version() -> u32 { 1 }
-fn is_legacy_swap_version(swap_version: &u32) -> bool { *swap_version == legacy_swap_version() }
+fn is_legacy_swap_version(swap_version: &u32) -> bool { swap_version == &legacy_swap_version() }
 
 pub struct TakerOrderBuilder<'a> {
     base_coin: &'a MmCoinEnum,

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -141,7 +141,7 @@ const TRIE_ORDER_HISTORY_TIMEOUT: u64 = 300;
 #[cfg(test)]
 const TRIE_ORDER_HISTORY_TIMEOUT: u64 = 3;
 /// Current swap protocol version
-const SWAP_VERSION: u8 = 2;
+const SWAP_VERSION_DEFAULT: u8 = 2;
 
 pub type OrderbookP2PHandlerResult = Result<(), MmError<OrderbookP2PHandlerError>>;
 
@@ -1362,7 +1362,7 @@ impl<'a> TakerOrderBuilder<'a> {
             order_type: OrderType::GoodTillCancelled,
             timeout: TAKER_ORDER_TIMEOUT,
             save_in_history: true,
-            swap_version: SWAP_VERSION,
+            swap_version: SWAP_VERSION_DEFAULT,
         }
     }
 
@@ -1426,7 +1426,7 @@ impl<'a> TakerOrderBuilder<'a> {
         self
     }
 
-    /// When a new [TakerOrderBuilder::new] is created, it sets [SWAP_VERSION] by default.
+    /// When a new [TakerOrderBuilder::new] is created, it sets [SWAP_VERSION_DEFAULT].
     /// However, if user has not specified in the config to use TPU V2,
     /// the TakerOrderBuilder's swap_version is changed to legacy.
     /// In the future alls users will be using TPU V2 by default without "use_trading_proto_v2" configuration.
@@ -1888,7 +1888,7 @@ impl<'a> MakerOrderBuilder<'a> {
             price: 0.into(),
             conf_settings: None,
             save_in_history: true,
-            swap_version: SWAP_VERSION,
+            swap_version: SWAP_VERSION_DEFAULT,
         }
     }
 
@@ -1927,7 +1927,7 @@ impl<'a> MakerOrderBuilder<'a> {
         self
     }
 
-    /// When a new [MakerOrderBuilder::new] is created, it sets [SWAP_VERSION] by default.
+    /// When a new [MakerOrderBuilder::new] is created, it sets [SWAP_VERSION_DEFAULT].
     /// However, if user has not specified in the config to use TPU V2,
     /// the MakerOrderBuilder's swap_version is changed to legacy.
     /// In the future alls users will be using TPU V2 by default without "use_trading_proto_v2" configuration.

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -1266,9 +1266,8 @@ impl TakerRequest {
     fn get_rel_amount(&self) -> &MmNumber { &self.rel_amount }
 }
 
-fn legacy_swap_version() -> u32 { 1 }
-
-fn is_legacy_swap_version(swap_version: &u32) -> bool { *swap_version == 1 }
+const fn legacy_swap_version() -> u32 { 1 }
+fn is_legacy_swap_version(swap_version: &u32) -> bool { *swap_version == legacy_swap_version() }
 
 pub struct TakerOrderBuilder<'a> {
     base_coin: &'a MmCoinEnum,

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -3241,6 +3241,7 @@ async fn start_maker_swap_state_machine<
         lock_duration: *params.locktime,
         taker_p2p_pubkey: *taker_p2p_pubkey,
         require_taker_payment_spend_confirm: true,
+        swap_version: maker_order.swap_version,
     };
     #[allow(clippy::box_default)]
     maker_swap_state_machine
@@ -3480,6 +3481,7 @@ async fn start_taker_swap_state_machine<
         maker_p2p_pubkey: *maker_p2p_pubkey,
         require_maker_payment_confirm_before_funding_spend: true,
         require_maker_payment_spend_confirm: true,
+        swap_version: taker_order.request.swap_version,
     };
     #[allow(clippy::box_default)]
     taker_swap_state_machine

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -139,6 +139,8 @@ const TRIE_STATE_HISTORY_TIMEOUT: u64 = 3;
 const TRIE_ORDER_HISTORY_TIMEOUT: u64 = 300;
 #[cfg(test)]
 const TRIE_ORDER_HISTORY_TIMEOUT: u64 = 3;
+/// Swap protocol version
+const SWAP_VERSION: u32 = 2;
 
 pub type OrderbookP2PHandlerResult = Result<(), MmError<OrderbookP2PHandlerError>>;
 
@@ -1184,6 +1186,9 @@ pub struct TakerRequest {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rel_protocol_info: Option<Vec<u8>>,
+    #[serde(default = "legacy_swap_version")]
+    #[serde(skip_serializing_if = "is_legacy_swap_version")]
+    pub swap_version: u32,
 }
 
 impl TakerRequest {
@@ -1204,6 +1209,7 @@ impl TakerRequest {
             conf_settings: Some(message.conf_settings),
             base_protocol_info: message.base_protocol_info,
             rel_protocol_info: message.rel_protocol_info,
+            swap_version: message.swap_version,
         }
     }
 
@@ -1249,6 +1255,7 @@ impl From<TakerOrder> for new_protocol::OrdermatchMessage {
             conf_settings: taker_order.request.conf_settings.unwrap(),
             base_protocol_info: taker_order.request.base_protocol_info,
             rel_protocol_info: taker_order.request.rel_protocol_info,
+            swap_version: taker_order.request.swap_version,
         })
     }
 }
@@ -1258,6 +1265,10 @@ impl TakerRequest {
 
     fn get_rel_amount(&self) -> &MmNumber { &self.rel_amount }
 }
+
+fn legacy_swap_version() -> u32 { 1 }
+
+fn is_legacy_swap_version(swap_version: &u32) -> bool { *swap_version == 1 }
 
 pub struct TakerOrderBuilder<'a> {
     base_coin: &'a MmCoinEnum,
@@ -1274,6 +1285,7 @@ pub struct TakerOrderBuilder<'a> {
     min_volume: Option<MmNumber>,
     timeout: u64,
     save_in_history: bool,
+    swap_version: u32,
 }
 
 pub enum TakerOrderBuildError {
@@ -1353,6 +1365,7 @@ impl<'a> TakerOrderBuilder<'a> {
             order_type: OrderType::GoodTillCancelled,
             timeout: TAKER_ORDER_TIMEOUT,
             save_in_history: true,
+            swap_version: SWAP_VERSION,
         }
     }
 
@@ -1413,6 +1426,17 @@ impl<'a> TakerOrderBuilder<'a> {
 
     pub fn with_rel_orderbook_ticker(mut self, ticker: Option<String>) -> Self {
         self.rel_orderbook_ticker = ticker;
+        self
+    }
+
+    /// When a new [TakerOrderBuilder::new] is created, it sets [SWAP_VERSION] by default.
+    /// However, if user has not specified in the config to use TPU V2,
+    /// the TakerOrderBuilder's swap_version is changed to legacy.
+    /// In the future alls users will be using TPU V2 by default without "use_trading_proto_v2" configuration.
+    pub fn use_trading_proto_v2(mut self, use_trading_proto_v2: bool) -> Self {
+        if !use_trading_proto_v2 {
+            self.swap_version = 1;
+        }
         self
     }
 
@@ -1504,6 +1528,7 @@ impl<'a> TakerOrderBuilder<'a> {
                 conf_settings: self.conf_settings,
                 base_protocol_info: Some(base_protocol_info),
                 rel_protocol_info: Some(rel_protocol_info),
+                swap_version: self.swap_version,
             },
             matches: Default::default(),
             min_volume,
@@ -1544,6 +1569,7 @@ impl<'a> TakerOrderBuilder<'a> {
                 conf_settings: self.conf_settings,
                 base_protocol_info: Some(base_protocol_info),
                 rel_protocol_info: Some(rel_protocol_info),
+                swap_version: self.swap_version,
             },
             matches: HashMap::new(),
             min_volume: Default::default(),
@@ -1705,6 +1731,9 @@ pub struct MakerOrder {
     /// A custom priv key for more privacy to prevent linking orders of the same node between each other
     /// Commonly used with privacy coins (ARRR, ZCash, etc.)
     p2p_privkey: Option<SerializableSecp256k1Keypair>,
+    #[serde(default = "legacy_swap_version")]
+    #[serde(skip_serializing_if = "is_legacy_swap_version")]
+    pub swap_version: u32,
 }
 
 pub struct MakerOrderBuilder<'a> {
@@ -1717,6 +1746,7 @@ pub struct MakerOrderBuilder<'a> {
     rel_orderbook_ticker: Option<String>,
     conf_settings: Option<OrderConfirmationsSettings>,
     save_in_history: bool,
+    swap_version: u32,
 }
 
 pub enum MakerOrderBuildError {
@@ -1866,6 +1896,7 @@ impl<'a> MakerOrderBuilder<'a> {
             price: 0.into(),
             conf_settings: None,
             save_in_history: true,
+            swap_version: SWAP_VERSION,
         }
     }
 
@@ -1901,6 +1932,17 @@ impl<'a> MakerOrderBuilder<'a> {
 
     pub fn with_rel_orderbook_ticker(mut self, rel_orderbook_ticker: Option<String>) -> Self {
         self.rel_orderbook_ticker = rel_orderbook_ticker;
+        self
+    }
+
+    /// When a new [MakerOrderBuilder::new] is created, it sets [SWAP_VERSION] by default.
+    /// However, if user has not specified in the config to use TPU V2,
+    /// the MakerOrderBuilder's swap_version is changed to legacy.
+    /// In the future alls users will be using TPU V2 by default without "use_trading_proto_v2" configuration.
+    pub fn use_trading_proto_v2(mut self, use_trading_proto_v2: bool) -> Self {
+        if !use_trading_proto_v2 {
+            self.swap_version = 1;
+        }
         self
     }
 
@@ -1960,6 +2002,7 @@ impl<'a> MakerOrderBuilder<'a> {
             base_orderbook_ticker: self.base_orderbook_ticker,
             rel_orderbook_ticker: self.rel_orderbook_ticker,
             p2p_privkey,
+            swap_version: self.swap_version,
         })
     }
 
@@ -1984,6 +2027,7 @@ impl<'a> MakerOrderBuilder<'a> {
             base_orderbook_ticker: None,
             rel_orderbook_ticker: None,
             p2p_privkey: None,
+            swap_version: self.swap_version,
         }
     }
 }
@@ -2114,6 +2158,7 @@ impl From<TakerOrder> for MakerOrder {
                 base_orderbook_ticker: taker_order.base_orderbook_ticker,
                 rel_orderbook_ticker: taker_order.rel_orderbook_ticker,
                 p2p_privkey: taker_order.p2p_privkey,
+                swap_version: taker_order.request.swap_version,
             },
             // The "buy" taker order is recreated with reversed pair as Maker order is always considered as "sell"
             TakerAction::Buy => {
@@ -2136,6 +2181,7 @@ impl From<TakerOrder> for MakerOrder {
                     base_orderbook_ticker: taker_order.rel_orderbook_ticker,
                     rel_orderbook_ticker: taker_order.base_orderbook_ticker,
                     p2p_privkey: taker_order.p2p_privkey,
+                    swap_version: taker_order.request.swap_version,
                 }
             },
         }
@@ -2188,6 +2234,9 @@ pub struct MakerReserved {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rel_protocol_info: Option<Vec<u8>>,
+    #[serde(default = "legacy_swap_version")]
+    #[serde(skip_serializing_if = "is_legacy_swap_version")]
+    pub swap_version: u32,
 }
 
 impl MakerReserved {
@@ -2215,6 +2264,7 @@ impl MakerReserved {
             conf_settings: Some(message.conf_settings),
             base_protocol_info: message.base_protocol_info,
             rel_protocol_info: message.rel_protocol_info,
+            swap_version: message.swap_version,
         }
     }
 }
@@ -2231,6 +2281,7 @@ impl From<MakerReserved> for new_protocol::OrdermatchMessage {
             conf_settings: maker_reserved.conf_settings.unwrap(),
             base_protocol_info: maker_reserved.base_protocol_info,
             rel_protocol_info: maker_reserved.rel_protocol_info,
+            swap_version: maker_reserved.swap_version,
         })
     }
 }
@@ -3052,8 +3103,10 @@ fn lp_connect_start_bob(ctx: MmArc, maker_match: MakerMatch, maker_order: MakerO
             },
         };
 
-        // TODO add alice swap protocol version check once protocol versioning is implemented
-        if !ctx.use_trading_proto_v2() {
+        let alice_swap_v = maker_match.request.swap_version;
+
+        // Start legacy swap if taker uses legacy protocol (version 1) or if conditions for trading_proto_v2 aren't met.
+        if alice_swap_v == 1u32 || !ctx.use_trading_proto_v2() {
             let params = LegacySwapParams {
                 maker_coin: &maker_coin,
                 taker_coin: &taker_coin,
@@ -3273,8 +3326,10 @@ fn lp_connected_alice(ctx: MmArc, taker_order: TakerOrder, taker_match: TakerMat
             uuid
         );
 
-        // TODO add bob swap protocol version check once protocol versioning is implemented
-        if !ctx.use_trading_proto_v2() {
+        let bob_swap_v = taker_match.reserved.swap_version;
+
+        // Start legacy swap if maker uses legacy protocol (version 1) or if conditions for trading_proto_v2 aren't met.
+        if bob_swap_v == 1u32 || !ctx.use_trading_proto_v2() {
             let params = LegacySwapParams {
                 maker_coin: &maker_coin,
                 taker_coin: &taker_coin,
@@ -3945,6 +4000,7 @@ async fn process_taker_request(ctx: MmArc, from_pubkey: H256Json, taker_request:
                     }),
                     base_protocol_info: Some(base_coin.coin_protocol_info(None)),
                     rel_protocol_info: Some(rel_coin.coin_protocol_info(Some(rel_amount.clone()))),
+                    swap_version: order.swap_version,
                 };
                 let topic = order.orderbook_topic();
                 log::debug!("Request matched sending reserved {:?}", reserved);
@@ -4191,7 +4247,8 @@ pub async fn lp_auto_buy(
         .with_sender_pubkey(H256Json::from(our_public_id.bytes))
         .with_save_in_history(input.save_in_history)
         .with_base_orderbook_ticker(ordermatch_ctx.orderbook_ticker(base_coin.ticker()))
-        .with_rel_orderbook_ticker(ordermatch_ctx.orderbook_ticker(rel_coin.ticker()));
+        .with_rel_orderbook_ticker(ordermatch_ctx.orderbook_ticker(rel_coin.ticker()))
+        .use_trading_proto_v2(ctx.use_trading_proto_v2());
     if let Some(timeout) = input.timeout {
         order_builder = order_builder.with_timeout(timeout);
     }
@@ -4936,7 +4993,8 @@ pub async fn create_maker_order(ctx: &MmArc, req: SetPriceReq) -> Result<MakerOr
         .with_conf_settings(conf_settings)
         .with_save_in_history(req.save_in_history)
         .with_base_orderbook_ticker(ordermatch_ctx.orderbook_ticker(base_coin.ticker()))
-        .with_rel_orderbook_ticker(ordermatch_ctx.orderbook_ticker(rel_coin.ticker()));
+        .with_rel_orderbook_ticker(ordermatch_ctx.orderbook_ticker(rel_coin.ticker()))
+        .use_trading_proto_v2(ctx.use_trading_proto_v2());
 
     let new_order = try_s!(builder.build());
 

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -1181,14 +1181,11 @@ pub struct TakerRequest {
     #[serde(default)]
     match_by: MatchBy,
     conf_settings: Option<OrderConfirmationsSettings>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_protocol_info: Option<Vec<u8>>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rel_protocol_info: Option<Vec<u8>>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "SwapVersion::is_legacy")]
+    #[serde(default, skip_serializing_if = "SwapVersion::is_legacy")]
     pub swap_version: SwapVersion,
 }
 
@@ -1723,8 +1720,7 @@ pub struct MakerOrder {
     /// A custom priv key for more privacy to prevent linking orders of the same node between each other
     /// Commonly used with privacy coins (ARRR, ZCash, etc.)
     p2p_privkey: Option<SerializableSecp256k1Keypair>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "SwapVersion::is_legacy")]
+    #[serde(default, skip_serializing_if = "SwapVersion::is_legacy")]
     pub swap_version: SwapVersion,
 }
 
@@ -2215,14 +2211,11 @@ pub struct MakerReserved {
     sender_pubkey: H256Json,
     dest_pub_key: H256Json,
     conf_settings: Option<OrderConfirmationsSettings>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_protocol_info: Option<Vec<u8>>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rel_protocol_info: Option<Vec<u8>>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "SwapVersion::is_legacy")]
+    #[serde(default, skip_serializing_if = "SwapVersion::is_legacy")]
     pub swap_version: SwapVersion,
 }
 

--- a/mm2src/mm2_main/src/lp_ordermatch/my_orders_storage.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch/my_orders_storage.rs
@@ -694,7 +694,8 @@ mod tests {
     use super::wasm_impl::{maker_order_to_filtering_history_item, taker_order_to_filtering_history_item};
     use super::*;
     use crate::lp_ordermatch::ordermatch_wasm_db::{ItemId, MyFilteringHistoryOrdersTable};
-    use crate::lp_ordermatch::{legacy_swap_version, OrdermatchContext, TakerRequest};
+    use crate::lp_ordermatch::{OrdermatchContext, TakerRequest};
+    use crate::swap_versioning::SwapVersion;
     use common::{new_uuid, now_ms};
     use futures::compat::Future01CompatExt;
     use itertools::Itertools;
@@ -724,7 +725,7 @@ mod tests {
             base_orderbook_ticker: None,
             rel_orderbook_ticker: None,
             p2p_privkey: None,
-            swap_version: legacy_swap_version(),
+            swap_version: SwapVersion::default(),
         }
     }
 
@@ -743,7 +744,7 @@ mod tests {
                 conf_settings: None,
                 base_protocol_info: None,
                 rel_protocol_info: None,
-                swap_version: legacy_swap_version(),
+                swap_version: SwapVersion::default(),
             },
             matches: HashMap::new(),
             created_at: now_ms(),

--- a/mm2src/mm2_main/src/lp_ordermatch/my_orders_storage.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch/my_orders_storage.rs
@@ -706,6 +706,8 @@ mod tests {
 
     wasm_bindgen_test_configure!(run_in_browser);
 
+    const LEGACY_SWAP_V: u32 = 1;
+
     fn maker_order_for_test() -> MakerOrder {
         MakerOrder {
             base: "BASE".to_owned(),
@@ -724,6 +726,7 @@ mod tests {
             base_orderbook_ticker: None,
             rel_orderbook_ticker: None,
             p2p_privkey: None,
+            swap_version: LEGACY_SWAP_V,
         }
     }
 
@@ -742,6 +745,7 @@ mod tests {
                 conf_settings: None,
                 base_protocol_info: None,
                 rel_protocol_info: None,
+                swap_version: LEGACY_SWAP_V,
             },
             matches: HashMap::new(),
             created_at: now_ms(),

--- a/mm2src/mm2_main/src/lp_ordermatch/my_orders_storage.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch/my_orders_storage.rs
@@ -694,7 +694,7 @@ mod tests {
     use super::wasm_impl::{maker_order_to_filtering_history_item, taker_order_to_filtering_history_item};
     use super::*;
     use crate::lp_ordermatch::ordermatch_wasm_db::{ItemId, MyFilteringHistoryOrdersTable};
-    use crate::lp_ordermatch::{OrdermatchContext, TakerRequest};
+    use crate::lp_ordermatch::{legacy_swap_version, OrdermatchContext, TakerRequest};
     use common::{new_uuid, now_ms};
     use futures::compat::Future01CompatExt;
     use itertools::Itertools;
@@ -705,8 +705,6 @@ mod tests {
     use wasm_bindgen_test::*;
 
     wasm_bindgen_test_configure!(run_in_browser);
-
-    const LEGACY_SWAP_V: u32 = 1;
 
     fn maker_order_for_test() -> MakerOrder {
         MakerOrder {
@@ -726,7 +724,7 @@ mod tests {
             base_orderbook_ticker: None,
             rel_orderbook_ticker: None,
             p2p_privkey: None,
-            swap_version: LEGACY_SWAP_V,
+            swap_version: legacy_swap_version(),
         }
     }
 
@@ -745,7 +743,7 @@ mod tests {
                 conf_settings: None,
                 base_protocol_info: None,
                 rel_protocol_info: None,
-                swap_version: LEGACY_SWAP_V,
+                swap_version: legacy_swap_version(),
             },
             matches: HashMap::new(),
             created_at: now_ms(),

--- a/mm2src/mm2_main/src/lp_ordermatch/new_protocol.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch/new_protocol.rs
@@ -5,7 +5,7 @@ use mm2_rpc::data::legacy::{MatchBy as SuperMatchBy, OrderConfirmationsSettings,
 use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
-use crate::lp_ordermatch::{AlbOrderedOrderbookPair, H64};
+use crate::lp_ordermatch::{is_legacy_swap_version, legacy_swap_version, AlbOrderedOrderbookPair, H64};
 
 #[derive(Debug, Deserialize, Serialize)]
 #[allow(clippy::large_enum_variant)]
@@ -265,6 +265,9 @@ pub struct TakerRequest {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rel_protocol_info: Option<Vec<u8>>,
+    #[serde(default = "legacy_swap_version")]
+    #[serde(skip_serializing_if = "is_legacy_swap_version")]
+    pub swap_version: u32,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -282,6 +285,9 @@ pub struct MakerReserved {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rel_protocol_info: Option<Vec<u8>>,
+    #[serde(default = "legacy_swap_version")]
+    #[serde(skip_serializing_if = "is_legacy_swap_version")]
+    pub swap_version: u32,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/mm2src/mm2_main/src/lp_ordermatch/new_protocol.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch/new_protocol.rs
@@ -1,11 +1,11 @@
+use crate::lp_ordermatch::{AlbOrderedOrderbookPair, H64};
+use crate::swap_versioning::SwapVersion;
 use common::now_sec;
 use compact_uuid::CompactUuid;
 use mm2_number::{BigRational, MmNumber};
 use mm2_rpc::data::legacy::{MatchBy as SuperMatchBy, OrderConfirmationsSettings, TakerAction};
 use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
-
-use crate::lp_ordermatch::{is_legacy_swap_version, legacy_swap_version, AlbOrderedOrderbookPair, H64};
 
 #[derive(Debug, Deserialize, Serialize)]
 #[allow(clippy::large_enum_variant)]
@@ -265,9 +265,9 @@ pub struct TakerRequest {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rel_protocol_info: Option<Vec<u8>>,
-    #[serde(default = "legacy_swap_version")]
-    #[serde(skip_serializing_if = "is_legacy_swap_version")]
-    pub swap_version: u32,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "SwapVersion::is_legacy")]
+    pub swap_version: SwapVersion,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -285,9 +285,9 @@ pub struct MakerReserved {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rel_protocol_info: Option<Vec<u8>>,
-    #[serde(default = "legacy_swap_version")]
-    #[serde(skip_serializing_if = "is_legacy_swap_version")]
-    pub swap_version: u32,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "SwapVersion::is_legacy")]
+    pub swap_version: SwapVersion,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/mm2src/mm2_main/src/lp_ordermatch/new_protocol.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch/new_protocol.rs
@@ -31,6 +31,7 @@ impl From<MakerOrderUpdated> for OrdermatchMessage {
 /// MsgPack compact representation does not work with tagged enums (encoding works, but decoding fails)
 /// This is untagged representation also using compact Uuid representation
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub enum MatchBy {
     Any,
     Orders(HashSet<CompactUuid>),
@@ -250,6 +251,7 @@ impl MakerOrderUpdated {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct TakerRequest {
     pub base: String,
     pub rel: String,
@@ -259,18 +261,16 @@ pub struct TakerRequest {
     pub uuid: CompactUuid,
     pub match_by: MatchBy,
     pub conf_settings: OrderConfirmationsSettings,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_protocol_info: Option<Vec<u8>>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rel_protocol_info: Option<Vec<u8>>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "SwapVersion::is_legacy")]
+    #[serde(default, skip_serializing_if = "SwapVersion::is_legacy")]
     pub swap_version: SwapVersion,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct MakerReserved {
     pub base: String,
     pub rel: String,
@@ -279,14 +279,11 @@ pub struct MakerReserved {
     pub taker_order_uuid: CompactUuid,
     pub maker_order_uuid: CompactUuid,
     pub conf_settings: OrderConfirmationsSettings,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_protocol_info: Option<Vec<u8>>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rel_protocol_info: Option<Vec<u8>>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "SwapVersion::is_legacy")]
+    #[serde(default, skip_serializing_if = "SwapVersion::is_legacy")]
     pub swap_version: SwapVersion,
 }
 
@@ -427,5 +424,157 @@ mod new_protocol_tests {
 
         let new_serialized = rmp_serde::to_vec_named(&new).unwrap();
         let _old_from_new: MakerOrderCreatedV1 = rmp_serde::from_slice(&new_serialized).unwrap();
+    }
+
+    #[test]
+    fn test_old_new_taker_request_rmp() {
+        // Old TakerRequest didn't have swap_version field
+        #[derive(Debug, Eq, Serialize, Deserialize, PartialEq)]
+        struct OldTakerRequest {
+            base: String,
+            rel: String,
+            base_amount: BigRational,
+            rel_amount: BigRational,
+            action: TakerAction,
+            uuid: CompactUuid,
+            match_by: MatchBy,
+            conf_settings: OrderConfirmationsSettings,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            base_protocol_info: Option<Vec<u8>>,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            rel_protocol_info: Option<Vec<u8>>,
+        }
+
+        let old_instance = OldTakerRequest {
+            base: "BTC".to_string(),
+            rel: "ETH".to_string(),
+            base_amount: BigRational::from_integer(1.into()),
+            rel_amount: BigRational::from_integer(50.into()),
+            action: TakerAction::Buy,
+            uuid: CompactUuid::from(Uuid::new_v4()),
+            match_by: MatchBy::Any,
+            conf_settings: OrderConfirmationsSettings::default(),
+            base_protocol_info: Some(vec![1u8; 10]),
+            rel_protocol_info: Some(vec![2u8; 10]),
+        };
+
+        // ------------------------------------------
+        // Step 1: Test Deserialization from Old Format
+        // ------------------------------------------
+        let old_serialized = rmp_serde::to_vec_named(&old_instance).expect("Old MessagePack serialization failed");
+        let new_instance: TakerRequest =
+            rmp_serde::from_slice(&old_serialized).expect("Deserialization into new TakerRequest failed");
+
+        assert_eq!(new_instance.base, old_instance.base);
+        assert_eq!(new_instance.rel, old_instance.rel);
+        assert_eq!(new_instance.base_amount, old_instance.base_amount);
+        assert_eq!(new_instance.rel_amount, old_instance.rel_amount);
+        assert_eq!(new_instance.action, old_instance.action);
+        assert_eq!(new_instance.uuid, old_instance.uuid);
+        assert_eq!(new_instance.match_by, old_instance.match_by);
+        assert_eq!(new_instance.conf_settings, old_instance.conf_settings);
+        assert_eq!(new_instance.base_protocol_info, old_instance.base_protocol_info);
+        assert_eq!(new_instance.rel_protocol_info, old_instance.rel_protocol_info);
+        assert_eq!(new_instance.swap_version, SwapVersion::default()); // Default swap_version
+
+        // ------------------------------------------
+        // Step 2: Test Serialization from New Format to Old Format
+        // ------------------------------------------
+        let new_serialized = rmp_serde::to_vec_named(&new_instance).expect("Serialization of new type failed");
+        let old_from_new: OldTakerRequest =
+            rmp_serde::from_slice(&new_serialized).expect("Old deserialization from new serialization failed");
+
+        assert_eq!(old_from_new.base, new_instance.base);
+        assert_eq!(old_from_new.rel, new_instance.rel);
+        assert_eq!(old_from_new.base_amount, new_instance.base_amount);
+        assert_eq!(old_from_new.rel_amount, new_instance.rel_amount);
+        assert_eq!(old_from_new.action, new_instance.action);
+        assert_eq!(old_from_new.uuid, new_instance.uuid);
+        assert_eq!(old_from_new.match_by, new_instance.match_by);
+        assert_eq!(old_from_new.conf_settings, new_instance.conf_settings);
+        assert_eq!(old_from_new.base_protocol_info, new_instance.base_protocol_info);
+        assert_eq!(old_from_new.rel_protocol_info, new_instance.rel_protocol_info);
+
+        // ------------------------------------------
+        // Step 3: Round-Trip Test of the New Format
+        // ------------------------------------------
+        let rt_serialized = rmp_serde::to_vec_named(&new_instance).expect("Round-trip serialization failed");
+        let round_trip: TakerRequest =
+            rmp_serde::from_slice(&rt_serialized).expect("Round-trip deserialization failed");
+        assert_eq!(round_trip, new_instance);
+    }
+
+    #[test]
+    fn test_old_new_maker_reserved_rmp() {
+        // Old MakerReserved didnt have swap_version field
+        #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+        struct OldMakerReserved {
+            base: String,
+            rel: String,
+            base_amount: BigRational,
+            rel_amount: BigRational,
+            taker_order_uuid: CompactUuid,
+            maker_order_uuid: CompactUuid,
+            conf_settings: OrderConfirmationsSettings,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            base_protocol_info: Option<Vec<u8>>,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            rel_protocol_info: Option<Vec<u8>>,
+        }
+
+        let old_instance = OldMakerReserved {
+            base: "BTC".to_string(),
+            rel: "ETH".to_string(),
+            base_amount: BigRational::from_integer(1.into()),
+            rel_amount: BigRational::from_integer(50.into()),
+            taker_order_uuid: CompactUuid::from(Uuid::new_v4()),
+            maker_order_uuid: CompactUuid::from(Uuid::new_v4()),
+            conf_settings: OrderConfirmationsSettings::default(),
+            base_protocol_info: Some(vec![1u8; 10]),
+            rel_protocol_info: Some(vec![2u8; 10]),
+        };
+
+        // ------------------------------------------
+        // Step 1: Test Deserialization from Old Format
+        // ------------------------------------------
+        let old_serialized = rmp_serde::to_vec_named(&old_instance).expect("Old MessagePack serialization failed");
+        let new_instance: MakerReserved =
+            rmp_serde::from_slice(&old_serialized).expect("Deserialization into new MakerReserved failed");
+
+        assert_eq!(new_instance.base, old_instance.base);
+        assert_eq!(new_instance.rel, old_instance.rel);
+        assert_eq!(new_instance.base_amount, old_instance.base_amount);
+        assert_eq!(new_instance.rel_amount, old_instance.rel_amount);
+        assert_eq!(new_instance.taker_order_uuid, old_instance.taker_order_uuid);
+        assert_eq!(new_instance.maker_order_uuid, old_instance.maker_order_uuid);
+        assert_eq!(new_instance.conf_settings, old_instance.conf_settings);
+        assert_eq!(new_instance.base_protocol_info, old_instance.base_protocol_info);
+        assert_eq!(new_instance.rel_protocol_info, old_instance.rel_protocol_info);
+        assert_eq!(new_instance.swap_version, SwapVersion::default()); // Default swap_version
+
+        // ------------------------------------------
+        // Step 2: Test Serialization from New Format to Old Format
+        // ------------------------------------------
+        let new_serialized = rmp_serde::to_vec_named(&new_instance).expect("Serialization of new type failed");
+        let old_from_new: OldMakerReserved =
+            rmp_serde::from_slice(&new_serialized).expect("Old deserialization from new serialization failed");
+
+        assert_eq!(old_from_new.base, new_instance.base);
+        assert_eq!(old_from_new.rel, new_instance.rel);
+        assert_eq!(old_from_new.base_amount, new_instance.base_amount);
+        assert_eq!(old_from_new.rel_amount, new_instance.rel_amount);
+        assert_eq!(old_from_new.taker_order_uuid, new_instance.taker_order_uuid);
+        assert_eq!(old_from_new.maker_order_uuid, new_instance.maker_order_uuid);
+        assert_eq!(old_from_new.conf_settings, new_instance.conf_settings);
+        assert_eq!(old_from_new.base_protocol_info, new_instance.base_protocol_info);
+        assert_eq!(old_from_new.rel_protocol_info, new_instance.rel_protocol_info);
+
+        // ------------------------------------------
+        // Step 3: Round-Trip Test of the New Format
+        // ------------------------------------------
+        let rt_serialized = rmp_serde::to_vec_named(&new_instance).expect("Round-trip serialization failed");
+        let round_trip: MakerReserved =
+            rmp_serde::from_slice(&rt_serialized).expect("Round-trip deserialization failed");
+        assert_eq!(round_trip, new_instance);
     }
 }

--- a/mm2src/mm2_main/src/lp_swap/maker_swap_v2.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap_v2.rs
@@ -283,7 +283,7 @@ pub struct MakerSwapDbRepr {
     /// Taker's P2P pubkey
     pub taker_p2p_pub: Secp256k1PubkeySerialize,
     /// Swap protocol version
-    pub swap_version: u32,
+    pub swap_version: u8,
 }
 
 impl StateMachineDbRepr for MakerSwapDbRepr {
@@ -398,7 +398,7 @@ pub struct MakerSwapStateMachine<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCo
     /// Determines if the taker payment spend transaction must be confirmed before marking swap as Completed.
     pub require_taker_payment_spend_confirm: bool,
     /// Swap protocol version
-    pub swap_version: u32,
+    pub swap_version: u8,
 }
 
 impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOpsV2>

--- a/mm2src/mm2_main/src/lp_swap/maker_swap_v2.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap_v2.rs
@@ -43,6 +43,7 @@ cfg_native!(
 
 cfg_wasm32!(
     use crate::lp_swap::swap_wasm_db::{MySwapsFiltersTable, SavedSwapTable};
+    use crate::swap_versioning::legacy_swap_version;
 );
 
 // This is needed to have Debug on messages
@@ -283,6 +284,7 @@ pub struct MakerSwapDbRepr {
     /// Taker's P2P pubkey
     pub taker_p2p_pub: Secp256k1PubkeySerialize,
     /// Swap protocol version
+    #[cfg_attr(target_arch = "wasm32", serde(default = "legacy_swap_version"))]
     pub swap_version: u8,
 }
 

--- a/mm2src/mm2_main/src/lp_swap/swap_v2_rpcs.rs
+++ b/mm2src/mm2_main/src/lp_swap/swap_v2_rpcs.rs
@@ -108,6 +108,7 @@ pub(crate) struct MySwapForRpc<T> {
     maker_coin_nota: bool,
     taker_coin_confs: i64,
     taker_coin_nota: bool,
+    swap_version: u32,
 }
 
 impl<T: DeserializeOwned> MySwapForRpc<T> {
@@ -141,6 +142,7 @@ impl<T: DeserializeOwned> MySwapForRpc<T> {
             maker_coin_nota: row.get(12)?,
             taker_coin_confs: row.get(13)?,
             taker_coin_nota: row.get(14)?,
+            swap_version: row.get(15)?,
         })
     }
 }
@@ -218,6 +220,7 @@ pub(super) async fn get_maker_swap_data_for_rpc(
         maker_coin_nota: json_repr.conf_settings.maker_coin_nota,
         taker_coin_confs: json_repr.conf_settings.taker_coin_confs as i64,
         taker_coin_nota: json_repr.conf_settings.taker_coin_nota,
+        swap_version: json_repr.swap_version,
     }))
 }
 
@@ -258,6 +261,7 @@ pub(super) async fn get_taker_swap_data_for_rpc(
         maker_coin_nota: json_repr.conf_settings.maker_coin_nota,
         taker_coin_confs: json_repr.conf_settings.taker_coin_confs as i64,
         taker_coin_nota: json_repr.conf_settings.taker_coin_nota,
+        swap_version: json_repr.swap_version,
     }))
 }
 

--- a/mm2src/mm2_main/src/lp_swap/swap_v2_rpcs.rs
+++ b/mm2src/mm2_main/src/lp_swap/swap_v2_rpcs.rs
@@ -108,7 +108,7 @@ pub(crate) struct MySwapForRpc<T> {
     maker_coin_nota: bool,
     taker_coin_confs: i64,
     taker_coin_nota: bool,
-    swap_version: u32,
+    swap_version: u8,
 }
 
 impl<T: DeserializeOwned> MySwapForRpc<T> {

--- a/mm2src/mm2_main/src/lp_swap/taker_swap_v2.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap_v2.rs
@@ -204,6 +204,7 @@ impl StateMachineStorage for TakerSwapStorage {
                 ":taker_coin_confs": repr.conf_settings.taker_coin_confs,
                 ":taker_coin_nota": repr.conf_settings.taker_coin_nota,
                 ":other_p2p_pub": repr.maker_p2p_pub.to_bytes(),
+                ":swap_version": repr.swap_version,
             };
             insert_new_swap_v2(&ctx, sql_params)?;
             Ok(())
@@ -311,6 +312,8 @@ pub struct TakerSwapDbRepr {
     pub events: Vec<TakerSwapEvent>,
     /// Maker's P2P pubkey
     pub maker_p2p_pub: Secp256k1PubkeySerialize,
+    /// Swap protocol version
+    pub swap_version: u32,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -365,6 +368,7 @@ impl TakerSwapDbRepr {
                         .map_err(|e| SqlError::FromSqlConversionFailure(19, SqlType::Blob, Box::new(e)))
                 })?
                 .into(),
+            swap_version: row.get(20)?,
         })
     }
 }
@@ -425,6 +429,8 @@ pub struct TakerSwapStateMachine<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCo
     pub require_maker_payment_confirm_before_funding_spend: bool,
     /// Determines if the maker payment spend transaction must be confirmed before marking swap as Completed.
     pub require_maker_payment_spend_confirm: bool,
+    /// Swap protocol version
+    pub swap_version: u32,
 }
 
 impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOpsV2>
@@ -480,6 +486,7 @@ impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOp
             events: Vec::new(),
             maker_p2p_pub: self.maker_p2p_pubkey.into(),
             dex_fee_burn: self.dex_fee.burn_amount().unwrap_or_default(),
+            swap_version: self.swap_version,
         }
     }
 
@@ -776,6 +783,7 @@ impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOp
             maker_p2p_pubkey: repr.maker_p2p_pub.into(),
             require_maker_payment_confirm_before_funding_spend: true,
             require_maker_payment_spend_confirm: true,
+            swap_version: repr.swap_version,
         };
         Ok((RestoredMachine::new(machine), current_state))
     }

--- a/mm2src/mm2_main/src/lp_swap/taker_swap_v2.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap_v2.rs
@@ -42,6 +42,7 @@ cfg_native!(
 
 cfg_wasm32!(
     use crate::lp_swap::swap_wasm_db::{MySwapsFiltersTable, SavedSwapTable};
+    use crate::swap_versioning::legacy_swap_version;
 );
 
 // This is needed to have Debug on messages
@@ -313,6 +314,7 @@ pub struct TakerSwapDbRepr {
     /// Maker's P2P pubkey
     pub maker_p2p_pub: Secp256k1PubkeySerialize,
     /// Swap protocol version
+    #[cfg_attr(target_arch = "wasm32", serde(default = "legacy_swap_version"))]
     pub swap_version: u8,
 }
 

--- a/mm2src/mm2_main/src/lp_swap/taker_swap_v2.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap_v2.rs
@@ -313,7 +313,7 @@ pub struct TakerSwapDbRepr {
     /// Maker's P2P pubkey
     pub maker_p2p_pub: Secp256k1PubkeySerialize,
     /// Swap protocol version
-    pub swap_version: u32,
+    pub swap_version: u8,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -430,7 +430,7 @@ pub struct TakerSwapStateMachine<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCo
     /// Determines if the maker payment spend transaction must be confirmed before marking swap as Completed.
     pub require_maker_payment_spend_confirm: bool,
     /// Swap protocol version
-    pub swap_version: u32,
+    pub swap_version: u8,
 }
 
 impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOpsV2>

--- a/mm2src/mm2_main/src/mm2.rs
+++ b/mm2src/mm2_main/src/mm2.rs
@@ -82,6 +82,7 @@ pub mod lp_stats;
 pub mod lp_swap;
 pub mod lp_wallet;
 pub mod rpc;
+mod swap_versioning;
 #[cfg(all(target_arch = "wasm32", test))] mod wasm_tests;
 
 pub const PASSWORD_MAXIMUM_CONSECUTIVE_CHARACTERS: usize = 3;

--- a/mm2src/mm2_main/src/ordermatch_tests.rs
+++ b/mm2src/mm2_main/src/ordermatch_tests.rs
@@ -20,8 +20,6 @@ use std::collections::HashSet;
 use std::iter::{self, FromIterator};
 use std::sync::Mutex;
 
-const LEGACY_SWAP_V: u32 = 1;
-
 #[test]
 fn test_match_maker_order_and_taker_request() {
     let maker = MakerOrder {
@@ -41,7 +39,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     let request = TakerRequest {
@@ -57,7 +55,7 @@ fn test_match_maker_order_and_taker_request() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     let actual = maker.match_with_request(&request);
@@ -81,7 +79,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     let request = TakerRequest {
@@ -97,7 +95,7 @@ fn test_match_maker_order_and_taker_request() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     let actual = maker.match_with_request(&request);
@@ -121,7 +119,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     let request = TakerRequest {
@@ -137,7 +135,7 @@ fn test_match_maker_order_and_taker_request() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     let actual = maker.match_with_request(&request);
@@ -161,7 +159,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     let request = TakerRequest {
@@ -177,7 +175,7 @@ fn test_match_maker_order_and_taker_request() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     let actual = maker.match_with_request(&request);
@@ -201,7 +199,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     let request = TakerRequest {
@@ -217,7 +215,7 @@ fn test_match_maker_order_and_taker_request() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     let actual = maker.match_with_request(&request);
@@ -241,7 +239,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     let request = TakerRequest {
@@ -257,7 +255,7 @@ fn test_match_maker_order_and_taker_request() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     let actual = maker.match_with_request(&request);
@@ -283,7 +281,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
     let request = TakerRequest {
         base: "KMD".to_owned(),
@@ -298,7 +296,7 @@ fn test_match_maker_order_and_taker_request() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
     let actual = maker.match_with_request(&request);
     assert_eq!(actual, OrderMatchResult::NotMatched);
@@ -325,7 +323,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
     let request = TakerRequest {
         base: "REL".to_owned(),
@@ -340,7 +338,7 @@ fn test_match_maker_order_and_taker_request() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
     let actual = maker.match_with_request(&request);
     let expected_base_amount = MmNumber::from(3);
@@ -398,7 +396,7 @@ fn test_maker_order_available_amount() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
     maker.matches.insert(new_uuid(), MakerMatch {
         request: TakerRequest {
@@ -414,7 +412,7 @@ fn test_maker_order_available_amount() {
             conf_settings: None,
             base_protocol_info: None,
             rel_protocol_info: None,
-            swap_version: LEGACY_SWAP_V,
+            swap_version: legacy_swap_version(),
         },
         reserved: MakerReserved {
             base: "BASE".into(),
@@ -428,7 +426,7 @@ fn test_maker_order_available_amount() {
             conf_settings: None,
             base_protocol_info: None,
             rel_protocol_info: None,
-            swap_version: LEGACY_SWAP_V,
+            swap_version: legacy_swap_version(),
         },
         connect: None,
         connected: None,
@@ -448,7 +446,7 @@ fn test_maker_order_available_amount() {
             conf_settings: None,
             base_protocol_info: None,
             rel_protocol_info: None,
-            swap_version: LEGACY_SWAP_V,
+            swap_version: legacy_swap_version(),
         },
         reserved: MakerReserved {
             base: "BASE".into(),
@@ -462,7 +460,7 @@ fn test_maker_order_available_amount() {
             conf_settings: None,
             base_protocol_info: None,
             rel_protocol_info: None,
-            swap_version: LEGACY_SWAP_V,
+            swap_version: legacy_swap_version(),
         },
         connect: None,
         connected: None,
@@ -491,7 +489,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     let order = TakerOrder {
@@ -519,7 +517,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -537,7 +535,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     let order = TakerOrder {
@@ -565,7 +563,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -583,7 +581,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     let order = TakerOrder {
@@ -611,7 +609,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -629,7 +627,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     let order = TakerOrder {
@@ -657,7 +655,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     assert_eq!(MatchReservedResult::NotMatched, order.match_reserved(&reserved));
@@ -675,7 +673,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     let order = TakerOrder {
@@ -703,7 +701,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -721,7 +719,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     let order = TakerOrder {
@@ -749,7 +747,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -767,7 +765,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     let order = TakerOrder {
@@ -795,7 +793,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -813,7 +811,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     let order = TakerOrder {
@@ -841,7 +839,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     assert_eq!(MatchReservedResult::NotMatched, order.match_reserved(&reserved));
@@ -863,7 +861,7 @@ fn test_taker_match_reserved() {
             conf_settings: None,
             base_protocol_info: None,
             rel_protocol_info: None,
-            swap_version: LEGACY_SWAP_V,
+            swap_version: legacy_swap_version(),
         },
         matches: HashMap::new(),
         order_type: OrderType::GoodTillCancelled,
@@ -887,7 +885,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -908,7 +906,7 @@ fn test_taker_order_cancellable() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     let order = TakerOrder {
@@ -939,7 +937,7 @@ fn test_taker_order_cancellable() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     let mut order = TakerOrder {
@@ -969,7 +967,7 @@ fn test_taker_order_cancellable() {
             conf_settings: None,
             base_protocol_info: None,
             rel_protocol_info: None,
-            swap_version: LEGACY_SWAP_V,
+            swap_version: legacy_swap_version(),
         },
         connect: TakerConnect {
             sender_pubkey: H256Json::default(),
@@ -1018,7 +1016,7 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
             base_orderbook_ticker: None,
             rel_orderbook_ticker: None,
             p2p_privkey: None,
-            swap_version: LEGACY_SWAP_V,
+            swap_version: legacy_swap_version(),
         },
         None,
     );
@@ -1041,7 +1039,7 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
             base_orderbook_ticker: None,
             rel_orderbook_ticker: None,
             p2p_privkey: None,
-            swap_version: LEGACY_SWAP_V,
+            swap_version: legacy_swap_version(),
         },
         None,
     );
@@ -1064,7 +1062,7 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
             base_orderbook_ticker: None,
             rel_orderbook_ticker: None,
             p2p_privkey: None,
-            swap_version: LEGACY_SWAP_V,
+            swap_version: legacy_swap_version(),
         },
         None,
     );
@@ -1084,7 +1082,7 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
             conf_settings: None,
             base_protocol_info: None,
             rel_protocol_info: None,
-            swap_version: LEGACY_SWAP_V,
+            swap_version: legacy_swap_version(),
         },
         order_type: OrderType::GoodTillCancelled,
         min_volume: 0.into(),
@@ -1187,7 +1185,7 @@ fn test_taker_order_match_by() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     let mut order = TakerOrder {
@@ -1215,7 +1213,7 @@ fn test_taker_order_match_by() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     assert_eq!(MatchReservedResult::NotMatched, order.match_reserved(&reserved));
@@ -1256,7 +1254,7 @@ fn test_maker_order_was_updated() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
     let mut update_msg = MakerOrderUpdated::new(maker_order.uuid);
     update_msg.with_new_price(BigRational::from_integer(2.into()));
@@ -3266,7 +3264,7 @@ fn test_maker_order_balance_loops() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     let morty_order = MakerOrder {
@@ -3286,7 +3284,7 @@ fn test_maker_order_balance_loops() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     assert!(!maker_orders_ctx.balance_loop_exists(rick_ticker));
@@ -3319,7 +3317,7 @@ fn test_maker_order_balance_loops() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: LEGACY_SWAP_V,
+        swap_version: legacy_swap_version(),
     };
 
     maker_orders_ctx.add_order(ctx.weak(), rick_order_2.clone(), None);

--- a/mm2src/mm2_main/src/ordermatch_tests.rs
+++ b/mm2src/mm2_main/src/ordermatch_tests.rs
@@ -20,6 +20,8 @@ use std::collections::HashSet;
 use std::iter::{self, FromIterator};
 use std::sync::Mutex;
 
+const LEGACY_SWAP_V: u32 = 1;
+
 #[test]
 fn test_match_maker_order_and_taker_request() {
     let maker = MakerOrder {
@@ -39,6 +41,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     let request = TakerRequest {
@@ -54,6 +57,7 @@ fn test_match_maker_order_and_taker_request() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     let actual = maker.match_with_request(&request);
@@ -77,6 +81,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     let request = TakerRequest {
@@ -92,6 +97,7 @@ fn test_match_maker_order_and_taker_request() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     let actual = maker.match_with_request(&request);
@@ -115,6 +121,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     let request = TakerRequest {
@@ -130,6 +137,7 @@ fn test_match_maker_order_and_taker_request() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     let actual = maker.match_with_request(&request);
@@ -153,6 +161,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     let request = TakerRequest {
@@ -168,6 +177,7 @@ fn test_match_maker_order_and_taker_request() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     let actual = maker.match_with_request(&request);
@@ -191,6 +201,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     let request = TakerRequest {
@@ -206,6 +217,7 @@ fn test_match_maker_order_and_taker_request() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     let actual = maker.match_with_request(&request);
@@ -229,6 +241,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     let request = TakerRequest {
@@ -244,6 +257,7 @@ fn test_match_maker_order_and_taker_request() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     let actual = maker.match_with_request(&request);
@@ -269,6 +283,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        swap_version: LEGACY_SWAP_V,
     };
     let request = TakerRequest {
         base: "KMD".to_owned(),
@@ -283,6 +298,7 @@ fn test_match_maker_order_and_taker_request() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
     let actual = maker.match_with_request(&request);
     assert_eq!(actual, OrderMatchResult::NotMatched);
@@ -309,6 +325,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        swap_version: LEGACY_SWAP_V,
     };
     let request = TakerRequest {
         base: "REL".to_owned(),
@@ -323,6 +340,7 @@ fn test_match_maker_order_and_taker_request() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
     let actual = maker.match_with_request(&request);
     let expected_base_amount = MmNumber::from(3);
@@ -380,6 +398,7 @@ fn test_maker_order_available_amount() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        swap_version: LEGACY_SWAP_V,
     };
     maker.matches.insert(new_uuid(), MakerMatch {
         request: TakerRequest {
@@ -395,6 +414,7 @@ fn test_maker_order_available_amount() {
             conf_settings: None,
             base_protocol_info: None,
             rel_protocol_info: None,
+            swap_version: LEGACY_SWAP_V,
         },
         reserved: MakerReserved {
             base: "BASE".into(),
@@ -408,6 +428,7 @@ fn test_maker_order_available_amount() {
             conf_settings: None,
             base_protocol_info: None,
             rel_protocol_info: None,
+            swap_version: LEGACY_SWAP_V,
         },
         connect: None,
         connected: None,
@@ -427,6 +448,7 @@ fn test_maker_order_available_amount() {
             conf_settings: None,
             base_protocol_info: None,
             rel_protocol_info: None,
+            swap_version: LEGACY_SWAP_V,
         },
         reserved: MakerReserved {
             base: "BASE".into(),
@@ -440,6 +462,7 @@ fn test_maker_order_available_amount() {
             conf_settings: None,
             base_protocol_info: None,
             rel_protocol_info: None,
+            swap_version: LEGACY_SWAP_V,
         },
         connect: None,
         connected: None,
@@ -468,6 +491,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     let order = TakerOrder {
@@ -495,6 +519,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -512,6 +537,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     let order = TakerOrder {
@@ -539,6 +565,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -556,6 +583,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     let order = TakerOrder {
@@ -583,6 +611,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -600,6 +629,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     let order = TakerOrder {
@@ -627,6 +657,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     assert_eq!(MatchReservedResult::NotMatched, order.match_reserved(&reserved));
@@ -644,6 +675,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     let order = TakerOrder {
@@ -671,6 +703,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -688,6 +721,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     let order = TakerOrder {
@@ -715,6 +749,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -732,6 +767,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     let order = TakerOrder {
@@ -759,6 +795,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -776,6 +813,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     let order = TakerOrder {
@@ -803,6 +841,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     assert_eq!(MatchReservedResult::NotMatched, order.match_reserved(&reserved));
@@ -824,6 +863,7 @@ fn test_taker_match_reserved() {
             conf_settings: None,
             base_protocol_info: None,
             rel_protocol_info: None,
+            swap_version: LEGACY_SWAP_V,
         },
         matches: HashMap::new(),
         order_type: OrderType::GoodTillCancelled,
@@ -847,6 +887,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -867,6 +908,7 @@ fn test_taker_order_cancellable() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     let order = TakerOrder {
@@ -897,6 +939,7 @@ fn test_taker_order_cancellable() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     let mut order = TakerOrder {
@@ -926,6 +969,7 @@ fn test_taker_order_cancellable() {
             conf_settings: None,
             base_protocol_info: None,
             rel_protocol_info: None,
+            swap_version: LEGACY_SWAP_V,
         },
         connect: TakerConnect {
             sender_pubkey: H256Json::default(),
@@ -974,6 +1018,7 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
             base_orderbook_ticker: None,
             rel_orderbook_ticker: None,
             p2p_privkey: None,
+            swap_version: LEGACY_SWAP_V,
         },
         None,
     );
@@ -996,6 +1041,7 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
             base_orderbook_ticker: None,
             rel_orderbook_ticker: None,
             p2p_privkey: None,
+            swap_version: LEGACY_SWAP_V,
         },
         None,
     );
@@ -1018,6 +1064,7 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
             base_orderbook_ticker: None,
             rel_orderbook_ticker: None,
             p2p_privkey: None,
+            swap_version: LEGACY_SWAP_V,
         },
         None,
     );
@@ -1037,6 +1084,7 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
             conf_settings: None,
             base_protocol_info: None,
             rel_protocol_info: None,
+            swap_version: LEGACY_SWAP_V,
         },
         order_type: OrderType::GoodTillCancelled,
         min_volume: 0.into(),
@@ -1139,6 +1187,7 @@ fn test_taker_order_match_by() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     let mut order = TakerOrder {
@@ -1166,6 +1215,7 @@ fn test_taker_order_match_by() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     assert_eq!(MatchReservedResult::NotMatched, order.match_reserved(&reserved));
@@ -1206,6 +1256,7 @@ fn test_maker_order_was_updated() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        swap_version: LEGACY_SWAP_V,
     };
     let mut update_msg = MakerOrderUpdated::new(maker_order.uuid);
     update_msg.with_new_price(BigRational::from_integer(2.into()));
@@ -3215,6 +3266,7 @@ fn test_maker_order_balance_loops() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     let morty_order = MakerOrder {
@@ -3234,6 +3286,7 @@ fn test_maker_order_balance_loops() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     assert!(!maker_orders_ctx.balance_loop_exists(rick_ticker));
@@ -3266,6 +3319,7 @@ fn test_maker_order_balance_loops() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        swap_version: LEGACY_SWAP_V,
     };
 
     maker_orders_ctx.add_order(ctx.weak(), rick_order_2.clone(), None);

--- a/mm2src/mm2_main/src/ordermatch_tests.rs
+++ b/mm2src/mm2_main/src/ordermatch_tests.rs
@@ -39,7 +39,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     let request = TakerRequest {
@@ -55,7 +55,7 @@ fn test_match_maker_order_and_taker_request() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     let actual = maker.match_with_request(&request);
@@ -79,7 +79,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     let request = TakerRequest {
@@ -95,7 +95,7 @@ fn test_match_maker_order_and_taker_request() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     let actual = maker.match_with_request(&request);
@@ -119,7 +119,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     let request = TakerRequest {
@@ -135,7 +135,7 @@ fn test_match_maker_order_and_taker_request() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     let actual = maker.match_with_request(&request);
@@ -159,7 +159,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     let request = TakerRequest {
@@ -175,7 +175,7 @@ fn test_match_maker_order_and_taker_request() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     let actual = maker.match_with_request(&request);
@@ -199,7 +199,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     let request = TakerRequest {
@@ -215,7 +215,7 @@ fn test_match_maker_order_and_taker_request() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     let actual = maker.match_with_request(&request);
@@ -239,7 +239,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     let request = TakerRequest {
@@ -255,7 +255,7 @@ fn test_match_maker_order_and_taker_request() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     let actual = maker.match_with_request(&request);
@@ -281,7 +281,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
     let request = TakerRequest {
         base: "KMD".to_owned(),
@@ -296,7 +296,7 @@ fn test_match_maker_order_and_taker_request() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
     let actual = maker.match_with_request(&request);
     assert_eq!(actual, OrderMatchResult::NotMatched);
@@ -323,7 +323,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
     let request = TakerRequest {
         base: "REL".to_owned(),
@@ -338,7 +338,7 @@ fn test_match_maker_order_and_taker_request() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
     let actual = maker.match_with_request(&request);
     let expected_base_amount = MmNumber::from(3);
@@ -396,7 +396,7 @@ fn test_maker_order_available_amount() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
     maker.matches.insert(new_uuid(), MakerMatch {
         request: TakerRequest {
@@ -412,7 +412,7 @@ fn test_maker_order_available_amount() {
             conf_settings: None,
             base_protocol_info: None,
             rel_protocol_info: None,
-            swap_version: legacy_swap_version(),
+            swap_version: SwapVersion::default(),
         },
         reserved: MakerReserved {
             base: "BASE".into(),
@@ -426,7 +426,7 @@ fn test_maker_order_available_amount() {
             conf_settings: None,
             base_protocol_info: None,
             rel_protocol_info: None,
-            swap_version: legacy_swap_version(),
+            swap_version: SwapVersion::default(),
         },
         connect: None,
         connected: None,
@@ -446,7 +446,7 @@ fn test_maker_order_available_amount() {
             conf_settings: None,
             base_protocol_info: None,
             rel_protocol_info: None,
-            swap_version: legacy_swap_version(),
+            swap_version: SwapVersion::default(),
         },
         reserved: MakerReserved {
             base: "BASE".into(),
@@ -460,7 +460,7 @@ fn test_maker_order_available_amount() {
             conf_settings: None,
             base_protocol_info: None,
             rel_protocol_info: None,
-            swap_version: legacy_swap_version(),
+            swap_version: SwapVersion::default(),
         },
         connect: None,
         connected: None,
@@ -489,7 +489,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     let order = TakerOrder {
@@ -517,7 +517,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -535,7 +535,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     let order = TakerOrder {
@@ -563,7 +563,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -581,7 +581,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     let order = TakerOrder {
@@ -609,7 +609,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -627,7 +627,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     let order = TakerOrder {
@@ -655,7 +655,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     assert_eq!(MatchReservedResult::NotMatched, order.match_reserved(&reserved));
@@ -673,7 +673,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     let order = TakerOrder {
@@ -701,7 +701,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -719,7 +719,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     let order = TakerOrder {
@@ -747,7 +747,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -765,7 +765,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     let order = TakerOrder {
@@ -793,7 +793,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -811,7 +811,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     let order = TakerOrder {
@@ -839,7 +839,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     assert_eq!(MatchReservedResult::NotMatched, order.match_reserved(&reserved));
@@ -861,7 +861,7 @@ fn test_taker_match_reserved() {
             conf_settings: None,
             base_protocol_info: None,
             rel_protocol_info: None,
-            swap_version: legacy_swap_version(),
+            swap_version: SwapVersion::default(),
         },
         matches: HashMap::new(),
         order_type: OrderType::GoodTillCancelled,
@@ -885,7 +885,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -906,7 +906,7 @@ fn test_taker_order_cancellable() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     let order = TakerOrder {
@@ -937,7 +937,7 @@ fn test_taker_order_cancellable() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     let mut order = TakerOrder {
@@ -967,7 +967,7 @@ fn test_taker_order_cancellable() {
             conf_settings: None,
             base_protocol_info: None,
             rel_protocol_info: None,
-            swap_version: legacy_swap_version(),
+            swap_version: SwapVersion::default(),
         },
         connect: TakerConnect {
             sender_pubkey: H256Json::default(),
@@ -1016,7 +1016,7 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
             base_orderbook_ticker: None,
             rel_orderbook_ticker: None,
             p2p_privkey: None,
-            swap_version: legacy_swap_version(),
+            swap_version: SwapVersion::default(),
         },
         None,
     );
@@ -1039,7 +1039,7 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
             base_orderbook_ticker: None,
             rel_orderbook_ticker: None,
             p2p_privkey: None,
-            swap_version: legacy_swap_version(),
+            swap_version: SwapVersion::default(),
         },
         None,
     );
@@ -1062,7 +1062,7 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
             base_orderbook_ticker: None,
             rel_orderbook_ticker: None,
             p2p_privkey: None,
-            swap_version: legacy_swap_version(),
+            swap_version: SwapVersion::default(),
         },
         None,
     );
@@ -1082,7 +1082,7 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
             conf_settings: None,
             base_protocol_info: None,
             rel_protocol_info: None,
-            swap_version: legacy_swap_version(),
+            swap_version: SwapVersion::default(),
         },
         order_type: OrderType::GoodTillCancelled,
         min_volume: 0.into(),
@@ -1185,7 +1185,7 @@ fn test_taker_order_match_by() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     let mut order = TakerOrder {
@@ -1213,7 +1213,7 @@ fn test_taker_order_match_by() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     assert_eq!(MatchReservedResult::NotMatched, order.match_reserved(&reserved));
@@ -1254,7 +1254,7 @@ fn test_maker_order_was_updated() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
     let mut update_msg = MakerOrderUpdated::new(maker_order.uuid);
     update_msg.with_new_price(BigRational::from_integer(2.into()));
@@ -3264,7 +3264,7 @@ fn test_maker_order_balance_loops() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     let morty_order = MakerOrder {
@@ -3284,7 +3284,7 @@ fn test_maker_order_balance_loops() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     assert!(!maker_orders_ctx.balance_loop_exists(rick_ticker));
@@ -3317,7 +3317,7 @@ fn test_maker_order_balance_loops() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        swap_version: legacy_swap_version(),
+        swap_version: SwapVersion::default(),
     };
 
     maker_orders_ctx.add_order(ctx.weak(), rick_order_2.clone(), None);

--- a/mm2src/mm2_main/src/swap_versioning.rs
+++ b/mm2src/mm2_main/src/swap_versioning.rs
@@ -4,7 +4,7 @@
 
 #[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct SwapVersion {
-    pub version: u32,
+    pub version: u8,
 }
 
 impl Default for SwapVersion {
@@ -19,8 +19,8 @@ impl SwapVersion {
     pub(crate) const fn is_legacy(&self) -> bool { self.version == legacy_swap_version() }
 }
 
-impl From<u32> for SwapVersion {
-    fn from(version: u32) -> Self { Self { version } }
+impl From<u8> for SwapVersion {
+    fn from(version: u8) -> Self { Self { version } }
 }
 
-pub(crate) const fn legacy_swap_version() -> u32 { 1 }
+pub(crate) const fn legacy_swap_version() -> u8 { 1 }

--- a/mm2src/mm2_main/src/swap_versioning.rs
+++ b/mm2src/mm2_main/src/swap_versioning.rs
@@ -16,7 +16,7 @@ impl Default for SwapVersion {
 }
 
 impl SwapVersion {
-    pub(crate) fn is_legacy(&self) -> bool { self.version == legacy_swap_version() }
+    pub(crate) const fn is_legacy(&self) -> bool { self.version == legacy_swap_version() }
 }
 
 impl From<u32> for SwapVersion {

--- a/mm2src/mm2_main/src/swap_versioning.rs
+++ b/mm2src/mm2_main/src/swap_versioning.rs
@@ -1,0 +1,26 @@
+//! Swap Versioning Module
+//!
+//! This module provides a dedicated type for handling swap versioning
+
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct SwapVersion {
+    pub version: u32,
+}
+
+impl Default for SwapVersion {
+    fn default() -> Self {
+        Self {
+            version: legacy_swap_version(),
+        }
+    }
+}
+
+impl SwapVersion {
+    pub(crate) fn is_legacy(&self) -> bool { self.version == legacy_swap_version() }
+}
+
+impl From<u32> for SwapVersion {
+    fn from(version: u32) -> Self { Self { version } }
+}
+
+pub(crate) const fn legacy_swap_version() -> u32 { 1 }


### PR DESCRIPTION
ref issue https://github.com/KomodoPlatform/komodo-defi-framework/issues/2337

ordermatch structs which got swap_version field:
- TakerOrderBuilder
- MakerOrderBuilder
- MakerOrder
- MakerReserved
- TakerRequest

swap structs. if swap started swap_version will be saved in db:
- MySwapForRpc
- TakerSwapStateMachine
- MakerSwapStateMachine
- TakerSwapDbRepr
- MakerSwapDbRepr

swap version 2 is tpu v2 protocol
legacy swap protocol is 1 version

When Taker or Maker **build** order, the value `const SWAP_VERSION: u32 = 2;` is used for order **Builder**. 
However in `create_maker_order`/`lp_auto_buy` if user didnt use `ctx.use_trading_proto_v2()` in config we set legacy protocol version to the order. 