### PR TITLE
chore(RPC): use consistent param name for QTUM delegation

### DIFF
--- a/mm2src/coins/utxo/qtum.rs
+++ b/mm2src/coins/utxo/qtum.rs
@@ -289,7 +289,7 @@ impl QtumBasedCoin for QtumCoin {}
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct QtumDelegationRequest {
-    pub address: String,
+    pub validator_address: String,
     pub fee: Option<u64>,
 }
 

--- a/mm2src/coins/utxo/qtum_delegation.rs
+++ b/mm2src/coins/utxo/qtum_delegation.rs
@@ -235,8 +235,9 @@ impl QtumCoin {
         if let Some(staking_addr) = self.am_i_currently_staking().await? {
             return MmError::err(DelegationError::AlreadyDelegating(staking_addr));
         }
-        let to_addr = Address::from_legacyaddress(request.address.as_str(), &self.as_ref().conf.address_prefixes)
-            .map_to_mm(DelegationError::AddressError)?;
+        let to_addr =
+            Address::from_legacyaddress(request.validator_address.as_str(), &self.as_ref().conf.address_prefixes)
+                .map_to_mm(DelegationError::AddressError)?;
         let fee = request.fee.unwrap_or(QTUM_DELEGATION_STANDARD_FEE);
         let _utxo_lock = UTXO_LOCK.lock();
         let staker_address_hex = qtum::contract_addr_from_utxo_addr(to_addr.clone())?;

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -1711,7 +1711,7 @@ fn test_qtum_add_delegation() {
     )
     .unwrap();
     let request = QtumDelegationRequest {
-        address: address.to_string(),
+        validator_address: address.to_string(),
         fee: Some(10),
     };
     let res = block_on_f01(coin.add_delegation(request)).unwrap();
@@ -1721,7 +1721,7 @@ fn test_qtum_add_delegation() {
     assert!(res.spent_by_me > res.received_by_me);
 
     let request = QtumDelegationRequest {
-        address: "fake_address".to_string(),
+        validator_address: "fake_address".to_string(),
         fee: Some(10),
     };
     let res = block_on_f01(coin.add_delegation(request));
@@ -1754,7 +1754,7 @@ fn test_qtum_add_delegation_on_already_delegating() {
     )
     .unwrap();
     let request = QtumDelegationRequest {
-        address: address.to_string(),
+        validator_address: address.to_string(),
         fee: Some(10),
     };
     let res = block_on_f01(coin.add_delegation(request));

--- a/mm2src/mm2_main/tests/mm2_tests/mm2_tests_inner.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/mm2_tests_inner.rs
@@ -2801,7 +2801,7 @@ fn test_add_delegation_qtum() {
             "coin": "tQTUM",
             "staking_details": {
                 "type": "Qtum",
-                "address": "qcyBHeSct7Wr4mAw18iuQ1zW5mMFYmtmBE"
+                "validator_address": "qcyBHeSct7Wr4mAw18iuQ1zW5mMFYmtmBE"
             }
         },
         "id": 0
@@ -2821,7 +2821,7 @@ fn test_add_delegation_qtum() {
             "coin": "tQTUM",
             "staking_details": {
                 "type": "Qtum",
-                "address": "fake_address"
+                "validator_address": "fake_address"
             }
         },
         "id": 0


### PR DESCRIPTION
Addressing https://github.com/KomodoPlatform/komodo-docs-mdx/issues/428#issuecomment-2818166149. I think it's fine to not accept `address` anymore as this RPC uses `experimental` prefix, but I can also do that if you think otherwise.

cc @smk762 