### PR TITLE
feat(tendermint): claim delegation rewards

### DIFF
--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -4950,17 +4950,17 @@ pub async fn add_delegation(ctx: MmArc, req: AddDelegateRequest) -> DelegationRe
 }
 
 pub async fn claim_staking_rewards(ctx: MmArc, req: ClaimStakingRewardsRequest) -> DelegationResult {
-    let coin = lp_coinfind_or_err(&ctx, &req.coin).await?;
-
     match req.claiming_details {
-        ClaimingDetails::Cosmos(req) => {
+        ClaimingDetails::Cosmos(r) => {
+            let coin = lp_coinfind_or_err(&ctx, &req.coin).await?;
+
             let MmCoinEnum::Tendermint(tendermint) = coin else {
                 return MmError::err(DelegationError::CoinDoesntSupportDelegation {
                     coin: coin.ticker().to_string(),
                 });
             };
 
-            tendermint.claim_staking_rewards(req).await
+            tendermint.claim_staking_rewards(r).await
         },
     }
 }

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -2150,14 +2150,12 @@ pub enum StakingDetails {
     Cosmos(Box<rpc_command::tendermint::staking::DelegationPayload>),
 }
 
-#[allow(dead_code)]
 #[derive(Deserialize)]
 pub struct AddDelegateRequest {
     pub coin: String,
     pub staking_details: StakingDetails,
 }
 
-#[allow(dead_code)]
 #[derive(Deserialize)]
 pub struct RemoveDelegateRequest {
     pub coin: String,
@@ -2170,7 +2168,6 @@ pub enum ClaimingDetails {
     Cosmos(rpc_command::tendermint::staking::ClaimRewardsPayload),
 }
 
-#[allow(dead_code)]
 #[derive(Deserialize)]
 pub struct ClaimStakingRewardsRequest {
     pub coin: String,

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -2803,6 +2803,14 @@ pub enum DelegationError {
         available: BigDecimal,
         requested: BigDecimal,
     },
+    #[display(
+        fmt = "Fee ({}) exceeds reward ({}) which makes this unprofitable. Set 'force' to true in the request to bypass this check.",
+        fee,
+        reward
+    )]
+    UnprofitableReward { reward: BigDecimal, fee: BigDecimal },
+    #[display(fmt = "There is no reward for {} to claim.", coin)]
+    NothingToClaim { coin: String },
     #[display(fmt = "{}", _0)]
     CannotInteractWithSmartContract(String),
     #[from_stringify("ScriptHashTypeNotSupported")]

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -2303,6 +2303,7 @@ impl KmdRewardsDetails {
 pub enum TransactionType {
     StakingDelegation,
     RemoveDelegation,
+    ClaimDelegationRewards,
     #[default]
     StandardTransfer,
     TokenTransfer(BytesJson),

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -5012,8 +5012,8 @@ pub async fn claim_staking_rewards(ctx: MmArc, req: ClaimStakingRewardsRequest) 
             let coin = lp_coinfind_or_err(&ctx, &req.coin).await?;
 
             let MmCoinEnum::Tendermint(tendermint) = coin else {
-                return MmError::err(DelegationError::CoinDoesntSupportDelegation {
-                    coin: coin.ticker().to_string(),
+                return MmError::err(DelegationError::InvalidPayload {
+                    reason: format!("{} is not a Cosmos coin", req.coin)
                 });
             };
 

--- a/mm2src/coins/my_tx_history_v2.rs
+++ b/mm2src/coins/my_tx_history_v2.rs
@@ -235,6 +235,7 @@ impl<'a, Addr: Clone + DisplayAddress + Eq + std::hash::Hash, Tx: Transaction> T
             },
             TransactionType::StakingDelegation
             | TransactionType::RemoveDelegation
+            | TransactionType::ClaimDelegationRewards
             | TransactionType::FeeForTokenTx
             | TransactionType::StandardTransfer
             | TransactionType::NftTransfer

--- a/mm2src/coins/rpc_command/tendermint/staking.rs
+++ b/mm2src/coins/rpc_command/tendermint/staking.rs
@@ -162,3 +162,11 @@ pub struct DelegationPayload {
     #[serde(default)]
     pub max: bool,
 }
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ClaimRewardsPayload {
+    pub validator_address: String,
+    pub fee: Option<WithdrawFee>,
+    #[serde(default)]
+    pub memo: String,
+}

--- a/mm2src/coins/rpc_command/tendermint/staking.rs
+++ b/mm2src/coins/rpc_command/tendermint/staking.rs
@@ -169,4 +169,6 @@ pub struct ClaimRewardsPayload {
     pub fee: Option<WithdrawFee>,
     #[serde(default)]
     pub memo: String,
+    #[serde(default)]
+    pub force: bool,
 }

--- a/mm2src/coins/rpc_command/tendermint/staking.rs
+++ b/mm2src/coins/rpc_command/tendermint/staking.rs
@@ -169,6 +169,9 @@ pub struct ClaimRewardsPayload {
     pub fee: Option<WithdrawFee>,
     #[serde(default)]
     pub memo: String,
+    /// If transaction fee exceeds the reward amount users will be
+    /// prevented from claiming their rewards as it will not be profitable.
+    /// Setting `force` to `true` disables this logic.
     #[serde(default)]
     pub force: bool,
 }

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -2552,8 +2552,8 @@ impl TendermintCoin {
             .map_to_mm(DelegationError::Transport)?
             + TIMEOUT_HEIGHT_DELTA;
 
-        // This uses more gas than any other transactions
-        let gas_limit_default = GAS_LIMIT_DEFAULT * 2;
+        // This uses more gas than the regular transactions
+        let gas_limit_default = (GAS_LIMIT_DEFAULT * 3) / 2;
         let (_, gas_limit) = self.gas_info_for_withdraw(&req.fee, gas_limit_default);
 
         let fee_amount_u64 = self

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -2492,6 +2492,8 @@ impl TendermintCoin {
         .to_any()
         .map_err(|e| DelegationError::InternalError(e.to_string()))?;
 
+        let reward_amount = todo!();
+
         let timeout_height = self
             .current_block()
             .compat()
@@ -2547,8 +2549,8 @@ impl TendermintCoin {
 
         Ok(TransactionDetails {
             tx,
-            from: vec![delegator_address.to_string()],
-            to: vec![], // We just pay the transaction fee for undelegation
+            from: vec![validator_address.to_string()],
+            to: vec![delegator_address.to_string()],
             my_balance_change: &BigDecimal::default() - &fee_amount_dec,
             spent_by_me: fee_amount_dec.clone(),
             total_amount: fee_amount_dec.clone(),

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -2566,7 +2566,7 @@ impl TendermintCoin {
             coin: self.ticker.to_string(),
             internal_id,
             kmd_rewards: None,
-            transaction_type: TransactionType::RemoveDelegation,
+            transaction_type: TransactionType::ClaimDelegationRewards,
             memo: Some(req.memo),
         })
     }

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -2430,7 +2430,7 @@ impl TendermintCoin {
         })
     }
 
-    pub(crate) async fn get_delegated_amount(
+    async fn get_delegated_amount(
         &self,
         validator_addr: &AccountId, // keep this as `AccountId` to make it pre-validated
     ) -> MmResult<(BigDecimal, u64), DelegationError> {
@@ -2477,7 +2477,7 @@ impl TendermintCoin {
         Ok((big_decimal_from_sat_unsigned(uamount, self.decimals()), uamount))
     }
 
-    pub(crate) async fn get_delegation_reward_amount(
+    async fn get_delegation_reward_amount(
         &self,
         validator_addr: &AccountId, // keep this as `AccountId` to make it pre-validated
     ) -> MmResult<BigDecimal, DelegationError> {

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -2519,6 +2519,7 @@ impl TendermintCoin {
 
         Ok(amount)
     }
+
     pub(crate) async fn claim_staking_rewards(
         &self,
         req: ClaimRewardsPayload,

--- a/mm2src/coins/tendermint/tendermint_tx_history_v2.rs
+++ b/mm2src/coins/tendermint/tendermint_tx_history_v2.rs
@@ -435,50 +435,57 @@ where
 
         /// Reads sender and receiver addresses properly from an IBC event.
         fn read_real_ibc_addresses(transfer_details: &mut TransferDetails, msg_event: &Event) {
-            transfer_details.transfer_event_type = match msg_event.kind.as_str() {
+            let event_type = match msg_event.kind.as_str() {
                 IBC_SEND_EVENT => TransferEventType::IBCSend,
                 IBC_RECEIVE_EVENT | IBC_NFT_RECEIVE_EVENT => TransferEventType::IBCReceive,
                 _ => unreachable!("`read_real_ibc_addresses` shouldn't be called for non-IBC events."),
             };
 
-            transfer_details.from = some_or_return!(get_value_from_event_attributes(
+            let from = some_or_return!(get_value_from_event_attributes(
                 &msg_event.attributes,
                 SENDER_TAG_KEY,
                 SENDER_TAG_KEY_BASE64
             ));
 
-            transfer_details.to = some_or_return!(get_value_from_event_attributes(
+            let to = some_or_return!(get_value_from_event_attributes(
                 &msg_event.attributes,
                 RECEIVER_TAG_KEY,
                 RECEIVER_TAG_KEY_BASE64,
             ));
+
+            transfer_details.from = from;
+            transfer_details.to = to;
+            transfer_details.transfer_event_type = event_type;
         }
 
         /// Reads sender and receiver addresses properly from an HTLC event.
         fn read_real_htlc_addresses(transfer_details: &mut TransferDetails, msg_event: &&Event) {
             match msg_event.kind.as_str() {
                 CREATE_HTLC_EVENT => {
-                    transfer_details.from = some_or_return!(get_value_from_event_attributes(
+                    let from = some_or_return!(get_value_from_event_attributes(
                         &msg_event.attributes,
                         SENDER_TAG_KEY,
                         SENDER_TAG_KEY_BASE64
                     ));
 
-                    transfer_details.to = some_or_return!(get_value_from_event_attributes(
+                    let to = some_or_return!(get_value_from_event_attributes(
                         &msg_event.attributes,
                         RECEIVER_TAG_KEY,
                         RECEIVER_TAG_KEY_BASE64,
                     ));
 
+                    transfer_details.from = from;
+                    transfer_details.to = to;
                     transfer_details.transfer_event_type = TransferEventType::CreateHtlc;
                 },
                 CLAIM_HTLC_EVENT => {
-                    transfer_details.from = some_or_return!(get_value_from_event_attributes(
+                    let from = some_or_return!(get_value_from_event_attributes(
                         &msg_event.attributes,
                         SENDER_TAG_KEY,
                         SENDER_TAG_KEY_BASE64
                     ));
 
+                    transfer_details.from = from;
                     transfer_details.transfer_event_type = TransferEventType::ClaimHtlc;
                 },
                 _ => unreachable!("`read_real_htlc_addresses` shouldn't be called for non-HTLC events."),

--- a/mm2src/coins/tendermint/tendermint_tx_history_v2.rs
+++ b/mm2src/coins/tendermint/tendermint_tx_history_v2.rs
@@ -637,17 +637,17 @@ where
         }
 
         fn get_transfer_details(tx_events: Vec<Event>, fee_amount_with_denom: String) -> Vec<TransferDetails> {
-            // We only interested `DELEGATE_EVENT` events for delegation transactions.
+            // We are only interested `DELEGATE_EVENT` events for delegation transactions.
             if let Some(delegate_event) = tx_events.iter().find(|e| e.kind == DELEGATE_EVENT) {
                 return parse_transfer_values_from_events(vec![delegate_event]);
             };
 
-            // We only interested `UNDELEGATE_EVENT` events for undelegation transactions.
+            // We are only interested `UNDELEGATE_EVENT` events for undelegation transactions.
             if let Some(undelegate_event) = tx_events.iter().find(|e| e.kind == UNDELEGATE_EVENT) {
                 return parse_transfer_values_from_events(vec![undelegate_event]);
             };
 
-            // We only interested `WITHDRAW_REWARDS_EVENT` events for withdraw reward transactions.
+            // We are only interested `WITHDRAW_REWARDS_EVENT` events for withdraw reward transactions.
             if let Some(withdraw_rewards_event) = tx_events.iter().find(|e| e.kind == WITHDRAW_REWARDS_EVENT) {
                 return parse_transfer_values_from_events(vec![withdraw_rewards_event]);
             };

--- a/mm2src/coins_activation/src/tendermint_with_assets_activation.rs
+++ b/mm2src/coins_activation/src/tendermint_with_assets_activation.rs
@@ -235,6 +235,16 @@ impl PlatformCoinWithTokensActivationOps for TendermintCoin {
         activation_request: Self::ActivationRequest,
         protocol_conf: Self::PlatformProtocolInfo,
     ) -> Result<Self, MmError<Self::ActivationError>> {
+        if protocol_conf.decimals > 18 {
+            return MmError::err(TendermintInitError {
+                ticker: ticker.clone(),
+                kind: TendermintInitErrorKind::InvalidProtocolData(format!(
+                    "'decimals' value is too high; it must be 18 or lower but the current value is {}",
+                    protocol_conf.decimals
+                )),
+            });
+        }
+
         let conf = TendermintConf::try_from_json(&ticker, coin_conf)?;
         let is_keplr_from_ledger = activation_request.is_keplr_from_ledger && activation_request.with_pubkey.is_some();
 

--- a/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
+++ b/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
@@ -46,9 +46,9 @@ use coins::utxo::qtum::QtumCoin;
 use coins::utxo::slp::SlpToken;
 use coins::utxo::utxo_standard::UtxoStandardCoin;
 use coins::z_coin::ZCoin;
-use coins::{add_delegation, get_my_address, get_raw_transaction, get_staking_infos, get_swap_transaction_fee_policy,
-            nft, remove_delegation, set_swap_transaction_fee_policy, sign_message, sign_raw_transaction,
-            verify_message, withdraw, claim_staking_rewards};
+use coins::{add_delegation, claim_staking_rewards, get_my_address, get_raw_transaction, get_staking_infos,
+            get_swap_transaction_fee_policy, nft, remove_delegation, set_swap_transaction_fee_policy, sign_message,
+            sign_raw_transaction, verify_message, withdraw};
 use coins_activation::{cancel_init_l2, cancel_init_platform_coin_with_tokens, cancel_init_standalone_coin,
                        cancel_init_token, enable_platform_coin_with_tokens, enable_token, init_l2, init_l2_status,
                        init_l2_user_action, init_platform_coin_with_tokens, init_platform_coin_with_tokens_status,

--- a/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
+++ b/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
@@ -48,7 +48,7 @@ use coins::utxo::utxo_standard::UtxoStandardCoin;
 use coins::z_coin::ZCoin;
 use coins::{add_delegation, get_my_address, get_raw_transaction, get_staking_infos, get_swap_transaction_fee_policy,
             nft, remove_delegation, set_swap_transaction_fee_policy, sign_message, sign_raw_transaction,
-            verify_message, withdraw};
+            verify_message, withdraw, claim_staking_rewards};
 use coins_activation::{cancel_init_l2, cancel_init_platform_coin_with_tokens, cancel_init_standalone_coin,
                        cancel_init_token, enable_platform_coin_with_tokens, enable_token, init_l2, init_l2_status,
                        init_l2_user_action, init_platform_coin_with_tokens, init_platform_coin_with_tokens_status,
@@ -176,6 +176,7 @@ async fn dispatcher_v2(request: MmRpcRequest, ctx: MmArc) -> DispatcherResult<Re
         "approve_token" => handle_mmrpc(ctx, request, approve_token_rpc).await,
         "get_token_allowance" => handle_mmrpc(ctx, request, get_token_allowance_rpc).await,
         "best_orders" => handle_mmrpc(ctx, request, best_orders_rpc_v2).await,
+        "claim_staking_rewards" => handle_mmrpc(ctx, request, claim_staking_rewards).await,
         "clear_nft_db" => handle_mmrpc(ctx, request, clear_nft_db).await,
         "enable_bch_with_tokens" => handle_mmrpc(ctx, request, enable_platform_coin_with_tokens::<BchCoin>).await,
         "enable_slp" => handle_mmrpc(ctx, request, enable_token::<SlpToken>).await,

--- a/mm2src/mm2_test_helpers/dummy_files/nucleus-history.json
+++ b/mm2src/mm2_test_helpers/dummy_files/nucleus-history.json
@@ -22,7 +22,7 @@
         },
         "coin": "NUCLEUS-TEST",
         "internal_id": "4335303135373938433145384342333931424145373846420000000000000000",
-        "transaction_type": "StandardTransfer",
+        "transaction_type": "TendermintIBCTransfer",
         "memo": "rly(2.5.2-28-gdf42391)"
     },
     {

--- a/mm2src/mm2_test_helpers/dummy_files/nucleus-history.json
+++ b/mm2src/mm2_test_helpers/dummy_files/nucleus-history.json
@@ -22,7 +22,7 @@
         },
         "coin": "NUCLEUS-TEST",
         "internal_id": "4335303135373938433145384342333931424145373846420000000000000000",
-        "transaction_type": "TendermintIBCTransfer",
+        "transaction_type": "StandardTransfer",
         "memo": "rly(2.5.2-28-gdf42391)"
     },
     {
@@ -48,7 +48,7 @@
         },
         "coin": "NUCLEUS-TEST",
         "internal_id": "3031414542453143353638454230314344383437414235390000000000000000",
-        "transaction_type": "StandardTransfer",
+        "transaction_type": "TendermintIBCTransfer",
         "memo": ""
     },
     {


### PR DESCRIPTION
Adds new RPC `claim_staking_rewards` with a support of tendermint protocol along with tx history support on tendermint claiming rewards.

Next is to add listing/querying RPCs.