### PR TITLE
fix(derive_key_from_path): check length of current_key_material

### DIFF
--- a/mm2src/crypto/src/key_derivation.rs
+++ b/mm2src/crypto/src/key_derivation.rs
@@ -134,6 +134,11 @@ pub(crate) fn derive_keys_for_mnemonic(
 /// Splits a path into its components and derives a key for each component.
 fn derive_key_from_path(master_node: &[u8], path: &str) -> MmResult<[u8; 32], KeyDerivationError> {
     let mut current_key_material = master_node.to_vec();
+
+    if current_key_material.len() < 64 {
+        return MmError::err(KeyDerivationError::InvalidKeyLength);
+    }
+
     for segment in path.split('/').filter(|s| !s.is_empty()) {
         let mut mac = HmacSha512::new_from_slice(&current_key_material[..32])
             .map_err(|_| KeyDerivationError::HmacInitialization)?;


### PR DESCRIPTION
The `derive_key_from_path` function ([[link to code](https://github.com/KomodoPlatform/komodo-defi-framework/blob/a7ffbb1858db794abe7929fd4dea90840bed292f/mm2src/crypto/src/key_derivation.rs#L135-L152)](https://github.com/KomodoPlatform/komodo-defi-framework/blob/a7ffbb1858db794abe7929fd4dea90840bed292f/mm2src/crypto/src/key_derivation.rs#L135-L152)) could potentially lead to a panic if the `master_node` length is not 64.  

For example, calling it like this:  
```rust
let master_node = [0u8; 32];
let result = derive_key_from_path(&master_node, "");
```
In this case, since the loop over `path` will not be executed, `current_key_material` remains unchanged, and attempting to slice `current_key_material[32..64]` will cause a panic.  

Another potential panic occurs when attempting to slice `current_key_material[..32]` if `master_node` has a length below 32.  

### Possible Solution  
A simple fix for both cases is to check the length before proceeding:  
```rust
if current_key_material.len() < 64 {
    return MmError::err(KeyDerivationError::InvalidKeyLength);
}
```
This would prevent panics and ensure safer execution.