### PR TITLE
fix(tests): stabilize `tendermint_coin::test_claim_staking_rewards`

### DIFF
--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -4709,8 +4709,9 @@ pub mod tendermint_coin_tests {
         assert_eq!(vec![coin.account_id.to_string()], res.to);
         assert_eq!(TransactionType::ClaimDelegationRewards, res.transaction_type);
         assert_eq!(Some(memo), res.memo);
-        assert_eq!(reward_amount, res.total_amount);
-        assert_eq!(reward_amount, res.received_by_me);
+        // Rewards can increase during our tests, so round the first 4 digits.
+        assert_eq!(reward_amount.round(4), res.total_amount.round(4));
+        assert_eq!(reward_amount.round(4), res.received_by_me.round(4));
         // tx fee must be taken into account
         assert!(reward_amount > res.my_balance_change);
     }


### PR DESCRIPTION
`tendermint_coin::test_claim_staking_rewards` sometimes fails because the actual reward amount increases while the test is running. This PR stabilizes the coverage logic.

Example failure: https://github.com/KomodoPlatform/komodo-defi-framework/actions/runs/13543733711/job/37850426342?pr=2372#step:6:435