### PR TITLE
improvement(network): remove static IPs from seed lists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4252,6 +4252,7 @@ dependencies = [
  "log",
  "mm2_core",
  "mm2_event_stream",
+ "mm2_net",
  "mm2_number",
  "parking_lot",
  "rand 0.7.3",

--- a/mm2src/mm2_main/src/lp_native_dex.rs
+++ b/mm2src/mm2_main/src/lp_native_dex.rs
@@ -99,7 +99,6 @@ const DEFAULT_NETID_SEEDNODES: &[SeedNodeInfo] = &[
         "12D3KooWPR2RoPi19vQtLugjCdvVmCcGLP2iXAzbDfP3tp81ZL4d",
         "kalessin.dragon-seed.com",
     ),
-    SeedNodeInfo::new("12D3KooWEaZpH61H4yuQkaNG5AsyGdpBhKRppaLdAY52a774ab5u", "fr1.cipig.net"),
 ];
 
 pub type P2PResult<T> = Result<T, MmError<P2PInitError>>;

--- a/mm2src/mm2_main/src/lp_native_dex.rs
+++ b/mm2src/mm2_main/src/lp_native_dex.rs
@@ -99,6 +99,14 @@ const DEFAULT_NETID_SEEDNODES: &[SeedNodeInfo] = &[
         "12D3KooWPR2RoPi19vQtLugjCdvVmCcGLP2iXAzbDfP3tp81ZL4d",
         "kalessin.dragon-seed.com",
     ),
+    SeedNodeInfo::new(
+        "12D3KooWEaZpH61H4yuQkaNG5AsyGdpBhKRppaLdAY52a774ab5u",
+        "seed01.kmdefi.net",
+    ),
+    SeedNodeInfo::new(
+        "12D3KooWAd5gPXwX7eDvKWwkr2FZGfoJceKDCA53SHmTFFVkrN7Q",
+        "seed02.kmdefi.net",
+    ),
 ];
 
 pub type P2PResult<T> = Result<T, MmError<P2PInitError>>;

