### PR TITLE
fix(event-streaming): initial addresses registration in utxo balance streaming

### DIFF
--- a/mm2src/coins/utxo/rpc_clients/electrum_rpc/connection_manager/manager.rs
+++ b/mm2src/coins/utxo/rpc_clients/electrum_rpc/connection_manager/manager.rs
@@ -9,7 +9,7 @@ use super::connection_context::ConnectionContext;
 use crate::utxo::rpc_clients::UtxoRpcClientOps;
 use common::executor::abortable_queue::AbortableQueue;
 use common::executor::{AbortableSystem, SpawnFuture, Timer};
-use common::log::{debug, error};
+use common::log::{debug, error, LogOnError};
 use common::notifier::{Notifiee, Notifier};
 use common::now_ms;
 use keys::Address;
@@ -277,7 +277,7 @@ impl ConnectionManager {
         let abandoned_subs = connection_ctx.disconnected();
         // Re-subscribe the abandoned addresses using the client.
         let client = unwrap_or_return!(self.get_client());
-        client.subscribe_addresses(abandoned_subs).ok();
+        client.subscribe_addresses(abandoned_subs).error_log();
     }
 
     /// A method that should be called after using a specific server for some request.

--- a/mm2src/coins/utxo/utxo_balance_events.rs
+++ b/mm2src/coins/utxo/utxo_balance_events.rs
@@ -153,7 +153,7 @@ impl EventStreamer for UtxoBalanceEventStreamer {
 async fn subscribe_to_addresses(utxo: &UtxoCoinFields, addresses: HashSet<Address>) -> HashMap<String, Address> {
     match utxo.rpc_client.clone() {
         UtxoRpcClientEnum::Electrum(client) => {
-            // Collect the scrpithash for every address into a map.
+            // Collect the scripthash for every address into a map.
             let scripthash_to_address_map = addresses
                 .into_iter()
                 .filter_map(|address| {
@@ -172,7 +172,8 @@ async fn subscribe_to_addresses(utxo: &UtxoCoinFields, addresses: HashSet<Addres
             scripthash_to_address_map
         },
         UtxoRpcClientEnum::Native(_) => {
-            unreachable!("The caller of this func checked that the RPC client is electrum. Native client isn't supported for balance streaming.")
+            // Unreachable: The caller should have checked that the RPC client isn't native.
+            HashMap::new()
         },
     }
 }

--- a/mm2src/coins/utxo/utxo_balance_events.rs
+++ b/mm2src/coins/utxo/utxo_balance_events.rs
@@ -61,7 +61,7 @@ impl EventStreamer for UtxoBalanceEventStreamer {
         let mut scripthash_to_address_map = HashMap::new();
 
         // Make sure the RPC client is not native. That doesn't support balance streaming.
-        if let UtxoRpcClientEnum::Native(_) = coin.as_ref().rpc_client {
+        if coin.as_ref().rpc_client.is_native() {
             let msg = "Balance streaming is not supported for native RPC client.";
             ready_tx.send(Err(msg.to_string())).expect(RECEIVER_DROPPED_MSG);
             panic!("{}", msg);

--- a/mm2src/coins/utxo/utxo_balance_events.rs
+++ b/mm2src/coins/utxo/utxo_balance_events.rs
@@ -58,45 +58,29 @@ impl EventStreamer for UtxoBalanceEventStreamer {
         const RECEIVER_DROPPED_MSG: &str = "Receiver is dropped, which should never happen.";
         let streamer_id = self.streamer_id();
         let coin = self.coin;
+        let mut scripthash_to_address_map = BTreeMap::default();
 
-        async fn subscribe_to_addresses(
-            utxo: &UtxoCoinFields,
-            addresses: HashSet<Address>,
-        ) -> Result<BTreeMap<String, Address>, String> {
-            match utxo.rpc_client.clone() {
-                UtxoRpcClientEnum::Electrum(client) => {
-                    // Collect the scrpithash for every address into a map.
-                    let scripthash_to_address_map = addresses
-                        .into_iter()
-                        .map(|address| {
-                            let scripthash = address_to_scripthash(&address).map_err(|e| e.to_string())?;
-                            Ok((scripthash, address))
-                        })
-                        .collect::<Result<HashMap<String, Address>, String>>()?;
-                    // Add these subscriptions to the connection manager. It will choose whatever connections
-                    // it sees fit to subscribe each of these addresses to.
-                    client
-                        .connection_manager
-                        .add_subscriptions(&scripthash_to_address_map)
-                        .await;
-                    // Convert the hashmap back to btreemap.
-                    Ok(scripthash_to_address_map.into_iter().map(|(k, v)| (k, v)).collect())
-                },
-                UtxoRpcClientEnum::Native(_) => {
-                    Err("Balance streaming is currently not supported for native client.".to_owned())
-                },
-            }
+        // Get all the addresses to subscribe to their balance updates.
+        let all_addresses = match coin.all_addresses().await {
+            Ok(addresses) => addresses,
+            Err(e) => {
+                let msg = format!("Failed to get all addresses: {e}");
+                ready_tx.send(Err(msg.clone())).expect(RECEIVER_DROPPED_MSG);
+                panic!("{}", msg);
+            },
+        };
+        // FIXME: This might take some good LONG time in an HD wallet with many addresses.
+        //        We better optimistically respond to the `ready_tx` to avoid blocking the enabler response to the RPC.
+        match subscribe_to_addresses(coin.as_ref(), all_addresses).await {
+            Ok(initial_tracking_list) => scripthash_to_address_map.extend(initial_tracking_list),
+            Err(e) => {
+                let msg = format!("Failed to subscribe to balance events: {e}");
+                ready_tx.send(Err(msg.clone())).expect(RECEIVER_DROPPED_MSG);
+                panic!("{}", msg);
+            },
         }
-
-        if coin.as_ref().rpc_client.is_native() {
-            let msg = "Native RPC client is not supported for UtxoBalanceEventStreamer.";
-            ready_tx.send(Err(msg.to_string())).expect(RECEIVER_DROPPED_MSG);
-            panic!("{}", msg);
-        }
-
         ready_tx.send(Ok(())).expect(RECEIVER_DROPPED_MSG);
 
-        let mut scripthash_to_address_map = BTreeMap::default();
         while let Some(message) = data_rx.next().await {
             let notified_scripthash = match message {
                 ScripthashNotification::Triggered(t) => t,
@@ -170,5 +154,34 @@ impl EventStreamer for UtxoBalanceEventStreamer {
 
             broadcaster.broadcast(Event::new(streamer_id.clone(), json!(vec![payload])));
         }
+    }
+}
+
+async fn subscribe_to_addresses(
+    utxo: &UtxoCoinFields,
+    addresses: HashSet<Address>,
+) -> Result<BTreeMap<String, Address>, String> {
+    match utxo.rpc_client.clone() {
+        UtxoRpcClientEnum::Electrum(client) => {
+            // Collect the scrpithash for every address into a map.
+            let scripthash_to_address_map = addresses
+                .into_iter()
+                .map(|address| {
+                    let scripthash = address_to_scripthash(&address).map_err(|e| e.to_string())?;
+                    Ok((scripthash, address))
+                })
+                .collect::<Result<HashMap<String, Address>, String>>()?;
+            // Add these subscriptions to the connection manager. It will choose whatever connections
+            // it sees fit to subscribe each of these addresses to.
+            client
+                .connection_manager
+                .add_subscriptions(&scripthash_to_address_map)
+                .await;
+            // Convert the hashmap back to btreemap.
+            Ok(scripthash_to_address_map.into_iter().map(|(k, v)| (k, v)).collect())
+        },
+        UtxoRpcClientEnum::Native(_) => {
+            Err("Balance streaming is currently not supported for native client.".to_owned())
+        },
     }
 }


### PR DESCRIPTION
We need to initially register the addresses we wanna get balance notification for. We used to do that in the past at coin enablement time (since event streaming config was static and doesn't change at runtime), that was removed since it doesn't make sense with runtime enabled/disabled streaming. But was never replaced with the appropriate logic to register these addresses once the *streamer was enabled*.

This PR register our addresses with the event streamer on initialization so it could track them.

