### PR TITLE
feat(swap): handle maker order matching based on electrum connection status

### DIFF
--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -261,7 +261,7 @@ pub mod utxo;
 use utxo::bch::{bch_coin_with_policy, BchActivationRequest, BchCoin};
 use utxo::qtum::{self, qtum_coin_with_policy, Qrc20AddressError, QtumCoin, QtumDelegationOps, QtumDelegationRequest,
                  QtumStakingInfosDetails, ScriptHashTypeNotSupported};
-use utxo::rpc_clients::{ElectrumClient, UtxoRpcClientEnum, UtxoRpcError};
+use utxo::rpc_clients::{UtxoRpcClientEnum, UtxoRpcError};
 use utxo::slp::SlpToken;
 use utxo::slp::{slp_addr_from_pubkey_str, SlpFeeDetails};
 use utxo::utxo_common::{big_decimal_from_sat_unsigned, payment_script, WaitForOutputSpendErr};
@@ -3566,8 +3566,8 @@ impl MmCoinEnum {
 
     fn is_platform_coin(&self) -> bool { self.ticker() == self.platform_ticker() }
 
-    pub fn electrum_client(&self) -> Option<ElectrumClient> {
-        let maybe_client = match self {
+    pub fn utxo_in_electrum_mode_has_active_connection(&self) -> Option<bool> {
+        if let UtxoRpcClientEnum::Electrum(c) = match self {
             MmCoinEnum::UtxoCoin(c) => &c.as_ref().rpc_client,
             MmCoinEnum::QtumCoin(c) => &c.as_ref().rpc_client,
             MmCoinEnum::Qrc20Coin(c) => &c.as_ref().rpc_client,
@@ -3575,13 +3575,15 @@ impl MmCoinEnum {
             MmCoinEnum::Bch(c) => &c.as_ref().rpc_client,
             MmCoinEnum::SlpToken(c) => &c.as_ref().rpc_client,
             _ => return None,
-        };
-
-        if let UtxoRpcClientEnum::Electrum(c) = maybe_client {
-            Some(c.clone())
-        } else {
-            None
+        } {
+            if c.connection_manager.get_active_connections().is_empty() {
+                return Some(false);
+            } else {
+                return Some(true);
+            }
         }
+
+        None
     }
 }
 

--- a/mm2src/mm2_main/src/lp_native_dex.rs
+++ b/mm2src/mm2_main/src/lp_native_dex.rs
@@ -51,7 +51,8 @@ use crate::lp_healthcheck::peer_healthcheck_topic;
 use crate::lp_message_service::{init_message_service, InitMessageServiceError};
 use crate::lp_network::{lp_network_ports, p2p_event_process_loop, subscribe_to_topic, NetIdError};
 use crate::lp_ordermatch::{broadcast_maker_orders_keep_alive_loop, clean_memory_loop, init_ordermatch_context,
-                           lp_ordermatch_loop, orders_kick_start, BalanceUpdateOrdermatchHandler, OrdermatchInitError};
+                           lp_ordermatch_loop, monitor_electrum_and_cancel_orders, orders_kick_start,
+                           BalanceUpdateOrdermatchHandler, OrdermatchInitError};
 use crate::lp_swap;
 use crate::lp_swap::swap_kick_starts;
 use crate::lp_wallet::{initialize_wallet_passphrase, WalletInitError};
@@ -490,6 +491,8 @@ pub async fn lp_init_continue(ctx: MmArc) -> MmInitResult<()> {
     ctx.spawner().spawn(lp_ordermatch_loop(ctx.clone()));
 
     ctx.spawner().spawn(broadcast_maker_orders_keep_alive_loop(ctx.clone()));
+
+    ctx.spawner().spawn(monitor_electrum_and_cancel_orders(ctx.clone()));
 
     #[cfg(target_arch = "wasm32")]
     init_wasm_event_streaming(&ctx);

--- a/mm2src/mm2_main/src/lp_native_dex.rs
+++ b/mm2src/mm2_main/src/lp_native_dex.rs
@@ -51,8 +51,7 @@ use crate::lp_healthcheck::peer_healthcheck_topic;
 use crate::lp_message_service::{init_message_service, InitMessageServiceError};
 use crate::lp_network::{lp_network_ports, p2p_event_process_loop, subscribe_to_topic, NetIdError};
 use crate::lp_ordermatch::{broadcast_maker_orders_keep_alive_loop, clean_memory_loop, init_ordermatch_context,
-                           lp_ordermatch_loop, monitor_electrum_and_cancel_orders, orders_kick_start,
-                           BalanceUpdateOrdermatchHandler, OrdermatchInitError};
+                           lp_ordermatch_loop, orders_kick_start, BalanceUpdateOrdermatchHandler, OrdermatchInitError};
 use crate::lp_swap;
 use crate::lp_swap::swap_kick_starts;
 use crate::lp_wallet::{initialize_wallet_passphrase, WalletInitError};
@@ -491,8 +490,6 @@ pub async fn lp_init_continue(ctx: MmArc) -> MmInitResult<()> {
     ctx.spawner().spawn(lp_ordermatch_loop(ctx.clone()));
 
     ctx.spawner().spawn(broadcast_maker_orders_keep_alive_loop(ctx.clone()));
-
-    ctx.spawner().spawn(monitor_electrum_and_cancel_orders(ctx.clone()));
 
     #[cfg(target_arch = "wasm32")]
     init_wasm_event_streaming(&ctx);

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -2004,6 +2004,8 @@ impl MakerOrder {
     }
 
     fn match_with_request(&self, taker: &TakerRequest) -> OrderMatchResult {
+        // TODO: only match with taker assuming our coin relies on electrum connections
+        // and there's an atleast 1 active connection.
         let taker_base_amount = taker.get_base_amount();
         let taker_rel_amount = taker.get_rel_amount();
 
@@ -3557,6 +3559,10 @@ async fn check_balance_for_maker_orders(ctx: MmArc, ordermatch_ctx: &OrdermatchC
             continue;
         }
 
+        // TODO: check coin depends on electrum and check their connection status.
+        // if connection status to all electrum client for this coin is down,
+        // change maker_order.is_active to false.
+
         let reason = if order.matches.is_empty() {
             MakerOrderCancellationReason::InsufficientBalance
         } else {
@@ -4883,6 +4889,8 @@ async fn cancel_previous_maker_orders(
         }
     }
 }
+
+// TODO: I should probaly implement `update_maker_order_active_status` here.
 
 pub async fn update_maker_order(ctx: &MmArc, req: MakerOrderUpdateReq) -> Result<MakerOrder, String> {
     let ordermatch_ctx = try_s!(OrdermatchContext::from_ctx(ctx));

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -1691,6 +1691,8 @@ pub struct MakerOrder {
     /// A custom priv key for more privacy to prevent linking orders of the same node between each other
     /// Commonly used with privacy coins (ARRR, ZCash, etc.)
     p2p_privkey: Option<SerializableSecp256k1Keypair>,
+    // Signal for maker orders that should be ordermatched.
+    is_active: bool,
 }
 
 pub struct MakerOrderBuilder<'a> {
@@ -1946,6 +1948,7 @@ impl<'a> MakerOrderBuilder<'a> {
             base_orderbook_ticker: self.base_orderbook_ticker,
             rel_orderbook_ticker: self.rel_orderbook_ticker,
             p2p_privkey,
+            is_active: true,
         })
     }
 
@@ -1970,6 +1973,7 @@ impl<'a> MakerOrderBuilder<'a> {
             base_orderbook_ticker: None,
             rel_orderbook_ticker: None,
             p2p_privkey: None,
+            is_active: true,
         }
     }
 }
