### PR TITLE
(chore): Update old urls referencing atomicdex or old docs pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <a href="https://atomicdex.io" alt="Contributors">
+    <a href="https://komodoplatform.com/en/docs/komodo-defi-framework/api/v20/" alt="Contributors">
         <img width="420" src="https://user-images.githubusercontent.com/24797699/252396802-de8f9264-8056-4430-a17d-5ecec9668dfc.png" />
     </a>
 </p>
@@ -48,11 +48,11 @@
 
 ## What is the Komodo DeFi Framework?
 
-The Komodo DeFi Framework is open-source [atomic-swap](https://komodoplatform.com/en/academy/atomic-swaps/) software for seamless, decentralized, peer to peer trading between almost every blockchain asset in existence. This software works with propagation of orderbooks and swap states through the [libp2p](https://libp2p.io/) protocol and uses [Hash Time Lock Contracts (HTLCs)](https://en.bitcoinwiki.org/wiki/Hashed_Timelock_Contracts) for ensuring that the two parties in a swap either mutually complete a trade, or funds return to thier original owner.
+The Komodo DeFi Framework is open-source [atomic-swap](https://komodoplatform.com/en/docs/komodo-defi-framework/tutorials/#technical-comparisons) software for seamless, decentralized, peer to peer trading between almost every blockchain asset in existence. This software works with propagation of orderbooks and swap states through the [libp2p](https://libp2p.io/) protocol and uses [Hash Time Lock Contracts (HTLCs)](https://en.bitcoinwiki.org/wiki/Hashed_Timelock_Contracts) for ensuring that the two parties in a swap either mutually complete a trade, or funds return to thier original owner.
 
 There is no 3rd party intermediary, no proxy tokens, and at all times users remain in sole possession of their private keys.
 
-A [well documented API](https://developers.komodoplatform.com/basic-docs/atomicdex/introduction-to-atomicdex.html) offers simple access to the underlying services using simple language agnostic JSON structured methods and parameters such that users can communicate with the core in a variety of methods such as [curl](https://developers.komodoplatform.com/basic-docs/atomicdex-api-legacy/buy.html) in CLI, or fully functioning [desktop and mobile applications](https://atomicdex.io/) like [Komodo Wallet Desktop](https://github.com/KomodoPlatform/komodo-wallet-desktop).
+A [well documented API](https://komodoplatform.com/en/docs/komodo-defi-framework/tutorials/) offers simple access to the underlying services using simple language agnostic JSON structured methods and parameters such that users can communicate with the core in a variety of methods such as [curl](https://komodoplatform.com/en/docs/komodo-defi-framework/api/legacy/buy/) in CLI, or fully functioning [browser, desktop and mobile wallet apps](https://komodoplatform.com/en/downloads/) like [Komodo Wallet](https://github.com/KomodoPlatform/komodo-wallet).
 
 For a curated list of Komodo DeFi Framework based projects and resources, check out [Awesome AtomicDEX](https://github.com/KomodoPlatform/awesome-atomicdex).
 
@@ -62,13 +62,13 @@ For a curated list of Komodo DeFi Framework based projects and resources, check 
 - Perform blockchain transactions without a local native chain (e.g. via Electrum servers)
 - Query orderbooks for all pairs within the [supported coins](https://github.com/KomodoPlatform/coins/blob/master/coins)
 - Buy/sell from the orderbook, or create maker orders
-- Configure automated ["makerbot" trading](https://developers.komodoplatform.com/basic-docs/atomicdex-api-20/start_simple_market_maker_bot.html) with periodic price updates and optional [telegram](https://telegram.org/) alerts
+- Configure automated ["makerbot" trading](https://komodoplatform.com/en/docs/komodo-defi-framework/api/v20/swaps_and_orders/start_simple_market_maker_bot/) with periodic price updates and optional [telegram](https://telegram.org/) alerts
 
 ## Building from source
 
 ### On Host System:
 
-[Pre-built release binaries](https://developers.komodoplatform.com/basic-docs/atomicdex/atomicdex-setup/get-started-atomicdex.html) are available for OSX, Linux or Windows.
+[Pre-built release binaries](https://github.com/KomodoPlatform/komodo-defi-framework/releases) are available for Android, iOS, OSX, Linux, Windows and WASM.
 
 If you want to build from source, the following prerequisites are required:
 - [Rustup](https://rustup.rs/)
@@ -80,7 +80,7 @@ If you want to build from source, the following prerequisites are required:
 
 To build, run `cargo build` (or `cargo build -vv` to get verbose build output).
 
-For more detailed instructions, please refer to the [Installation Guide](https://developers.komodoplatform.com/basic-docs/atomicdex/atomicdex-setup/get-started-atomicdex.html).
+For more detailed instructions, please refer to the [Installation Guide](https://komodoplatform.com/en/docs/komodo-defi-framework/setup/).
 
 ### From Container:
 
@@ -100,6 +100,8 @@ docker run -v "$(pwd)":/app -w /app kdf-build-container cargo build
 
 Just like building it on your host system, you will now have the target directory containing the build files.
 
+Alternatively, container images are available on [DockerHub](https://hub.docker.com/r/komodoofficial/komodo-defi-framework)
+
 ## Building WASM binary
 
 Please refer to the [WASM Build Guide](./docs/WASM_BUILD.md).
@@ -108,7 +110,7 @@ Please refer to the [WASM Build Guide](./docs/WASM_BUILD.md).
 
 Basic config is contained in two files, `MM2.json` and `coins`
 
-The user configuration [MM2.json file](https://developers.komodoplatform.com/basic-docs/atomicdex/atomicdex-setup/configure-mm2-json.html) contains rpc credentials, your mnemonic seed phrase, a `netid` (8762 is the current main network) and some extra [optional parameters](https://developers.komodoplatform.com/basic-docs/atomicdex/atomicdex-setup/get-started-atomicdex.html).
+The user configuration `MM2.json` file contains rpc credentials, your mnemonic seed phrase, a `netid` (8762 is the current main network) and some extra [optional parameters](https://komodoplatform.com/en/docs/komodo-defi-framework/setup/configure-mm2-json/).
 
 For example:
 ```json
@@ -167,7 +169,7 @@ curl --url "http://127.0.0.1:7783" --data '{
 }'
 ```
 
-Refer to the [Komodo Developer Docs](https://developers.komodoplatform.com/basic-docs/atomicdex/introduction-to-atomicdex.html) for details of additional RPC methods and parameters
+Refer to the [Komodo Developer Docs](https://komodoplatform.com/en/docs/komodo-defi-framework/api/) for details of additional RPC methods and parameters
 
 
 ## Project structure
@@ -180,7 +182,7 @@ Refer to the [Komodo Developer Docs](https://developers.komodoplatform.com/basic
 - [Contribution guide](./docs/CONTRIBUTING.md)
 - [Setting up the environment to run the full tests suite](./docs/DEV_ENVIRONMENT.md)
 - [Git flow and general workflow](./docs/GIT_FLOW_AND_WORKING_PROCESS.md)
-- [Komodo Developer Docs](https://developers.komodoplatform.com/basic-docs/atomicdex/introduction-to-atomicdex.html)
+- [Komodo Developer Docs](https://komodoplatform.com/en/docs/komodo-defi-framework/)
 
 
 ## Disclaimer

--- a/mm2src/mm2_main/src/mm2.rs
+++ b/mm2src/mm2_main/src/mm2.rs
@@ -249,12 +249,12 @@ Environment variables:
                      Defaults to `MM2.json`
   MM_COINS_PATH  ..  File path. MM2 will try to load coins data from this file.
                      File must contain valid json.
-                     Recommended: https://github.com/jl777/coins/blob/master/coins.
+                     Recommended: https://github.com/komodoplatform/coins/blob/master/coins.
                      Defaults to `coins`.
   MM_LOG         ..  File path. Must end with '.log'. MM will log to this file.
 
 See also the online documentation at
-https://developers.atomicdex.io
+https://komodoplatform.com/en/docs
 "#;
 
     println!("{}", HELP_MSG);


### PR DESCRIPTION
Noticed a couple of URLs to the atomicdex.io domain while searching the code for something else. Further checking revealed old docs urls (hough most docs links would 301 to the new page, these were also updated).