### PR TITLE
fix(fs): make `filter_files_by_extension` return only files

### DIFF
--- a/mm2src/mm2_io/src/fs.rs
+++ b/mm2src/mm2_io/src/fs.rs
@@ -337,3 +337,10 @@ pub fn copy_dir_all(src: &dyn AsRef<Path>, dst: &dyn AsRef<Path>) -> io::Result<
     }
     Ok(())
 }
+
+pub async fn is_file_async(path: &PathBuf) -> bool {
+    async_fs::metadata(path)
+        .await
+        .map(|metadata| metadata.is_file())
+        .unwrap_or(false)
+}

--- a/mm2src/mm2_io/src/fs.rs
+++ b/mm2src/mm2_io/src/fs.rs
@@ -337,10 +337,3 @@ pub fn copy_dir_all(src: &dyn AsRef<Path>, dst: &dyn AsRef<Path>) -> io::Result<
     }
     Ok(())
 }
-
-pub async fn is_file_async(path: &PathBuf) -> bool {
-    async_fs::metadata(path)
-        .await
-        .map(|metadata| metadata.is_file())
-        .unwrap_or(false)
-}

--- a/mm2src/mm2_io/src/fs.rs
+++ b/mm2src/mm2_io/src/fs.rs
@@ -197,7 +197,7 @@ async fn filter_files_by_extension(dir_path: &Path, extension: &str) -> IoResult
     let entries = read_dir_async(dir_path)
         .await?
         .into_iter()
-        .filter(|path| path.extension().map(|ext| ext.to_ascii_lowercase()) == ext)
+        .filter(|path| path.extension().map(|ext| ext.to_ascii_lowercase()) == ext && !path.is_dir())
         .collect();
     Ok(entries)
 }

--- a/mm2src/mm2_main/src/lp_wallet/mnemonics_storage.rs
+++ b/mm2src/mm2_main/src/lp_wallet/mnemonics_storage.rs
@@ -71,13 +71,10 @@ pub(super) async fn read_all_wallet_names(ctx: &MmArc) -> WalletsStorageResult<i
 
     // let's exclude "directories" from the wallet_names
     let dir_path = ctx.db_root();
-    let mut file_wallet_names = Vec::new();
-    for wallet_name in wallet_names {
-        let file_path = dir_path.join(&wallet_name).with_extension(ext);
-        if file_path.is_file() {
-            file_wallet_names.push(wallet_name);
-        }
-    }
-    drop_mutability!(file_wallet_names);
-    Ok(file_wallet_names.into_iter())
+    let file_wallet_names = wallet_names
+        .filter(move |wallet_name| {
+            let file_path = dir_path.join(wallet_name).with_extension(ext);
+            file_path.is_file()
+        });
+    Ok(file_wallet_names)
 }

--- a/mm2src/mm2_main/src/lp_wallet/mnemonics_storage.rs
+++ b/mm2src/mm2_main/src/lp_wallet/mnemonics_storage.rs
@@ -69,14 +69,11 @@ pub(super) async fn read_all_wallet_names(ctx: &MmArc) -> WalletsStorageResult<i
         .await
         .mm_err(|e| WalletsStorageError::FsReadError(format!("Error reading wallets directory: {}", e)))?;
 
-    // let's exclude directories from the wallet_names, of course we can do it on the upper levels,
-    // but let's leave `filter_files_by_extension` as is for now
+    // let's exclude "directories" from the wallet_names
     let dir_path = ctx.db_root();
     let mut file_wallet_names = Vec::new();
     for wallet_name in wallet_names {
-        let mut file_path = dir_path.to_path_buf();
-        file_path.push(&wallet_name);
-        file_path.set_extension(ext);
+        let file_path = dir_path.join(&wallet_name).with_extension(ext);
         if file_path.is_file() {
             file_wallet_names.push(wallet_name);
         }

--- a/mm2src/mm2_main/src/lp_wallet/mnemonics_storage.rs
+++ b/mm2src/mm2_main/src/lp_wallet/mnemonics_storage.rs
@@ -64,17 +64,8 @@ pub(super) async fn read_encrypted_passphrase_if_available(ctx: &MmArc) -> Walle
 }
 
 pub(super) async fn read_all_wallet_names(ctx: &MmArc) -> WalletsStorageResult<impl Iterator<Item = String>> {
-    let ext: &str = "dat";
-    let wallet_names = list_files_by_extension(&ctx.db_root(), ext, false)
+    let wallet_names = list_files_by_extension(&ctx.db_root(), "dat", false)
         .await
         .mm_err(|e| WalletsStorageError::FsReadError(format!("Error reading wallets directory: {}", e)))?;
-
-    // let's exclude "directories" from the wallet_names
-    let dir_path = ctx.db_root();
-    let file_wallet_names = wallet_names
-        .filter(move |wallet_name| {
-            let file_path = dir_path.join(wallet_name).with_extension(ext);
-            file_path.is_file()
-        });
-    Ok(file_wallet_names)
+    Ok(wallet_names)
 }

--- a/mm2src/mm2_main/src/lp_wallet/mnemonics_storage.rs
+++ b/mm2src/mm2_main/src/lp_wallet/mnemonics_storage.rs
@@ -1,7 +1,7 @@
 use crypto::EncryptedData;
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::prelude::*;
-use mm2_io::fs::{ensure_file_is_writable, list_files_by_extension, is_file_async};
+use mm2_io::fs::{ensure_file_is_writable, list_files_by_extension};
 
 type WalletsStorageResult<T> = Result<T, MmError<WalletsStorageError>>;
 
@@ -77,7 +77,7 @@ pub(super) async fn read_all_wallet_names(ctx: &MmArc) -> WalletsStorageResult<i
         let mut file_path = dir_path.to_path_buf();
         file_path.push(&wallet_name);
         file_path.set_extension(ext);
-        if is_file_async(&file_path).await {
+        if file_path.is_file() {
             file_wallet_names.push(wallet_name);
         }
     }


### PR DESCRIPTION
By default, `get_wallet_names` returns not only `*.dat` filenames from `db_root` as wallet names but also directories. For example, if we create a `l.dat` **folder** in `db_root`, it will be included in the wallet names list, like this:  

```json
{
  "mmrpc": "2.0",
  "result": {
    "wallet_names": [
      "l",
      "decker",
      "hello"
    ],
    "activated_wallet": "decker"
  },
  "id": null
}
```
  
The current implementation is not necessarily ideal. Maybe we should perform this check (i.e., ensuring it’s a file and not a directory) directly in `filter_files_by_extension`. But my primary goal was to avoid modifying existing file-related functions.