### PR TITLE
fix(ci): use correct rustup component syntax in fmt-and-lint job

### DIFF
--- a/.github/workflows/fmt-and-lint.yml
+++ b/.github/workflows/fmt-and-lint.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Install toolchain
         run: |
-          rustup toolchain install nightly-2023-06-01 --no-self-update --profile=minimal --component rustfmt clippy
+          rustup toolchain install nightly-2023-06-01 --no-self-update --profile=minimal --component rustfmt,clippy
           rustup default nightly-2023-06-01
 
       - name: Install build deps


### PR DESCRIPTION
The `--component` flag in rustup commands was using incorrect syntax when specifying multiple components. This caused CI failures with the error `invalid value 'clippy' for '[TOOLCHAIN]...': invalid toolchain name: 'clippy'`.