### PR TITLE
test(electrums): fix failing test_one_unavailable_electrum_proto_version

### DIFF
--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -1600,9 +1600,36 @@ fn test_spam_rick() {
 }
 
 #[test]
-#[ignore]
 fn test_one_unavailable_electrum_proto_version() {
-    // Patch the electurm client construct to require protocol version 1.4 only.
+    // First mock with an unrealistically high version requirement that no server would support
+    ElectrumClientImpl::try_new_arc.mock_safe(
+        |client_settings, block_headers_storage, streaming_manager, abortable_system, event_handlers| {
+            MockResult::Return(ElectrumClientImpl::with_protocol_version(
+                client_settings,
+                block_headers_storage,
+                streaming_manager,
+                abortable_system,
+                event_handlers,
+                OrdRange::new(7.4, 7.4).unwrap(),
+            ))
+        },
+    );
+
+    // Try to connect with the high version requirement - should fail
+    let client = electrum_client_for_test(&["electrum1.cipig.net:10000"]);
+    // When an electrum server doesn't support our protocol version range, it gets removed by the client,
+    // wait a little bit to make sure this is the case.
+    block_on(Timer::sleep(2.));
+    let error = block_on_f01(client.get_block_count_from("electrum1.cipig.net:10000"))
+        .unwrap_err()
+        .to_string();
+    log!("{}", error);
+    assert!(error.contains("Unknown server address"));
+
+    drop(client);
+    log!("Run BTC coin to test the server.version loop");
+
+    // Now reset the mock to a supported version
     ElectrumClientImpl::try_new_arc.mock_safe(
         |client_settings, block_headers_storage, streaming_manager, abortable_system, event_handlers| {
             MockResult::Return(ElectrumClientImpl::with_protocol_version(
@@ -1615,25 +1642,11 @@ fn test_one_unavailable_electrum_proto_version() {
             ))
         },
     );
-    // check if the electrum-mona.bitbank.cc:50001 doesn't support the protocol version 1.4
-    let client = electrum_client_for_test(&["electrum-mona.bitbank.cc:50001"]);
-    // When an electrum server doesn't support our protocol version range, it gets removed by the client,
-    // wait a little bit to make sure this is the case.
-    block_on(Timer::sleep(2.));
-    let error = block_on_f01(client.get_block_count_from("electrum-mona.bitbank.cc:50001"))
-        .unwrap_err()
-        .to_string();
-    log!("{}", error);
-    assert!(error.contains("Unknown server address"));
-
-    drop(client);
-    log!("Run BTC coin to test the server.version loop");
 
     let conf = json!({"coin":"BTC","asset":"BTC","rpcport":8332});
     let req = json!({
          "method": "electrum",
-         // electrum-mona.bitbank.cc:50001 supports only 1.2 protocol version
-         "servers": [{"url":"electrum1.cipig.net:10000"},{"url":"electrum-mona.bitbank.cc:50001"}],
+         "servers": [{"url":"electrum1.cipig.net:10000"}],
     });
 
     let ctx = MmCtxBuilder::new().into_mm_arc();

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -1600,6 +1600,7 @@ fn test_spam_rick() {
 }
 
 #[test]
+#[ignore]
 fn test_one_unavailable_electrum_proto_version() {
     // Patch the electurm client construct to require protocol version 1.4 only.
     ElectrumClientImpl::try_new_arc.mock_safe(


### PR DESCRIPTION
~~Couldn't find an electrum with a version other than 1.4 here https://1209k.com/bitcoin-eye/ele.php (for all coins not only btc) so decided to ignore the failing test as there is no way to fix it.~~

Did this https://github.com/KomodoPlatform/komodo-defi-framework/pull/2412#issuecomment-2795848462 instead
