### PR TITLE
deps(timed-map): bump to `1.3.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6976,9 +6976,9 @@ dependencies = [
 
 [[package]]
 name = "timed-map"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30565aee368a9b233f397f46cd803c59285b61d54c5b3ae378611bd467beecbe"
+checksum = "07be2341cfbd1b8b9a84eb9212476ea383ef5cddeb85fa3ef89dc66666196619"
 dependencies = [
  "rustc-hash",
  "web-time",


### PR DESCRIPTION
Bumps to [`timed-map@1.3.1`](https://github.com/ozmann-industries/timed-map/releases/tag/v1.3.1), which is the latest release.