--- a/mm2src/mm2_main/src/lp_native_dex.rs
+++ b/mm2src/mm2_main/src/lp_native_dex.rs
@@ -73,44 +73,33 @@ cfg_wasm32! {
 const DEFAULT_NETID_SEEDNODES: &[SeedNodeInfo] = &[
     SeedNodeInfo::new(
         "12D3KooWHKkHiNhZtKceQehHhPqwU5W1jXpoVBgS1qst899GjvTm",
-        "168.119.236.251",
         "viserion.dragon-seed.com",
     ),
     SeedNodeInfo::new(
         "12D3KooWAToxtunEBWCoAHjefSv74Nsmxranw8juy3eKEdrQyGRF",
-        "168.119.236.240",
         "rhaegal.dragon-seed.com",
     ),
     SeedNodeInfo::new(
         "12D3KooWSmEi8ypaVzFA1AGde2RjxNW5Pvxw3qa2fVe48PjNs63R",
-        "168.119.236.239",
         "drogon.dragon-seed.com",
     ),
     SeedNodeInfo::new(
         "12D3KooWMrjLmrv8hNgAoVf1RfumfjyPStzd4nv5XL47zN4ZKisb",
-        "168.119.237.8",
         "falkor.dragon-seed.com",
     ),
     SeedNodeInfo::new(
         "12D3KooWEWzbYcosK2JK9XpFXzumfgsWJW1F7BZS15yLTrhfjX2Z",
-        "65.21.51.47",
         "smaug.dragon-seed.com",
     ),
     SeedNodeInfo::new(
         "12D3KooWJWBnkVsVNjiqUEPjLyHpiSmQVAJ5t6qt1Txv5ctJi9Xd",
-        "135.181.34.220",
         "balerion.dragon-seed.com",
     ),
     SeedNodeInfo::new(
         "12D3KooWPR2RoPi19vQtLugjCdvVmCcGLP2iXAzbDfP3tp81ZL4d",
-        "168.119.237.13",
         "kalessin.dragon-seed.com",
     ),
-    SeedNodeInfo::new(
-        "12D3KooWEaZpH61H4yuQkaNG5AsyGdpBhKRppaLdAY52a774ab5u",
-        "46.4.78.11",
-        "fr1.cipig.net",
-    ),
+    SeedNodeInfo::new("12D3KooWEaZpH61H4yuQkaNG5AsyGdpBhKRppaLdAY52a774ab5u", "fr1.cipig.net"),
 ];
 
 pub type P2PResult<T> = Result<T, MmError<P2PInitError>>;
@@ -314,11 +303,10 @@ fn default_seednodes(netid: u16) -> Vec<RelayAddress> {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn default_seednodes(netid: u16) -> Vec<RelayAddress> {
-    use crate::lp_network::addr_to_ipv4_string;
     if netid == 8762 {
         DEFAULT_NETID_SEEDNODES
             .iter()
-            .filter_map(|SeedNodeInfo { domain, .. }| addr_to_ipv4_string(domain).ok())
+            .filter_map(|SeedNodeInfo { domain, .. }| mm2_net::ip_addr::addr_to_ipv4_string(domain).ok())
             .map(RelayAddress::IPv4)
             .collect()
     } else {

--- a/mm2src/mm2_main/src/lp_stats.rs
+++ b/mm2src/mm2_main/src/lp_stats.rs
@@ -9,13 +9,13 @@ use mm2_core::mm_ctx::{from_ctx, MmArc};
 use mm2_err_handle::prelude::*;
 use mm2_libp2p::application::request_response::network_info::NetworkInfoRequest;
 use mm2_libp2p::{encode_message, NetworkInfo, PeerId, RelayAddress, RelayAddressError};
+use mm2_net::ip_addr::ParseAddressError;
 use serde_json::{self as json, Value as Json};
 use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
 use std::sync::Arc;
 
-use crate::lp_network::{add_reserved_peer_addresses, lp_network_ports, request_peers, NetIdError, ParseAddressError,
-                        PeerDecodedResponse};
+use crate::lp_network::{add_reserved_peer_addresses, lp_network_ports, request_peers, NetIdError, PeerDecodedResponse};
 use std::str::FromStr;
 
 pub type NodeVersionResult<T> = Result<T, MmError<NodeVersionError>>;
@@ -127,8 +127,6 @@ pub async fn add_node_to_version_stat(_ctx: MmArc, _req: Json) -> NodeVersionRes
 /// Adds node info. to db to be used later for stats collection
 #[cfg(not(target_arch = "wasm32"))]
 pub async fn add_node_to_version_stat(ctx: MmArc, req: Json) -> NodeVersionResult<String> {
-    use crate::lp_network::addr_to_ipv4_string;
-
     let node_info: NodeInfo = json::from_value(req)?;
 
     // Check that the entered peer_id is valid
@@ -137,7 +135,7 @@ pub async fn add_node_to_version_stat(ctx: MmArc, req: Json) -> NodeVersionResul
         .parse::<PeerId>()
         .map_to_mm(|e| NodeVersionError::PeerIdParseError(node_info.peer_id.clone(), e.to_string()))?;
 
-    let ipv4_addr = addr_to_ipv4_string(&node_info.address)?;
+    let ipv4_addr = mm2_net::ip_addr::addr_to_ipv4_string(&node_info.address)?;
     let node_info_with_ipv4_addr = NodeInfo {
         name: node_info.name,
         address: ipv4_addr,

--- a/mm2src/mm2_net/src/ip_addr.rs
+++ b/mm2src/mm2_net/src/ip_addr.rs
@@ -1,5 +1,6 @@
 use crate::transport::slurp_url;
-use common::log;
+use common::{cfg_native, log};
+use derive_more::Display;
 use gstuff::try_s;
 use gstuff::{ERR, ERRL};
 use mm2_core::mm_ctx::MmArc;
@@ -9,6 +10,11 @@ use std::fs;
 use std::io::Read;
 use std::net::{IpAddr, Ipv4Addr};
 use std::path::Path;
+
+cfg_native! {
+    use std::net::ToSocketAddrs;
+    use mm2_err_handle::prelude::MmError;
+}
 
 const IP_PROVIDERS: [&str; 2] = ["http://checkip.amazonaws.com/", "http://api.ipify.org"];
 
@@ -168,4 +174,50 @@ pub async fn myipaddr(ctx: MmArc) -> Result<IpAddr, String> {
         try_s!(detect_myipaddr(ctx).await)
     };
     Ok(myipaddr)
+}
+
+#[derive(Debug, Display)]
+pub enum ParseAddressError {
+    #[display(fmt = "Address/Seed {} resolved to IPv6 which is not supported", _0)]
+    UnsupportedIPv6Address(String),
+    #[display(fmt = "Address/Seed {} to_socket_addrs empty iter", _0)]
+    EmptyIterator(String),
+    #[display(fmt = "Couldn't resolve '{}' Address/Seed: {}", _0, _1)]
+    UnresolvedAddress(String, String),
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn addr_to_ipv4_string(address: &str) -> Result<String, MmError<ParseAddressError>> {
+    // Remove "https:// or http://" etc.. from address str
+    let formated_address = address.split("://").last().unwrap_or(address);
+
+    let address_with_port = format!(
+        "{formated_address}{}",
+        if formated_address.contains(':') { "" } else { ":0" }
+    );
+
+    match address_with_port.as_str().to_socket_addrs() {
+        Ok(mut iter) => match iter.next() {
+            Some(addr) => {
+                if addr.is_ipv4() {
+                    Ok(addr.ip().to_string())
+                } else {
+                    log::warn!(
+                        "Address/Seed {} resolved to IPv6 {} which is not supported",
+                        address,
+                        addr
+                    );
+                    MmError::err(ParseAddressError::UnsupportedIPv6Address(address.into()))
+                }
+            },
+            None => {
+                log::warn!("Address/Seed {} to_socket_addrs empty iter", address);
+                MmError::err(ParseAddressError::EmptyIterator(address.into()))
+            },
+        },
+        Err(e) => {
+            log::error!("Couldn't resolve '{}' seed: {}", address, e);
+            MmError::err(ParseAddressError::UnresolvedAddress(address.into(), e.to_string()))
+        },
+    }
 }

--- a/mm2src/mm2_net/src/ip_addr.rs
+++ b/mm2src/mm2_net/src/ip_addr.rs
@@ -1,5 +1,5 @@
 use crate::transport::slurp_url;
-use common::{cfg_native, log};
+use common::log;
 use derive_more::Display;
 use gstuff::try_s;
 use gstuff::{ERR, ERRL};
@@ -11,10 +11,8 @@ use std::io::Read;
 use std::net::{IpAddr, Ipv4Addr};
 use std::path::Path;
 
-cfg_native! {
-    use std::net::ToSocketAddrs;
-    use mm2_err_handle::prelude::MmError;
-}
+use mm2_err_handle::prelude::MmError;
+use std::net::ToSocketAddrs;
 
 const IP_PROVIDERS: [&str; 2] = ["http://checkip.amazonaws.com/", "http://api.ipify.org"];
 
@@ -33,7 +31,6 @@ const IP_PROVIDERS: [&str; 2] = ["http://checkip.amazonaws.com/", "http://api.ip
 /// Dropping or using that Sender will stop the HTTP fallback server.
 ///
 /// Also the port of the HTTP fallback server is returned.
-#[cfg(not(target_arch = "wasm32"))]
 fn test_ip(ctx: &MmArc, ip: IpAddr) -> Result<(), String> {
     let netid = ctx.netid();
 
@@ -72,7 +69,6 @@ fn simple_ip_extractor(ip: &str) -> Result<IpAddr, String> {
 }
 
 /// Detect the outer IP address, visible to the internet.
-#[cfg(not(target_arch = "wasm32"))]
 pub async fn fetch_external_ip() -> Result<IpAddr, String> {
     for url in IP_PROVIDERS.iter() {
         log::info!("Trying to fetch the real IP from '{}' ...", url);
@@ -111,7 +107,6 @@ pub async fn fetch_external_ip() -> Result<IpAddr, String> {
 /// Later we'll try to *bind* on this IP address,
 /// and this will break under NAT or forwarding because the internal IP address will be different.
 /// Which might be a good thing, allowing us to detect the likehoodness of NAT early.
-#[cfg(not(target_arch = "wasm32"))]
 async fn detect_myipaddr(ctx: MmArc) -> Result<IpAddr, String> {
     let ip = try_s!(fetch_external_ip().await);
 
@@ -154,7 +149,6 @@ async fn detect_myipaddr(ctx: MmArc) -> Result<IpAddr, String> {
     Ok(all_interfaces)
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 pub async fn myipaddr(ctx: MmArc) -> Result<IpAddr, String> {
     let myipaddr: IpAddr = if Path::new("myipaddr").exists() {
         match fs::File::open("myipaddr") {
@@ -186,7 +180,6 @@ pub enum ParseAddressError {
     UnresolvedAddress(String, String),
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 pub fn addr_to_ipv4_string(address: &str) -> Result<String, MmError<ParseAddressError>> {
     // Remove "https:// or http://" etc.. from address str
     let formated_address = address.split("://").last().unwrap_or(address);

--- a/mm2src/mm2_net/src/lib.rs
+++ b/mm2src/mm2_net/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod event_streaming;
 pub mod grpc_web;
-pub mod transport;
 pub mod ip_addr;
+pub mod transport;
 
 #[cfg(not(target_arch = "wasm32"))] pub mod native_http;
 #[cfg(not(target_arch = "wasm32"))] pub mod native_tls;

--- a/mm2src/mm2_net/src/lib.rs
+++ b/mm2src/mm2_net/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod event_streaming;
 pub mod grpc_web;
-#[cfg(not(target_arch = "wasm32"))] pub mod ip_addr;
+pub mod transport;
+pub mod ip_addr;
+
 #[cfg(not(target_arch = "wasm32"))] pub mod native_http;
 #[cfg(not(target_arch = "wasm32"))] pub mod native_tls;
-pub mod transport;
+
 #[cfg(target_arch = "wasm32")] pub mod wasm;

--- a/mm2src/mm2_p2p/Cargo.toml
+++ b/mm2src/mm2_p2p/Cargo.toml
@@ -22,6 +22,7 @@ lazy_static = "1.4"
 log = "0.4"
 mm2_core = { path = "../mm2_core" }
 mm2_event_stream = { path = "../mm2_event_stream" }
+mm2_net = { path = "../mm2_net" }
 mm2_number = { path = "../mm2_number", optional = true }
 parking_lot = { version = "0.12.0", features = ["nightly"] }
 rand = { version = "0.7", default-features = false, features = ["wasm-bindgen"] }

--- a/mm2src/mm2_p2p/src/network.rs
+++ b/mm2src/mm2_p2p/src/network.rs
@@ -5,61 +5,48 @@ pub const DEFAULT_NETID: u16 = 8762;
 
 pub struct SeedNodeInfo {
     pub id: &'static str,
-    pub ip: &'static str,
     pub domain: &'static str,
 }
 
 impl SeedNodeInfo {
-    pub const fn new(id: &'static str, ip: &'static str, domain: &'static str) -> Self { Self { id, ip, domain } }
+    pub const fn new(id: &'static str, domain: &'static str) -> Self { Self { id, domain } }
 }
 
 #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 const ALL_DEFAULT_NETID_SEEDNODES: &[SeedNodeInfo] = &[
     SeedNodeInfo::new(
         "12D3KooWHKkHiNhZtKceQehHhPqwU5W1jXpoVBgS1qst899GjvTm",
-        "168.119.236.251",
         "viserion.dragon-seed.com",
     ),
     SeedNodeInfo::new(
         "12D3KooWAToxtunEBWCoAHjefSv74Nsmxranw8juy3eKEdrQyGRF",
-        "168.119.236.240",
         "rhaegal.dragon-seed.com",
     ),
     SeedNodeInfo::new(
         "12D3KooWSmEi8ypaVzFA1AGde2RjxNW5Pvxw3qa2fVe48PjNs63R",
-        "168.119.236.239",
         "drogon.dragon-seed.com",
     ),
     SeedNodeInfo::new(
         "12D3KooWMrjLmrv8hNgAoVf1RfumfjyPStzd4nv5XL47zN4ZKisb",
-        "168.119.237.8",
         "falkor.dragon-seed.com",
     ),
     SeedNodeInfo::new(
         "12D3KooWEWzbYcosK2JK9XpFXzumfgsWJW1F7BZS15yLTrhfjX2Z",
-        "65.21.51.47",
         "smaug.dragon-seed.com",
     ),
     SeedNodeInfo::new(
         "12D3KooWJWBnkVsVNjiqUEPjLyHpiSmQVAJ5t6qt1Txv5ctJi9Xd",
-        "135.181.34.220",
         "balerion.dragon-seed.com",
     ),
     SeedNodeInfo::new(
         "12D3KooWPR2RoPi19vQtLugjCdvVmCcGLP2iXAzbDfP3tp81ZL4d",
-        "168.119.237.13",
         "kalessin.dragon-seed.com",
     ),
     SeedNodeInfo::new(
         "12D3KooWJDoV9vJdy6PnzwVETZ3fWGMhV41VhSbocR1h2geFqq9Y",
-        "65.108.90.210",
         "icefyre.dragon-seed.com",
     ),
-    SeedNodeInfo::new(
-        "12D3KooWEaZpH61H4yuQkaNG5AsyGdpBhKRppaLdAY52a774ab5u",
-        "46.4.78.11",
-        "fr1.cipig.net",
-    ),
+    SeedNodeInfo::new("12D3KooWEaZpH61H4yuQkaNG5AsyGdpBhKRppaLdAY52a774ab5u", "fr1.cipig.net"),
 ];
 
 // TODO: Uncomment these once re-enabled on the main network.
@@ -86,9 +73,11 @@ pub fn get_all_network_seednodes(netid: u16) -> Vec<(PeerId, RelayAddress, Strin
     }
     ALL_DEFAULT_NETID_SEEDNODES
         .iter()
-        .map(|SeedNodeInfo { id, ip, domain }| {
-            let peer_id = PeerId::from_str(id).expect("valid peer id");
-            let address = RelayAddress::IPv4(ip.to_string());
+        .map(|SeedNodeInfo { id, domain }| {
+            let peer_id = PeerId::from_str(id).unwrap_or_else(|e| panic!("Valid peer id {id}: {e}"));
+            let ip =
+                mm2_net::ip_addr::addr_to_ipv4_string(domain).unwrap_or_else(|e| panic!("Valid domain {domain}: {e}"));
+            let address = RelayAddress::IPv4(ip);
             let domain = domain.to_string();
             (peer_id, address, domain)
         })

--- a/mm2src/mm2_p2p/src/network.rs
+++ b/mm2src/mm2_p2p/src/network.rs
@@ -48,18 +48,6 @@ const ALL_DEFAULT_NETID_SEEDNODES: &[SeedNodeInfo] = &[
     ),
 ];
 
-// TODO: Uncomment these once re-enabled on the main network.
-// Operated by Dragonhound, still on NetID 7777. Domains will update after netid migration.
-// SeedNodeInfo::new("12D3KooWEsuiKcQaBaKEzuMtT6uFjs89P1E8MK3wGRZbeuCbCw6P", "168.119.236.241", "seed1.komodo.earth"), // tintaglia.dragon-seed.com
-// SeedNodeInfo::new("12D3KooWHBeCnJdzNk51G4mLnao9cDsjuqiMTEo5wMFXrd25bd1F", "168.119.236.243", "seed2.komodo.earth"), // mercor.dragon-seed.com
-// SeedNodeInfo::new("12D3KooWKxavLCJVrQ5Gk1kd9m6cohctGQBmiKPS9XQFoXEoyGmS", "168.119.236.249", "seed3.komodo.earth"), // karrigvestrit.dragon-seed.com
-// SeedNodeInfo::new("12D3KooWGrUpCAbkxhPRioNs64sbUmPmpEcou6hYfrqQvxfWDEuf", "135.181.35.77", "seed4.komodo.earth"), // sintara.dragon-seed.com
-// SeedNodeInfo::new("12D3KooWKu8pMTgteWacwFjN7zRWWHb3bctyTvHU3xx5x4x6qDYY", "65.21.56.210", "seed6.komodo.earth"), // heeby.dragon-seed.com
-// SeedNodeInfo::new("12D3KooW9soGyPfX6kcyh3uVXNHq1y2dPmQNt2veKgdLXkBiCVKq", "168.119.236.246", "seed7.komodo.earth"), // kalo.dragon-seed.com
-// SeedNodeInfo::new("12D3KooWL6yrrNACb7t7RPyTEPxKmq8jtrcbkcNd6H5G2hK7bXaL", "168.119.236.233", "seed8.komodo.earth"),  // relpda.dragon-seed.com
-// Operated by Cipi, still on NetID 7777
-// SeedNodeInfo::new("12D3KooWAd5gPXwX7eDvKWwkr2FZGfoJceKDCA53SHmTFFVkrN7Q", "46.4.87.18", "fr2.cipig.net"),
-
 #[cfg(target_arch = "wasm32")]
 pub fn get_all_network_seednodes(_netid: u16) -> Vec<(PeerId, RelayAddress, String)> { Vec::new() }
 

--- a/mm2src/mm2_p2p/src/network.rs
+++ b/mm2src/mm2_p2p/src/network.rs
@@ -46,7 +46,6 @@ const ALL_DEFAULT_NETID_SEEDNODES: &[SeedNodeInfo] = &[
         "12D3KooWJDoV9vJdy6PnzwVETZ3fWGMhV41VhSbocR1h2geFqq9Y",
         "icefyre.dragon-seed.com",
     ),
-    SeedNodeInfo::new("12D3KooWEaZpH61H4yuQkaNG5AsyGdpBhKRppaLdAY52a774ab5u", "fr1.cipig.net"),
 ];
 
 // TODO: Uncomment these once re-enabled on the main network.

--- a/mm2src/mm2_p2p/src/network.rs
+++ b/mm2src/mm2_p2p/src/network.rs
@@ -46,6 +46,14 @@ const ALL_DEFAULT_NETID_SEEDNODES: &[SeedNodeInfo] = &[
         "12D3KooWJDoV9vJdy6PnzwVETZ3fWGMhV41VhSbocR1h2geFqq9Y",
         "icefyre.dragon-seed.com",
     ),
+    SeedNodeInfo::new(
+        "12D3KooWEaZpH61H4yuQkaNG5AsyGdpBhKRppaLdAY52a774ab5u",
+        "seed01.kmdefi.net",
+    ),
+    SeedNodeInfo::new(
+        "12D3KooWAd5gPXwX7eDvKWwkr2FZGfoJceKDCA53SHmTFFVkrN7Q",
+        "seed02.kmdefi.net",
+    ),
 ];
 
 #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
It's dangerous to hard-code IPs statically because they can become outdated. In fact, with this change, I was able to discover that 'falkor.dragon-seed.com' corresponds to the IP '65.108.252.86', not '168.119.237.8' and 'fr1.cipig.net' is an unavailable node.