@@ -2077,6 +2081,8 @@ impl MakerOrder {
     fn was_updated(&self) -> bool { self.updated_at != Some(self.created_at) }
 
     fn p2p_keypair(&self) -> Option<&KeyPair> { self.p2p_privkey.as_ref().map(|key| key.key_pair()) }
+
+    fn is_active(&self) -> bool { self.is_active }
 }
 
 impl From<TakerOrder> for MakerOrder {
@@ -2100,6 +2106,7 @@ impl From<TakerOrder> for MakerOrder {
                 base_orderbook_ticker: taker_order.base_orderbook_ticker,
                 rel_orderbook_ticker: taker_order.rel_orderbook_ticker,
                 p2p_privkey: taker_order.p2p_privkey,
+                is_active: true,
             },
             // The "buy" taker order is recreated with reversed pair as Maker order is always considered as "sell"
             TakerAction::Buy => {
@@ -2122,6 +2129,7 @@ impl From<TakerOrder> for MakerOrder {
                     base_orderbook_ticker: taker_order.rel_orderbook_ticker,
                     rel_orderbook_ticker: taker_order.base_orderbook_ticker,
                     p2p_privkey: taker_order.p2p_privkey,
+                    is_active: true,
                 }
             },
         }

--- a/mm2src/mm2_main/src/lp_ordermatch/my_orders_storage.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch/my_orders_storage.rs
@@ -724,6 +724,7 @@ mod tests {
             base_orderbook_ticker: None,
             rel_orderbook_ticker: None,
             p2p_privkey: None,
+            is_active: true,
         }
     }
 

