### PR TITLE
fix(eth-tpu): remove state from funding validation

### DIFF
--- a/mm2src/coins/coin_errors.rs
+++ b/mm2src/coins/coin_errors.rs
@@ -107,7 +107,6 @@ impl From<HtlcParamsError> for ValidatePaymentError {
 impl From<ValidatePaymentV2Err> for ValidatePaymentError {
     fn from(err: ValidatePaymentV2Err) -> Self {
         match err {
-            ValidatePaymentV2Err::UnexpectedPaymentState(e) => ValidatePaymentError::UnexpectedPaymentState(e),
             ValidatePaymentV2Err::WrongPaymentTx(e) => ValidatePaymentError::WrongPaymentTx(e),
         }
     }

--- a/mm2src/coins/coin_errors.rs
+++ b/mm2src/coins/coin_errors.rs
@@ -89,7 +89,7 @@ impl From<PaymentStatusErr> for ValidatePaymentError {
     fn from(err: PaymentStatusErr) -> Self {
         match err {
             PaymentStatusErr::Transport(e) => Self::Transport(e),
-            PaymentStatusErr::ABIError(e) | PaymentStatusErr::Internal(e) => Self::InternalError(e),
+            PaymentStatusErr::ABIError(e) => Self::InternalError(e),
             PaymentStatusErr::InvalidData(e) => Self::InvalidData(e),
         }
     }

--- a/mm2src/coins/coin_errors.rs
+++ b/mm2src/coins/coin_errors.rs
@@ -1,4 +1,4 @@
-use crate::eth::eth_swap_v2::{PaymentStatusErr, PrepareTxDataError, ValidatePaymentV2Err};
+use crate::eth::eth_swap_v2::{PrepareTxDataError, ValidatePaymentV2Err};
 use crate::eth::nft_swap_v2::errors::{Erc721FunctionError, HtlcParamsError};
 use crate::eth::{EthAssocTypesError, EthNftAssocTypesError, Web3RpcError};
 use crate::{utxo::rpc_clients::UtxoRpcError, NumConversError, UnexpectedDerivationMethod};
@@ -81,16 +81,6 @@ impl From<Web3RpcError> for ValidatePaymentError {
             Web3RpcError::NftProtocolNotSupported => {
                 ValidatePaymentError::ProtocolNotSupported("Nft protocol is not supported".to_string())
             },
-        }
-    }
-}
-
-impl From<PaymentStatusErr> for ValidatePaymentError {
-    fn from(err: PaymentStatusErr) -> Self {
-        match err {
-            PaymentStatusErr::Transport(e) => Self::Transport(e),
-            PaymentStatusErr::ABIError(e) => Self::InternalError(e),
-            PaymentStatusErr::InvalidData(e) => Self::InvalidData(e),
         }
     }
 }

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -4683,6 +4683,30 @@ impl EthCoin {
         self.call(request, Some(BlockId::Number(block_number))).await
     }
 
+    /// Calls a contract function by name, returns the decoded output tokens
+    pub(crate) async fn call_contract_function(
+        &self,
+        contract_abi: &Contract,
+        function_name: &str,
+        args: &[Token],
+        contract_addr: Address,
+        block_number: BlockNumber,
+    ) -> Result<Vec<Token>, Web3RpcError> {
+        let function = contract_abi.function(function_name)?;
+        let data = function.encode_input(args)?;
+        let bytes = self
+            .call_request(
+                self.my_addr().await,
+                contract_addr,
+                None,
+                Some(data.into()),
+                block_number,
+            )
+            .await?;
+        let decoded_tokens = function.decode_output(&bytes.0)?;
+        Ok(decoded_tokens)
+    }
+
     pub fn allowance(&self, spender: Address) -> Web3RpcFut<U256> {
         let coin = self.clone();
         let fut = async move {

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -4686,13 +4686,11 @@ impl EthCoin {
     /// Calls a contract function by name, returns the decoded output tokens
     pub(crate) async fn call_contract_function(
         &self,
-        contract_abi: &Contract,
-        function_name: &str,
+        function: &Function,
         args: &[Token],
         contract_addr: Address,
         block_number: BlockNumber,
     ) -> Result<Vec<Token>, Web3RpcError> {
-        let function = contract_abi.function(function_name)?;
         let data = function.encode_input(args)?;
         let bytes = self
             .call_request(

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -4683,28 +4683,6 @@ impl EthCoin {
         self.call(request, Some(BlockId::Number(block_number))).await
     }
 
-    /// Calls a contract function by name, returns the decoded output tokens
-    pub(crate) async fn call_contract_function(
-        &self,
-        function: &Function,
-        args: &[Token],
-        contract_addr: Address,
-        block_number: BlockNumber,
-    ) -> Result<Vec<Token>, Web3RpcError> {
-        let data = function.encode_input(args)?;
-        let bytes = self
-            .call_request(
-                self.my_addr().await,
-                contract_addr,
-                None,
-                Some(data.into()),
-                block_number,
-            )
-            .await?;
-        let decoded_tokens = function.decode_output(&bytes.0)?;
-        Ok(decoded_tokens)
-    }
-
     pub fn allowance(&self, spender: Address) -> Web3RpcFut<U256> {
         let coin = self.clone();
         let fut = async move {

--- a/mm2src/coins/eth/eth_swap_v2/eth_maker_swap_v2.rs
+++ b/mm2src/coins/eth/eth_swap_v2/eth_maker_swap_v2.rs
@@ -2,7 +2,7 @@ use super::{validate_amount, validate_from_to_and_status, EthPaymentType, Paymen
             ZERO_VALUE};
 use crate::coin_errors::{ValidatePaymentError, ValidatePaymentResult};
 use crate::eth::{decode_contract_call, get_function_input_data, wei_from_big_decimal, EthCoin, EthCoinType,
-                 MakerPaymentStateV2, SignedEthTx, MAKER_SWAP_V2};
+                 SignedEthTx, MAKER_SWAP_V2};
 use crate::{ParseCoinAssocTypes, RefundMakerPaymentSecretArgs, RefundMakerPaymentTimelockArgs, SendMakerPaymentArgs,
             SpendMakerPaymentArgs, SwapTxTypeWithSecretHash, TransactionErr, ValidateMakerPaymentArgs};
 use ethabi::{Function, Token};
@@ -13,19 +13,10 @@ use futures::compat::Future01CompatExt;
 use mm2_err_handle::mm_error::MmError;
 use mm2_err_handle::prelude::MapToMmResult;
 use std::convert::TryInto;
-use web3::types::{BlockNumber, TransactionId};
+use web3::types::TransactionId;
 
 const ETH_MAKER_PAYMENT: &str = "ethMakerPayment";
 const ERC20_MAKER_PAYMENT: &str = "erc20MakerPayment";
-
-/// state index for `MakerPayment` structure from `EtomicSwapMakerV2.sol`
-///
-///     struct MakerPayment {
-///         bytes20 paymentHash;
-///         uint32 paymentLockTime;
-///         MakerPaymentState state;
-///     }
-const MAKER_PAYMENT_STATE_INDEX: usize = 2;
 
 struct MakerPaymentArgs<'a> {
     taker_address: Address,
@@ -136,16 +127,6 @@ impl EthCoin {
         let maker_secret_hash = args.maker_secret_hash.try_into()?;
         validate_amount(&args.amount).map_to_mm(ValidatePaymentError::InternalError)?;
         let swap_id = self.etomic_swap_id_v2(args.time_lock, args.maker_secret_hash);
-        let maker_status = self
-            .payment_status_v2(
-                maker_swap_v2_contract,
-                Token::FixedBytes(swap_id.clone()),
-                &MAKER_SWAP_V2,
-                EthPaymentType::MakerPayments,
-                MAKER_PAYMENT_STATE_INDEX,
-                BlockNumber::Latest,
-            )
-            .await?;
 
         let tx_from_rpc = self
             .transaction(TransactionId::Hash(args.maker_payment_tx.tx_hash()))
@@ -157,13 +138,7 @@ impl EthCoin {
             ))
         })?;
         let maker_address = public_to_address(args.maker_pub);
-        validate_from_to_and_status(
-            tx_from_rpc,
-            maker_address,
-            maker_swap_v2_contract,
-            maker_status,
-            MakerPaymentStateV2::PaymentSent as u8,
-        )?;
+        validate_from_to_and_status(tx_from_rpc, maker_address, maker_swap_v2_contract)?;
 
         let validation_args = {
             let amount = wei_from_big_decimal(&args.amount, self.decimals)?;

--- a/mm2src/coins/eth/eth_swap_v2/eth_maker_swap_v2.rs
+++ b/mm2src/coins/eth/eth_swap_v2/eth_maker_swap_v2.rs
@@ -1,5 +1,4 @@
-use super::{validate_amount, validate_from_to_and_status, EthPaymentType, PaymentMethod, PrepareTxDataError,
-            ZERO_VALUE};
+use super::{validate_amount, validate_from_to_addresses, EthPaymentType, PaymentMethod, PrepareTxDataError, ZERO_VALUE};
 use crate::coin_errors::{ValidatePaymentError, ValidatePaymentResult};
 use crate::eth::{decode_contract_call, get_function_input_data, wei_from_big_decimal, EthCoin, EthCoinType,
                  SignedEthTx, MAKER_SWAP_V2};
@@ -138,7 +137,7 @@ impl EthCoin {
             ))
         })?;
         let maker_address = public_to_address(args.maker_pub);
-        validate_from_to_and_status(tx_from_rpc, maker_address, maker_swap_v2_contract)?;
+        validate_from_to_addresses(tx_from_rpc, maker_address, maker_swap_v2_contract)?;
 
         let validation_args = {
             let amount = wei_from_big_decimal(&args.amount, self.decimals)?;

--- a/mm2src/coins/eth/eth_swap_v2/eth_taker_swap_v2.rs
+++ b/mm2src/coins/eth/eth_swap_v2/eth_taker_swap_v2.rs
@@ -371,7 +371,7 @@ impl EthCoin {
                 &TAKER_SWAP_V2,
                 EthPaymentType::TakerPayments,
                 TAKER_PAYMENT_STATE_INDEX,
-                // Use the Latest confirmed block to ensure smart contract has the correct taker payment state (TakerApproved)
+                // Use the latest confirmed block to ensure smart contract has the correct taker payment state (`TakerPaymentStateV2::TakerApproved`)
                 // before the maker sends the spend transaction, which reveals the maker's secret.
                 // TPU state machine waits confirmations only for send payment tx, not approve tx.
                 BlockNumber::Latest,
@@ -712,8 +712,7 @@ impl EthCoin {
         state_index: usize,
         block_number: BlockNumber,
     ) -> Result<U256, PaymentStatusErr> {
-        let function_name = payment_type.as_str();
-        let function = contract_abi.function(function_name)?;
+        let function = contract_abi.function(payment_type.as_str())?;
         let data = function.encode_input(&[swap_id])?;
         let bytes = self
             .call_request(

--- a/mm2src/coins/eth/eth_swap_v2/eth_taker_swap_v2.rs
+++ b/mm2src/coins/eth/eth_swap_v2/eth_taker_swap_v2.rs
@@ -1,4 +1,4 @@
-use super::{check_decoded_length, extract_id_from_tx_data, validate_amount, validate_from_to_and_status,
+use super::{check_decoded_length, extract_id_from_tx_data, validate_amount, validate_from_to_addresses,
             validate_payment_state, EthPaymentType, PaymentMethod, PrepareTxDataError, SpendTxSearchParams, ZERO_VALUE};
 use crate::eth::{decode_contract_call, get_function_input_data, wei_from_big_decimal, EthCoin, EthCoinType,
                  ParseCoinAssocTypes, RefundFundingSecretArgs, RefundTakerPaymentArgs, SendTakerFundingArgs,
@@ -165,7 +165,7 @@ impl EthCoin {
             ))
         })?;
         let taker_address = public_to_address(args.taker_pub);
-        validate_from_to_and_status(tx_from_rpc, taker_address, taker_swap_v2_contract)?;
+        validate_from_to_addresses(tx_from_rpc, taker_address, taker_swap_v2_contract)?;
 
         let validation_args = {
             let dex_fee = wei_from_big_decimal(&args.dex_fee.fee_amount().into(), self.decimals)?;

--- a/mm2src/coins/eth/eth_swap_v2/eth_taker_swap_v2.rs
+++ b/mm2src/coins/eth/eth_swap_v2/eth_taker_swap_v2.rs
@@ -219,19 +219,6 @@ impl EthCoin {
             .taker_swap_v2_details(ETH_TAKER_PAYMENT, ERC20_TAKER_PAYMENT)
             .await?;
         let decoded = try_tx_s!(decode_contract_call(send_func, args.funding_tx.unsigned().data()));
-        let taker_status = try_tx_s!(
-            self.payment_status_v2(
-                taker_swap_v2_contract,
-                decoded[0].clone(),
-                &TAKER_SWAP_V2,
-                EthPaymentType::TakerPayments,
-                TAKER_PAYMENT_STATE_INDEX,
-                BlockNumber::Latest,
-            )
-            .await
-        );
-        validate_payment_state(args.funding_tx, taker_status, TakerPaymentStateV2::PaymentSent as u8)
-            .map_err(|e| TransactionErr::Plain(ERRL!("{}", e)))?;
         let data = try_tx_s!(
             self.prepare_taker_payment_approve_data(args, decoded, token_address)
                 .await

--- a/mm2src/coins/eth/eth_swap_v2/eth_taker_swap_v2.rs
+++ b/mm2src/coins/eth/eth_swap_v2/eth_taker_swap_v2.rs
@@ -367,10 +367,10 @@ impl EthCoin {
             .get_funding_decoded_and_swap_contract(tx)
             .await
             .map_err(|e| SearchForFundingSpendErr::Internal(ERRL!("{}", e)))?;
+        let function = TAKER_SWAP_V2.function(EthPaymentType::TakerPayments.as_str())?;
 
         let call_params = CallParams {
-            contract_abi: &TAKER_SWAP_V2,
-            function_name: EthPaymentType::TakerPayments.as_str(),
+            function,
             args: &[decoded[0].clone()], // swap ID from decoded ethTakerPayment or erc20TakerPayment
             contract_addr: taker_swap_v2_contract,
             // Better to use the Latest confirmed block to ensure smart contract has the correct taker payment state (TakerApproved)

--- a/mm2src/coins/eth/eth_swap_v2/eth_taker_swap_v2.rs
+++ b/mm2src/coins/eth/eth_swap_v2/eth_taker_swap_v2.rs
@@ -18,6 +18,10 @@ use web3::types::{BlockNumber, TransactionId};
 const ETH_TAKER_PAYMENT: &str = "ethTakerPayment";
 const ERC20_TAKER_PAYMENT: &str = "erc20TakerPayment";
 const TAKER_PAYMENT_APPROVE: &str = "takerPaymentApprove";
+/// Maximum number of retry attempts for validating the token.
+const ATTEMPTS: usize = 3;
+/// Delay between call retries, in seconds.
+const RETRY_DELAY: f64 = 1.5;
 
 /// state index for `TakerPayment` structure from `EtomicSwapTakerV2.sol`
 ///
@@ -386,11 +390,8 @@ impl EthCoin {
             }
         };
 
-        let attempts = 3; // Retry up to 3 times
-        let retry_delay = 1.0; // Wait 1 second between retries
-
         match self
-            .call_validate_token_with_retry(call_params, validator, attempts, retry_delay)
+            .call_validate_token_with_retry(call_params, validator, ATTEMPTS, RETRY_DELAY)
             .await
         {
             Ok(()) => Ok(Some(FundingTxSpend::TransferredToTakerPayment(tx.clone()))),

--- a/mm2src/coins/eth/eth_swap_v2/eth_taker_swap_v2.rs
+++ b/mm2src/coins/eth/eth_swap_v2/eth_taker_swap_v2.rs
@@ -374,7 +374,7 @@ impl EthCoin {
             function,
             args: &[decoded[0].clone()], // swap ID from decoded ethTakerPayment or erc20TakerPayment
             contract_addr: taker_swap_v2_contract,
-            // Better to use the Latest confirmed block to ensure smart contract has the correct taker payment state (TakerApproved)
+            // Use the Latest confirmed block to ensure smart contract has the correct taker payment state (TakerApproved)
             // before the maker sends the spend transaction, which reveals the maker's secret.
             // TPU state machine waits confirmations only for send payment tx, not approve tx.
             block_number: BlockNumber::Latest,

--- a/mm2src/coins/eth/eth_swap_v2/eth_taker_swap_v2.rs
+++ b/mm2src/coins/eth/eth_swap_v2/eth_taker_swap_v2.rs
@@ -3,7 +3,7 @@ use super::{check_decoded_length, extract_id_from_tx_data, validate_amount, vali
 use crate::eth::{decode_contract_call, get_function_input_data, wei_from_big_decimal, EthCoin, EthCoinType,
                  ParseCoinAssocTypes, RefundFundingSecretArgs, RefundTakerPaymentArgs, SendTakerFundingArgs,
                  SignedEthTx, SwapTxTypeWithSecretHash, TakerPaymentStateV2, TransactionErr, ValidateSwapV2TxError,
-                 ValidateSwapV2TxResult, ValidateTakerFundingArgs, Web3RpcError, TAKER_SWAP_V2};
+                 ValidateSwapV2TxResult, ValidateTakerFundingArgs, TAKER_SWAP_V2};
 use crate::{FindPaymentSpendError, FundingTxSpend, GenTakerFundingSpendArgs, GenTakerPaymentSpendArgs,
             SearchForFundingSpendErr};
 use ethabi::{Function, Token};
@@ -380,13 +380,10 @@ impl EthCoin {
             decode_index: TAKER_PAYMENT_STATE_INDEX,
         };
 
-        let validator = |token: &Token| -> Result<bool, Web3RpcError> {
+        let validator = |token: &Token| -> Result<bool, String> {
             match token {
                 Token::Uint(state) => Ok(*state == U256::from(TakerPaymentStateV2::TakerApproved as u8)),
-                _ => Err(Web3RpcError::Internal(format!(
-                    "Payment status must be Uint, got {:?}",
-                    token
-                ))),
+                _ => Err(format!("Payment status must be Uint, got {:?}", token)),
             }
         };
 

--- a/mm2src/coins/eth/eth_swap_v2/mod.rs
+++ b/mm2src/coins/eth/eth_swap_v2/mod.rs
@@ -46,7 +46,6 @@ pub enum PaymentMethod {
 
 #[derive(Debug, Display)]
 pub(crate) enum ValidatePaymentV2Err {
-    UnexpectedPaymentState(String),
     WrongPaymentTx(String),
 }
 
@@ -244,15 +243,7 @@ pub(crate) fn validate_from_to_and_status(
     tx_from_rpc: &Web3Tx,
     expected_from: Address,
     expected_to: Address,
-    status: U256,
-    expected_status: u8,
 ) -> Result<(), MmError<ValidatePaymentV2Err>> {
-    if status != U256::from(expected_status) {
-        return MmError::err(ValidatePaymentV2Err::UnexpectedPaymentState(format!(
-            "tx {:?} Payment state is not `PaymentSent`, got {}",
-            tx_from_rpc.hash, status
-        )));
-    }
     if tx_from_rpc.from != Some(expected_from) {
         return MmError::err(ValidatePaymentV2Err::WrongPaymentTx(format!(
             "Payment tx {:?} was sent from wrong address, expected {:?}",

--- a/mm2src/coins/eth/eth_swap_v2/mod.rs
+++ b/mm2src/coins/eth/eth_swap_v2/mod.rs
@@ -251,7 +251,7 @@ impl EthCoin {
         validator: &F,
     ) -> Result<bool, Web3RpcError>
     where
-        F: Fn(&Token) -> Result<bool, Web3RpcError>,
+        F: Fn(&Token) -> Result<bool, String>,
     {
         let tokens = self
             .call_contract_function(
@@ -267,7 +267,7 @@ impl EthCoin {
             .get(call_params.decode_index)
             .ok_or_else(|| Web3RpcError::Internal(format!("No token at index {}", call_params.decode_index)))?;
 
-        validator(&tokens[call_params.decode_index])
+        validator(&tokens[call_params.decode_index]).map_err(Web3RpcError::Internal)
     }
 
     /// This method wraps [EthCoin::call_and_validate_token] with a retry mechanism.
@@ -281,7 +281,7 @@ impl EthCoin {
         retry_delay: f64,
     ) -> Result<(), Web3RpcError>
     where
-        F: Fn(&Token) -> Result<bool, Web3RpcError>,
+        F: Fn(&Token) -> Result<bool, String>,
     {
         if attempts == 0 {
             return Err(Web3RpcError::Internal(

--- a/mm2src/coins/eth/eth_swap_v2/mod.rs
+++ b/mm2src/coins/eth/eth_swap_v2/mod.rs
@@ -49,19 +49,6 @@ pub(crate) enum ValidatePaymentV2Err {
     WrongPaymentTx(String),
 }
 
-// TODO RENAME OR REMOVE IT
-#[derive(Debug, Display, EnumFromStringify)]
-pub(crate) enum PaymentStatusErr {
-    #[from_stringify("ethabi::Error")]
-    #[display(fmt = "ABI error: {}", _0)]
-    ABIError(String),
-    #[from_stringify("web3::Error")]
-    #[display(fmt = "Transport error: {}", _0)]
-    Transport(String),
-    #[display(fmt = "Invalid data error: {}", _0)]
-    InvalidData(String),
-}
-
 #[derive(Debug, Display, EnumFromStringify)]
 pub(crate) enum PrepareTxDataError {
     #[from_stringify("ethabi::Error")]
@@ -69,6 +56,8 @@ pub(crate) enum PrepareTxDataError {
     ABIError(String),
     #[display(fmt = "Internal error: {}", _0)]
     Internal(String),
+    #[display(fmt = "Invalid data error: {}", _0)]
+    InvalidData(String),
 }
 
 pub(crate) struct SpendTxSearchParams<'a> {

--- a/mm2src/coins/eth/eth_swap_v2/mod.rs
+++ b/mm2src/coins/eth/eth_swap_v2/mod.rs
@@ -5,7 +5,7 @@ use common::executor::Timer;
 use common::log::{error, info, warn};
 use common::now_sec;
 use enum_derives::EnumFromStringify;
-use ethabi::{Contract, Token};
+use ethabi::{Contract, Function, Token};
 use ethcore_transaction::SignedTransaction as SignedEthTx;
 use ethereum_types::{Address, H256, U256};
 use futures::compat::Future01CompatExt;
@@ -255,8 +255,7 @@ impl EthCoin {
     {
         let tokens = self
             .call_contract_function(
-                call_params.contract_abi,
-                call_params.function_name,
+                call_params.function,
                 call_params.args,
                 call_params.contract_addr,
                 call_params.block_number,
@@ -319,8 +318,7 @@ impl EthCoin {
 }
 
 pub(crate) struct CallParams<'a> {
-    contract_abi: &'a Contract,
-    function_name: &'a str,
+    function: &'a Function,
     args: &'a [Token],
     contract_addr: Address,
     block_number: BlockNumber,

--- a/mm2src/coins/eth/eth_swap_v2/mod.rs
+++ b/mm2src/coins/eth/eth_swap_v2/mod.rs
@@ -1,11 +1,10 @@
-use crate::eth::{decode_contract_call, signed_tx_from_web3_tx, EthCoin, EthCoinType, Transaction, TransactionErr,
-                 Web3RpcError};
+use crate::eth::{decode_contract_call, signed_tx_from_web3_tx, EthCoin, EthCoinType, Transaction, TransactionErr};
 use crate::{FindPaymentSpendError, MarketCoinOps, ParseCoinAssocTypes};
 use common::executor::Timer;
-use common::log::{error, info, warn};
+use common::log::{error, info};
 use common::now_sec;
 use enum_derives::EnumFromStringify;
-use ethabi::{Contract, Function, Token};
+use ethabi::{Contract, Token};
 use ethcore_transaction::SignedTransaction as SignedEthTx;
 use ethereum_types::{Address, H256, U256};
 use futures::compat::Future01CompatExt;
@@ -295,113 +294,6 @@ impl EthCoin {
         }
         Ok(())
     }
-
-    #[allow(dead_code)]
-    /// Calls a contract function by name, returns the decoded output tokens
-    async fn call_contract_function(
-        &self,
-        function: &Function,
-        args: &[Token],
-        contract_addr: Address,
-        block_number: BlockNumber,
-    ) -> Result<Vec<Token>, Web3RpcError> {
-        let data = function.encode_input(args)?;
-        let bytes = self
-            .call_request(
-                self.my_addr().await,
-                contract_addr,
-                None,
-                Some(data.into()),
-                block_number,
-            )
-            .await?;
-        let decoded_tokens = function.decode_output(&bytes.0)?;
-        Ok(decoded_tokens)
-    }
-
-    #[allow(dead_code)]
-    /// Calls a contract function and validates the output token using a provided validator function.
-    /// Returns `true` if the validation passes, otherwise `false`.
-    async fn call_and_validate_token<F>(
-        &self,
-        call_params: &CallParams<'_>,
-        validator: &F,
-    ) -> Result<bool, Web3RpcError>
-    where
-        F: Fn(&Token) -> Result<bool, String>,
-    {
-        let tokens = self
-            .call_contract_function(
-                call_params.function,
-                call_params.args,
-                call_params.contract_addr,
-                call_params.block_number,
-            )
-            .await?;
-
-        tokens
-            .get(call_params.decode_index)
-            .ok_or_else(|| Web3RpcError::Internal(format!("No token at index {}", call_params.decode_index)))?;
-
-        validator(&tokens[call_params.decode_index]).map_err(Web3RpcError::Internal)
-    }
-
-    #[allow(dead_code)]
-    /// This method wraps [EthCoin::call_and_validate_token] with a retry mechanism.
-    /// - If `call_and_validate_token` returns an error, we return immediately (no retry).
-    /// - If `call_and_validate_token` returns `false`, we retry until `attempts` is exhausted.
-    async fn call_validate_token_with_retry<F>(
-        &self,
-        call_params: CallParams<'_>,
-        validator: F,
-        attempts: usize,
-        retry_delay: f64,
-    ) -> Result<(), Web3RpcError>
-    where
-        F: Fn(&Token) -> Result<bool, String>,
-    {
-        if attempts == 0 {
-            return Err(Web3RpcError::Internal(
-                "Attempt count is zero, cannot validate".to_string(),
-            ));
-        }
-
-        for attempt in 1..=attempts {
-            match self.call_and_validate_token(&call_params, &validator).await {
-                Ok(true) => {
-                    return Ok(());
-                },
-                Ok(false) => {
-                    if attempt == attempts {
-                        return Err(Web3RpcError::Internal(format!(
-                            "Validation failed after {} attempts",
-                            attempts
-                        )));
-                    } else {
-                        warn!(
-                            "Validation failed on attempt {}/{}. Retrying in {:?}",
-                            attempt, attempts, retry_delay
-                        );
-                        Timer::sleep(retry_delay).await;
-                    }
-                },
-                // If there's an actual error, we abort immediately
-                Err(e) => return Err(e),
-            }
-        }
-
-        // better to use explicit err then panic with unreachable!()
-        Err(Web3RpcError::Internal("Unreachable: exhausted attempts".into()))
-    }
-}
-
-#[allow(dead_code)]
-pub(crate) struct CallParams<'a> {
-    function: &'a Function,
-    args: &'a [Token],
-    contract_addr: Address,
-    block_number: BlockNumber,
-    decode_index: usize,
 }
 
 pub(crate) async fn extract_id_from_tx_data(

--- a/mm2src/coins/eth/eth_swap_v2/mod.rs
+++ b/mm2src/coins/eth/eth_swap_v2/mod.rs
@@ -226,20 +226,6 @@ impl EthCoin {
     }
 }
 
-pub(crate) fn validate_payment_state(
-    tx: &SignedEthTx,
-    state: U256,
-    expected_state: u8,
-) -> Result<(), PrepareTxDataError> {
-    if state != U256::from(expected_state) {
-        return Err(PrepareTxDataError::Internal(format!(
-            "Payment {:?} state is not `{}`, got `{}`",
-            tx, expected_state, state
-        )));
-    }
-    Ok(())
-}
-
 pub(crate) fn validate_from_to_addresses(
     tx_from_rpc: &Web3Tx,
     expected_from: Address,

--- a/mm2src/coins/eth/eth_swap_v2/mod.rs
+++ b/mm2src/coins/eth/eth_swap_v2/mod.rs
@@ -317,7 +317,7 @@ impl EthCoin {
         validator: &F,
     ) -> Result<bool, Web3RpcError>
     where
-        F: Fn(&Token) -> bool,
+        F: Fn(&Token) -> Result<bool, Web3RpcError>,
     {
         let tokens = self
             .call_contract_function(
@@ -333,7 +333,7 @@ impl EthCoin {
             .get(call_params.decode_index)
             .ok_or_else(|| Web3RpcError::Internal(format!("No token at index {}", call_params.decode_index)))?;
 
-        Ok(validator(&tokens[call_params.decode_index]))
+        validator(&tokens[call_params.decode_index])
     }
 
     #[allow(dead_code)]
@@ -348,7 +348,7 @@ impl EthCoin {
         retry_delay: f64,
     ) -> Result<(), Web3RpcError>
     where
-        F: Fn(&Token) -> bool,
+        F: Fn(&Token) -> Result<bool, Web3RpcError>,
     {
         if attempts == 0 {
             return Err(Web3RpcError::Internal(

--- a/mm2src/coins/eth/nft_swap_v2/mod.rs
+++ b/mm2src/coins/eth/nft_swap_v2/mod.rs
@@ -81,16 +81,6 @@ impl EthCoin {
                 let token_address = args.nft_swap_info.token_address;
                 let maker_address = public_to_address(args.maker_pub);
                 let swap_id = self.etomic_swap_id_v2(args.time_lock, args.maker_secret_hash);
-                let maker_status = self
-                    .payment_status_v2(
-                        nft_maker_swap_v2_contract,
-                        Token::FixedBytes(swap_id.clone()),
-                        &NFT_MAKER_SWAP_V2,
-                        EthPaymentType::MakerPayments,
-                        2,
-                        BlockNumber::Latest,
-                    )
-                    .await?;
                 let tx_from_rpc = self
                     .transaction(TransactionId::Hash(args.maker_payment_tx.tx_hash()))
                     .await?;
@@ -100,13 +90,7 @@ impl EthCoin {
                         args.maker_payment_tx.tx_hash()
                     ))
                 })?;
-                validate_from_to_and_status(
-                    tx_from_rpc,
-                    maker_address,
-                    *token_address,
-                    maker_status,
-                    MakerPaymentStateV2::PaymentSent as u8,
-                )?;
+                validate_from_to_and_status(tx_from_rpc, maker_address, *token_address)?;
 
                 let (decoded, bytes_index) = get_decoded_tx_data_and_bytes_index(contract_type, &tx_from_rpc.input.0)?;
 

--- a/mm2src/coins/eth/nft_swap_v2/mod.rs
+++ b/mm2src/coins/eth/nft_swap_v2/mod.rs
@@ -10,8 +10,7 @@ use web3::types::TransactionId;
 
 use super::ContractType;
 use crate::coin_errors::{ValidatePaymentError, ValidatePaymentResult};
-use crate::eth::eth_swap_v2::{validate_from_to_addresses, PaymentMethod, PaymentStatusErr, PrepareTxDataError,
-                              ZERO_VALUE};
+use crate::eth::eth_swap_v2::{validate_from_to_addresses, PaymentMethod, PrepareTxDataError, ZERO_VALUE};
 use crate::eth::{decode_contract_call, EthCoin, EthCoinType, SignedEthTx, ERC1155_CONTRACT, ERC721_CONTRACT,
                  NFT_MAKER_SWAP_V2};
 use crate::{ParseCoinAssocTypes, RefundNftMakerPaymentArgs, SendNftMakerPaymentArgs, SpendNftMakerPaymentArgs,
@@ -386,17 +385,17 @@ impl EthCoin {
         &self,
         decoded_data: &[Token],
         index: usize,
-    ) -> Result<Vec<Token>, PaymentStatusErr> {
+    ) -> Result<Vec<Token>, PrepareTxDataError> {
         let data_bytes = match decoded_data.get(index) {
             Some(Token::Bytes(data_bytes)) => data_bytes,
             _ => {
-                return Err(PaymentStatusErr::InvalidData(ERRL!(
+                return Err(PrepareTxDataError::InvalidData(ERRL!(
                     "Failed to decode HTLCParams from data_bytes"
                 )))
             },
         };
         let htlc_params =
-            ethabi::decode(htlc_params(), data_bytes).map_err(|e| PaymentStatusErr::ABIError(ERRL!("{}", e)))?;
+            ethabi::decode(htlc_params(), data_bytes).map_err(|e| PrepareTxDataError::ABIError(ERRL!("{}", e)))?;
         Ok(htlc_params)
     }
 }

--- a/mm2src/coins/eth/nft_swap_v2/mod.rs
+++ b/mm2src/coins/eth/nft_swap_v2/mod.rs
@@ -10,7 +10,7 @@ use web3::types::TransactionId;
 
 use super::ContractType;
 use crate::coin_errors::{ValidatePaymentError, ValidatePaymentResult};
-use crate::eth::eth_swap_v2::{validate_from_to_and_status, PaymentMethod, PaymentStatusErr, PrepareTxDataError,
+use crate::eth::eth_swap_v2::{validate_from_to_addresses, PaymentMethod, PaymentStatusErr, PrepareTxDataError,
                               ZERO_VALUE};
 use crate::eth::{decode_contract_call, EthCoin, EthCoinType, SignedEthTx, ERC1155_CONTRACT, ERC721_CONTRACT,
                  NFT_MAKER_SWAP_V2};
@@ -90,7 +90,7 @@ impl EthCoin {
                         args.maker_payment_tx.tx_hash()
                     ))
                 })?;
-                validate_from_to_and_status(tx_from_rpc, maker_address, *token_address)?;
+                validate_from_to_addresses(tx_from_rpc, maker_address, *token_address)?;
 
                 let (decoded, bytes_index) = get_decoded_tx_data_and_bytes_index(contract_type, &tx_from_rpc.input.0)?;
 

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -1466,7 +1466,6 @@ impl From<PaymentStatusErr> for ValidateSwapV2TxError {
 impl From<ValidatePaymentV2Err> for ValidateSwapV2TxError {
     fn from(err: ValidatePaymentV2Err) -> Self {
         match err {
-            ValidatePaymentV2Err::UnexpectedPaymentState(e) => ValidateSwapV2TxError::UnexpectedPaymentState(e),
             ValidatePaymentV2Err::WrongPaymentTx(e) => ValidateSwapV2TxError::WrongPaymentTx(e),
         }
     }

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -218,7 +218,7 @@ pub mod coins_tests;
 
 pub mod eth;
 use eth::erc20::get_erc20_ticker_by_contract_address;
-use eth::eth_swap_v2::{PaymentStatusErr, PrepareTxDataError, ValidatePaymentV2Err};
+use eth::eth_swap_v2::{PrepareTxDataError, ValidatePaymentV2Err};
 use eth::{eth_coin_from_conf_and_request, get_eth_address, EthCoin, EthGasDetailsErr, EthTxFeeDetails,
           GetEthAddressError, GetValidEthWithdrawAddError, SignedEthTx};
 
@@ -1453,15 +1453,6 @@ impl From<UtxoRpcError> for ValidateSwapV2TxError {
     fn from(err: UtxoRpcError) -> Self { ValidateSwapV2TxError::Rpc(err.to_string()) }
 }
 
-impl From<PaymentStatusErr> for ValidateSwapV2TxError {
-    fn from(err: PaymentStatusErr) -> Self {
-        match err {
-            PaymentStatusErr::Transport(e) => ValidateSwapV2TxError::Rpc(e),
-            PaymentStatusErr::ABIError(e) | PaymentStatusErr::InvalidData(e) => ValidateSwapV2TxError::InvalidData(e),
-        }
-    }
-}
-
 impl From<ValidatePaymentV2Err> for ValidateSwapV2TxError {
     fn from(err: ValidatePaymentV2Err) -> Self {
         match err {
@@ -1474,6 +1465,7 @@ impl From<PrepareTxDataError> for ValidateSwapV2TxError {
     fn from(err: PrepareTxDataError) -> Self {
         match err {
             PrepareTxDataError::ABIError(e) | PrepareTxDataError::Internal(e) => ValidateSwapV2TxError::Internal(e),
+            PrepareTxDataError::InvalidData(e) => ValidateSwapV2TxError::InvalidData(e),
         }
     }
 }
@@ -1828,21 +1820,12 @@ impl From<WaitForOutputSpendErr> for FindPaymentSpendError {
     }
 }
 
-impl From<PaymentStatusErr> for FindPaymentSpendError {
-    fn from(e: PaymentStatusErr) -> Self {
-        match e {
-            PaymentStatusErr::ABIError(e) => Self::ABIError(e),
-            PaymentStatusErr::Transport(e) => Self::Transport(e),
-            PaymentStatusErr::InvalidData(e) => Self::InvalidData(e),
-        }
-    }
-}
-
 impl From<PrepareTxDataError> for FindPaymentSpendError {
     fn from(e: PrepareTxDataError) -> Self {
         match e {
             PrepareTxDataError::ABIError(e) => Self::ABIError(e),
             PrepareTxDataError::Internal(e) => Self::Internal(e),
+            PrepareTxDataError::InvalidData(e) => Self::InvalidData(e),
         }
     }
 }

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -1456,7 +1456,6 @@ impl From<UtxoRpcError> for ValidateSwapV2TxError {
 impl From<PaymentStatusErr> for ValidateSwapV2TxError {
     fn from(err: PaymentStatusErr) -> Self {
         match err {
-            PaymentStatusErr::Internal(e) => ValidateSwapV2TxError::Internal(e),
             PaymentStatusErr::Transport(e) => ValidateSwapV2TxError::Rpc(e),
             PaymentStatusErr::ABIError(e) | PaymentStatusErr::InvalidData(e) => ValidateSwapV2TxError::InvalidData(e),
         }
@@ -1834,7 +1833,6 @@ impl From<PaymentStatusErr> for FindPaymentSpendError {
         match e {
             PaymentStatusErr::ABIError(e) => Self::ABIError(e),
             PaymentStatusErr::Transport(e) => Self::Transport(e),
-            PaymentStatusErr::Internal(e) => Self::Internal(e),
             PaymentStatusErr::InvalidData(e) => Self::InvalidData(e),
         }
     }

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -1865,7 +1865,7 @@ impl<T: ParseCoinAssocTypes + ?Sized> fmt::Debug for FundingTxSpend<T> {
 }
 
 /// Enum representing errors that can occur during the search for funding spend.
-#[derive(Debug)]
+#[derive(Debug, EnumFromStringify)]
 pub enum SearchForFundingSpendErr {
     /// Variant indicating an invalid input transaction error with additional information.
     InvalidInputTx(String),
@@ -1875,6 +1875,7 @@ pub enum SearchForFundingSpendErr {
     Rpc(String),
     /// Variant indicating an error during conversion of the `from_block` argument with associated `TryFromIntError`.
     FromBlockConversionErr(TryFromIntError),
+    #[from_stringify("ethabi::Error")]
     Internal(String),
 }
 


### PR DESCRIPTION
**Note:** This PRs updates eth TPU part.

This PR covers this issue https://github.com/KomodoPlatform/komodo-defi-framework/issues/2328 in eth tpu functionality.

- The payment status (`PaymentSent`) check has been removed from TPU validation payment functionality for all ETH implementations, including taker, maker, and maker-nft https://github.com/KomodoPlatform/komodo-defi-framework/pull/2334/commits/7be74aa788de9cd7d268132d1b963688304425bc. 
It is done to avoid unnecessary loops of checking  `PaymentSent` in KDF code, as we already explicitly wait for taker/maker payment transaction confirmations in TPU (see `wait_for_confirmations` function). If tx confirmation failed, it would mean that payment doesnt have `PaymentSent`state in smart contract.
Additionally this check is handled in smart contract code (see `MakerPaymentState.PaymentSent` in [EtomicSwapMakerV2](https://github.com/KomodoPlatform/etomic-swap/blob/bbdeb369eab0753454dae29640adaa4fdba221ba/contracts/EtomicSwapMakerV2.sol) and TakerPaymentState.PaymentSent in [EtomicSwapTakerV2](https://github.com/KomodoPlatform/etomic-swap/blob/bbdeb369eab0753454dae29640adaa4fdba221ba/contracts/EtomicSwapTakerV2.sol))


- Payment state check is now only in `search_for_taker_funding_spend_impl`, specifically checking `TakerPaymentStateV2::TakerApproved`.
In TPU state machine we wait for taker payment tx confirmation (in smart contract storage it changes payment state from `Unintialized` to `PaymentSent`) before calling `sign_and_broadcast_taker_payment_spend`. 
However, Taker payment has more states than maker payment, with the additional `TakerApproved` state. So we need to check somehow on KDF that taker approve tx was successful.
```solidity
enum TakerPaymentState {
        Uninitialized,
        PaymentSent,
        TakerApproved,
        MakerSpent,
        TakerRefunded
    }
```
This `TakerApproved` state check is handled in `search_for_taker_funding_spend` function.
 
As maker payment has less statuses, it is sufficient to wait for maker payment tx confirmation (in smart contract storage it changes payment state from `Unintialized` to `PaymentSent`). There is no need to do additional eth calls in retry loop for this.
 ```solidity
enum MakerPaymentState {
        Uninitialized,
        PaymentSent,
        TakerSpent,
        MakerRefunded
    }
```

---
NOTE: The below is removed, see https://github.com/KomodoPlatform/komodo-defi-framework/pull/2334#issuecomment-2662748282

- This PR introduces `call_validate_token_with_retry`, which validates in `eth_taker_swap_v2.rs` the payment state decoded from `Token` with a retry mechanism (incudes retry delay and attempts) for ETH calls.  

Even though in generic state machine `search_for_taker_funding_spend` is already called in a loop with a timeout (see picture below), having **retry logic within the ETH implementation** is necessary because it directly addresses an ETH-specific issue ([ref. issue #2328](https://github.com/KomodoPlatform/komodo-defi-framework/issues/2328)).  

If the loop is ever removed from the state machine and ETH `search_for_taker_funding_spend` lacks this retry mechanism, the taker-approved check could fail, leading to a swap failure. 
This can happen for `"eth_call"`API if the **Latest** block flag is used and the smart contract storage didnt get updates yet, or if the **Pending** flag is used and the ETH call is sent to a node that doesn't have the pending transaction.
<img width="1207" alt="image" src="https://github.com/user-attachments/assets/488c7dba-1c72-44a3-873d-d3e50e9feeb3" />
