### PR TITLE
fix(makerbot): add LiveCoinWatch price provider

### DIFF
--- a/mm2src/coins/lp_price.rs
+++ b/mm2src/coins/lp_price.rs
@@ -80,8 +80,8 @@ pub enum Provider {
     Coinpaprika,
     #[serde(rename = "forex")]
     Forex,
-    #[serde(rename = "nomics")]
-    Nomics,
+    #[serde(rename = "livecoinwatch")]
+    LiveCoinWatch,
     #[cfg(any(test, feature = "for-tests"))]
     #[serde(rename = "testcoin")]
     TestCoin,


### PR DESCRIPTION
This PR also removes Nomics as it was shutdown. Fixes https://github.com/KomodoPlatform/komodo-defi-framework/issues/2403

This is a quick fix for https://github.com/KomodoPlatform/komodo-defi-framework/issues/2403 but a subsequent PR should remove this hardcoded providers and allow setting them through either config or request.