--- a/mm2src/mm2_main/src/ordermatch_tests.rs
+++ b/mm2src/mm2_main/src/ordermatch_tests.rs
@@ -3299,3 +3299,45 @@ fn test_maker_order_balance_loops() {
     assert!(!maker_orders_ctx.balance_loop_exists(morty_ticker));
     assert_eq!(*maker_orders_ctx.count_by_tickers.get(morty_ticker).unwrap(), 0);
 }
+
+#[test]
+fn test_match_maker_order_and_taker_request_fails_with_not_active() {
+    let maker = MakerOrder {
+        base: "BASE".into(),
+        rel: "REL".into(),
+        created_at: now_ms(),
+        updated_at: Some(now_ms()),
+        max_base_vol: 10.into(),
+        min_base_vol: 0.into(),
+        price: 1.into(),
+        matches: HashMap::new(),
+        started_swaps: Vec::new(),
+        uuid: new_uuid(),
+        conf_settings: None,
+        changes_history: None,
+        save_in_history: false,
+        base_orderbook_ticker: None,
+        rel_orderbook_ticker: None,
+        p2p_privkey: None,
+        is_active: false, // maker order not active
+    };
+
+    let request = TakerRequest {
+        base: "BASE".into(),
+        rel: "REL".into(),
+        uuid: new_uuid(),
+        dest_pub_key: H256Json::default(),
+        sender_pubkey: H256Json::default(),
+        base_amount: 10.into(),
+        rel_amount: 20.into(),
+        action: TakerAction::Buy,
+        match_by: MatchBy::Any,
+        conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
+    };
+
+    let actual = maker.match_with_request(&request);
+    let expected = OrderMatchResult::NotMatched;
+    assert_eq!(expected, actual);
+}

--- a/mm2src/mm2_main/src/ordermatch_tests.rs
+++ b/mm2src/mm2_main/src/ordermatch_tests.rs
@@ -39,6 +39,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        is_active: true,
     };
 
     let request = TakerRequest {
@@ -77,6 +78,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        is_active: true,
     };
 
     let request = TakerRequest {
@@ -115,6 +117,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        is_active: true,
     };
 
     let request = TakerRequest {
@@ -153,6 +156,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        is_active: true,
     };
 
     let request = TakerRequest {
@@ -191,6 +195,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        is_active: true,
     };
 
     let request = TakerRequest {
@@ -229,6 +234,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        is_active: true,
     };
 
     let request = TakerRequest {
@@ -269,6 +275,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        is_active: true,
     };
     let request = TakerRequest {
         base: "KMD".to_owned(),
@@ -309,6 +316,7 @@ fn test_match_maker_order_and_taker_request() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        is_active: true,
     };
     let request = TakerRequest {
         base: "REL".to_owned(),
@@ -380,6 +388,7 @@ fn test_maker_order_available_amount() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        is_active: true,
     };
     maker.matches.insert(new_uuid(), MakerMatch {
         request: TakerRequest {
@@ -974,6 +983,7 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
             base_orderbook_ticker: None,
             rel_orderbook_ticker: None,
             p2p_privkey: None,
+            is_active: true,
         },
         None,
     );
@@ -996,6 +1006,7 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
             base_orderbook_ticker: None,
             rel_orderbook_ticker: None,
             p2p_privkey: None,
+            is_active: true,
         },
         None,
     );
@@ -1018,6 +1029,7 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
             base_orderbook_ticker: None,
             rel_orderbook_ticker: None,
             p2p_privkey: None,
+            is_active: true,
         },
         None,
     );
@@ -1206,6 +1218,7 @@ fn test_maker_order_was_updated() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        is_active: true,
     };
     let mut update_msg = MakerOrderUpdated::new(maker_order.uuid);
     update_msg.with_new_price(BigRational::from_integer(2.into()));
@@ -3215,6 +3228,7 @@ fn test_maker_order_balance_loops() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        is_active: true,
     };
 
     let morty_order = MakerOrder {
@@ -3234,6 +3248,7 @@ fn test_maker_order_balance_loops() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        is_active: true,
     };
 
     assert!(!maker_orders_ctx.balance_loop_exists(rick_ticker));
@@ -3266,6 +3281,7 @@ fn test_maker_order_balance_loops() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        is_active: true,
     };
 
     maker_orders_ctx.add_order(ctx.weak(), rick_order_2.clone(), None);


### PR DESCRIPTION
fix: #2281
handle maker order matching by checking electrum connection status, deactivate orders when all electrum servers are down, and reactivate them once the connection is restored
