### PR TITLE
feat(tendermint): staking queries

### DIFF
--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -5003,11 +5003,9 @@ pub async fn delegations_info(ctx: MmArc, req: DelegationsInfo) -> Result<Json, 
         DelegationsInfoDetails::Cosmos(r) => match coin {
             MmCoinEnum::Tendermint(t) => Ok(t.delegations_list(r.paging).await.map(|v| json!(v))?),
             MmCoinEnum::TendermintToken(t) => Ok(t.platform_coin.delegations_list(r.paging).await.map(|v| json!(v))?),
-            _ => {
-                return MmError::err(StakingInfoError::InvalidPayload {
-                    reason: format!("{} is not a Cosmos coin", req.coin),
-                });
-            },
+            _ => MmError::err(StakingInfoError::InvalidPayload {
+                reason: format!("{} is not a Cosmos coin", req.coin),
+            }),
         },
     }
 }

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -5014,7 +5014,9 @@ pub async fn delegations_info(ctx: MmArc, req: DelegationsInfo) -> Result<Json, 
 
         DelegationsInfoDetails::Cosmos(r) => match coin {
             MmCoinEnum::Tendermint(t) => Ok(t.delegations_list(r.paging).await.map(|v| json!(v))?),
-            MmCoinEnum::TendermintToken(t) => Ok(t.platform_coin.delegations_list(r.paging).await.map(|v| json!(v))?),
+            MmCoinEnum::TendermintToken(_) => MmError::err(StakingInfoError::InvalidPayload {
+                reason: "Tokens are not supported for delegation".into(),
+            }),
             _ => MmError::err(StakingInfoError::InvalidPayload {
                 reason: format!("{} is not a Cosmos coin", req.coin),
             }),
@@ -5028,11 +5030,9 @@ pub async fn ongoing_undelegations_info(ctx: MmArc, req: UndelegationsInfo) -> R
     match req.info_details {
         UndelegationsInfoDetails::Cosmos(r) => match coin {
             MmCoinEnum::Tendermint(t) => Ok(t.ongoing_undelegations_list(r.paging).await.map(|v| json!(v))?),
-            MmCoinEnum::TendermintToken(t) => Ok(t
-                .platform_coin
-                .ongoing_undelegations_list(r.paging)
-                .await
-                .map(|v| json!(v))?),
+            MmCoinEnum::TendermintToken(_) => MmError::err(StakingInfoError::InvalidPayload {
+                reason: "Tokens are not supported for delegation".into(),
+            }),
             _ => MmError::err(StakingInfoError::InvalidPayload {
                 reason: format!("{} is not a Cosmos coin", req.coin),
             }),

--- a/mm2src/coins/rpc_command/tendermint/staking.rs
+++ b/mm2src/coins/rpc_command/tendermint/staking.rs
@@ -153,7 +153,7 @@ pub struct ClaimRewardsPayload {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct DelegationsQuery {
+pub struct SimpleListQuery {
     #[serde(flatten)]
     pub paging: PagingOptions,
 }
@@ -167,4 +167,23 @@ pub struct DelegationsQueryResponse {
 pub(crate) struct Delegation {
     pub(crate) validator_address: String,
     pub(crate) delegated_amount: BigDecimal,
+    pub(crate) reward_amount: BigDecimal,
+}
+
+#[derive(Serialize)]
+pub struct UndelegationsQueryResponse {
+    pub(crate) ongoing_undelegations: Vec<Undelegation>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct Undelegation {
+    pub(crate) validator_address: String,
+    pub(crate) entries: Vec<UndelegationEntry>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct UndelegationEntry {
+    pub(crate) creation_height: i64,
+    pub(crate) completion_datetime: String,
+    pub(crate) balance: BigDecimal,
 }

--- a/mm2src/coins/rpc_command/tendermint/staking.rs
+++ b/mm2src/coins/rpc_command/tendermint/staking.rs
@@ -158,12 +158,12 @@ pub struct DelegationsQuery {
     pub paging: PagingOptions,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, PartialEq, Serialize)]
 pub struct DelegationsQueryResponse {
     pub(crate) delegations: Vec<Delegation>,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, PartialEq, Serialize)]
 pub(crate) struct Delegation {
     pub(crate) validator_address: String,
     pub(crate) delegated_amount: BigDecimal,

--- a/mm2src/coins/rpc_command/tendermint/staking.rs
+++ b/mm2src/coins/rpc_command/tendermint/staking.rs
@@ -155,7 +155,7 @@ pub struct ClaimRewardsPayload {
 #[derive(Debug, Deserialize)]
 pub struct SimpleListQuery {
     #[serde(flatten)]
-    pub paging: PagingOptions,
+    pub(crate) paging: PagingOptions,
 }
 
 #[derive(Debug, PartialEq, Serialize)]

--- a/mm2src/coins/rpc_command/tendermint/staking.rs
+++ b/mm2src/coins/rpc_command/tendermint/staking.rs
@@ -30,7 +30,7 @@ impl ToString for ValidatorStatus {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct ValidatorsRPC {
+pub struct ValidatorsQuery {
     #[serde(flatten)]
     paging: PagingOptions,
     #[serde(default)]
@@ -38,7 +38,7 @@ pub struct ValidatorsRPC {
 }
 
 #[derive(Clone, Serialize)]
-pub struct ValidatorsRPCResponse {
+pub struct ValidatorsQueryResponse {
     validators: Vec<serde_json::Value>,
 }
 
@@ -59,8 +59,8 @@ impl From<TendermintCoinRpcError> for StakingInfoError {
 
 pub async fn validators_rpc(
     coin: MmCoinEnum,
-    req: ValidatorsRPC,
-) -> Result<ValidatorsRPCResponse, MmError<StakingInfoError>> {
+    req: ValidatorsQuery,
+) -> Result<ValidatorsQueryResponse, MmError<StakingInfoError>> {
     fn maybe_jsonize_description(description: Option<Description>) -> Option<serde_json::Value> {
         description.map(|d| {
             json!({
@@ -121,7 +121,7 @@ pub async fn validators_rpc(
         },
     };
 
-    Ok(ValidatorsRPCResponse {
+    Ok(ValidatorsQueryResponse {
         validators: validators.into_iter().map(jsonize_validator).collect(),
     })
 }
@@ -150,4 +150,21 @@ pub struct ClaimRewardsPayload {
     /// Setting `force` to `true` disables this logic.
     #[serde(default)]
     pub force: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DelegationsQuery {
+    #[serde(flatten)]
+    pub paging: PagingOptions,
+}
+
+#[derive(Serialize)]
+pub struct DelegationsQueryResponse {
+    pub(crate) delegations: Vec<Delegation>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct Delegation {
+    pub(crate) validator_address: String,
+    pub(crate) delegated_amount: BigDecimal,
 }

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -2690,6 +2690,7 @@ impl TendermintCoin {
         Ok(DelegationsQueryResponse { delegations })
     }
 
+    /// TODO: needs coverage
     pub(crate) async fn ongoing_undelegations_list(
         &self,
         paging: PagingOptions,

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -2690,7 +2690,6 @@ impl TendermintCoin {
         Ok(DelegationsQueryResponse { delegations })
     }
 
-    /// TODO: needs coverage
     pub(crate) async fn ongoing_undelegations_list(
         &self,
         paging: PagingOptions,

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -2672,9 +2672,9 @@ impl TendermintCoin {
 
             let reward_amount = match self.get_delegation_reward_amount(&account_id).await {
                 Ok(reward) => reward,
-                Err(e) => match e.into_inner() {
+                Err(e) => match e.get_inner() {
                     DelegationError::NothingToClaim { .. } => BigDecimal::zero(),
-                    e => return MmError::err(TendermintCoinRpcError::InvalidResponse(e.to_string())),
+                    _ => return MmError::err(TendermintCoinRpcError::InvalidResponse(e.to_string())),
                 },
             };
 

--- a/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
+++ b/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
@@ -46,8 +46,9 @@ use coins::utxo::slp::SlpToken;
 use coins::utxo::utxo_standard::UtxoStandardCoin;
 use coins::z_coin::ZCoin;
 use coins::{add_delegation, claim_staking_rewards, delegations_info, get_my_address, get_raw_transaction,
-            get_swap_transaction_fee_policy, nft, remove_delegation, set_swap_transaction_fee_policy, sign_message,
-            sign_raw_transaction, validators_info, verify_message, withdraw};
+            get_swap_transaction_fee_policy, nft, ongoing_undelegations_info, remove_delegation,
+            set_swap_transaction_fee_policy, sign_message, sign_raw_transaction, validators_info, verify_message,
+            withdraw};
 use coins_activation::{cancel_init_l2, cancel_init_platform_coin_with_tokens, cancel_init_standalone_coin,
                        cancel_init_token, enable_platform_coin_with_tokens, enable_token, init_l2, init_l2_status,
                        init_l2_user_action, init_platform_coin_with_tokens, init_platform_coin_with_tokens_status,
@@ -468,8 +469,9 @@ async fn staking_dispatcher(
         staking_query_method: &str,
     ) -> DispatcherResult<Response<Vec<u8>>> {
         match staking_query_method {
-            "validators" => handle_mmrpc(ctx, request, validators_info).await,
             "delegations" => handle_mmrpc(ctx, request, delegations_info).await,
+            "ongoing_undelegations" => handle_mmrpc(ctx, request, ongoing_undelegations_info).await,
+            "validators" => handle_mmrpc(ctx, request, validators_info).await,
             _ => MmError::err(DispatcherError::NoSuchMethod),
         }
     }

--- a/mm2src/mm2_main/tests/docker_tests/tendermint_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/tendermint_tests.rs
@@ -5,7 +5,8 @@ use mm2_test_helpers::for_tests::{atom_testnet_conf, disable_coin, disable_coin_
                                   enable_tendermint_token, enable_tendermint_without_balance,
                                   get_tendermint_my_tx_history, ibc_withdraw, iris_ibc_nucleus_testnet_conf,
                                   my_balance, nucleus_testnet_conf, orderbook, orderbook_v2, send_raw_transaction,
-                                  set_price, tendermint_add_delegation, tendermint_remove_delegation,
+                                  set_price, tendermint_add_delegation, tendermint_delegations,
+                                  tendermint_ongoing_undelegations, tendermint_remove_delegation,
                                   tendermint_remove_delegation_raw, tendermint_validators, withdraw_v1, MarketMakerIt,
                                   Mm2TestConf};
 use mm2_test_helpers::structs::{Bip44Chain, HDAccountAddressId, OrderbookAddress, OrderbookV2Response, RpcV2Response,
@@ -760,6 +761,10 @@ fn test_tendermint_remove_delegation() {
     let send_raw_tx = block_on(send_raw_transaction(&mm, coin_ticker, &tx_details.tx_hex));
     log!("Send raw tx {}", serde_json::to_string(&send_raw_tx).unwrap());
 
+    let r = block_on(tendermint_delegations(&mm, coin_ticker));
+    let delegation_info = r["result"]["delegations"].as_array().unwrap().last().unwrap();
+    assert_eq!(delegation_info["validator_address"], VALIDATOR_ADDRESS);
+
     // Try to undelegate more than the total delegated amount
     let raw_response = block_on(tendermint_remove_delegation_raw(
         &mm,
@@ -777,17 +782,17 @@ fn test_tendermint_remove_delegation() {
     };
     assert!(raw_response.1.contains("TooMuchToUndelegate"));
 
-    // TODO: check currently delegated stakes and assert them
-    // This requires delegation listing feature
-
     let tx_details = block_on(tendermint_remove_delegation(&mm, coin_ticker, VALIDATOR_ADDRESS, "0.5"));
 
     assert_eq!(tx_details.from, vec![MY_ADDRESS.to_owned()]);
     assert!(tx_details.to.is_empty());
     assert_eq!(tx_details.transaction_type, TransactionType::RemoveDelegation);
 
-    // TODO: check currently delegated stakes and assert them
-    // This requires delegation listing feature
+    let r = block_on(tendermint_ongoing_undelegations(&mm, coin_ticker));
+    let undelegation_info = r["result"]["ongoing_undelegations"].as_array().unwrap().last().unwrap();
+    assert_eq!(undelegation_info["validator_address"], VALIDATOR_ADDRESS);
+    let undelegation_entry = undelegation_info["entries"].as_array().unwrap().last().unwrap();
+    assert_eq!(undelegation_entry["balance"], "0.5");
 }
 
 mod swap {

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -237,10 +237,7 @@ pub const QRC20_ELECTRUMS: &[&str] = &[
     "electrum3.cipig.net:10071",
 ];
 pub const T_BCH_ELECTRUMS: &[&str] = &["tbch.loping.net:60001", "bch0.kister.net:51001"];
-pub const TBTC_ELECTRUMS: &[&str] = &[
-    "electrum3.cipig.net:10068",
-    "testnet.aranguren.org:51001",
-];
+pub const TBTC_ELECTRUMS: &[&str] = &["electrum3.cipig.net:10068", "testnet.aranguren.org:51001"];
 
 pub const ETH_MAINNET_NODES: &[&str] = &[
     "https://mainnet.infura.io/v3/c01c1b4cf66642528547624e1d6d9d6b",
@@ -831,13 +828,9 @@ pub fn eth_testnet_conf_trezor() -> Json {
 }
 
 /// ETH configuration used for dockerized Geth dev node
-pub fn eth_dev_conf() -> Json {
-    eth_conf("ETH")
-}
+pub fn eth_dev_conf() -> Json { eth_conf("ETH") }
 
-pub fn eth1_dev_conf() -> Json {
-    eth_conf("ETH1")
-}
+pub fn eth1_dev_conf() -> Json { eth_conf("ETH1") }
 
 fn eth_conf(coin: &str) -> Json {
     json!({
@@ -2102,7 +2095,12 @@ pub async fn enable_eth_coin_v2(
         }))
         .await
         .unwrap();
-    assert_eq!(enable.0, StatusCode::OK, "'enable_eth_with_tokens' failed: {}", enable.1);
+    assert_eq!(
+        enable.0,
+        StatusCode::OK,
+        "'enable_eth_with_tokens' failed: {}",
+        enable.1
+    );
     json::from_str(&enable.1).unwrap()
 }
 
@@ -3130,6 +3128,52 @@ pub async fn get_tendermint_my_tx_history(mm: &MarketMakerIt, coin: &str, limit:
     );
 
     log!("tendermint 'my_tx_history' response {}", request.1);
+    json::from_str(&request.1).unwrap()
+}
+
+pub async fn tendermint_delegations(mm: &MarketMakerIt, coin: &str) -> Json {
+    let rpc_endpoint = "experimental::staking::query::delegations";
+    let request = json!({
+        "userpass": mm.userpass,
+        "method": rpc_endpoint,
+        "mmrpc": "2.0",
+        "params": {
+            "coin": coin,
+            "info_details": {
+                "type": "Cosmos",
+                "limit": 0,
+                "page_number": 1
+            }
+        }
+    });
+    log!("{rpc_endpoint} request {}", json::to_string(&request).unwrap());
+
+    let request = mm.rpc(&request).await.unwrap();
+    assert_eq!(request.0, StatusCode::OK, "'{rpc_endpoint}' failed: {}", request.1);
+    log!("{rpc_endpoint} response {}", request.1);
+    json::from_str(&request.1).unwrap()
+}
+
+pub async fn tendermint_ongoing_undelegations(mm: &MarketMakerIt, coin: &str) -> Json {
+    let rpc_endpoint = "experimental::staking::query::ongoing_undelegations";
+    let request = json!({
+        "userpass": mm.userpass,
+        "method": rpc_endpoint,
+        "mmrpc": "2.0",
+        "params": {
+            "coin": coin,
+            "info_details": {
+                "type": "Cosmos",
+                "limit": 0,
+                "page_number": 1
+            }
+        }
+    });
+    log!("{rpc_endpoint} request {}", json::to_string(&request).unwrap());
+
+    let request = mm.rpc(&request).await.unwrap();
+    assert_eq!(request.0, StatusCode::OK, "'{rpc_endpoint}' failed: {}", request.1);
+    log!("{rpc_endpoint} response {}", request.1);
     json::from_str(&request.1).unwrap()
 }
 


### PR DESCRIPTION
Implements `delegations` and `ongoing_undelegations` searching RPCs including rewards and undelegation completion period information for tendermint.