### PR TITLE
chore(build-artifacts): remove duplicated mm2 build artifacts

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -59,6 +59,7 @@ jobs:
           NAME="kdf_$KDF_BUILD_TAG-linux-x86-64.zip"
           zip $NAME target/release/kdf -j
           SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
+          mkdir $SAFE_DIR_NAME
           mv $NAME ./$SAFE_DIR_NAME/
 
       - name: Upload build artifact
@@ -122,6 +123,7 @@ jobs:
           NAME="kdf_$KDF_BUILD_TAG-mac-x86-64.zip"
           zip $NAME target/x86_64-apple-darwin/release/kdf -j
           SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
+          mkdir $SAFE_DIR_NAME
           mv $NAME ./$SAFE_DIR_NAME/
 
       - name: Upload build artifact
@@ -173,6 +175,7 @@ jobs:
           NAME="kdf_$KDF_BUILD_TAG-mac-arm64.zip"
           zip $NAME target/aarch64-apple-darwin/release/kdf -j
           SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
+          mkdir $SAFE_DIR_NAME
           mv $NAME ./$SAFE_DIR_NAME/
 
       - name: Upload build artifact
@@ -223,6 +226,7 @@ jobs:
           $NAME="kdf_$Env:KDF_BUILD_TAG-win-x86-64.zip"
           7z a $NAME .\target\release\kdf.exe .\target\release\*.dll
           $SAFE_DIR_NAME = $Env:BRANCH_NAME -replace '/', '-'
+          mkdir $SAFE_DIR_NAME
           mv $NAME ./$SAFE_DIR_NAME/
 
       - name: Upload build artifact
@@ -275,6 +279,7 @@ jobs:
           mv target/x86_64-apple-darwin/release/libkdflib.a target/x86_64-apple-darwin/release/libkdf.a
           zip $NAME target/x86_64-apple-darwin/release/libkdf.a -j
           SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
+          mkdir $SAFE_DIR_NAME
           mv $NAME ./$SAFE_DIR_NAME/
 
       - name: Upload build artifact
@@ -392,6 +397,7 @@ jobs:
           mv target/aarch64-apple-ios/release/libkdflib.a target/aarch64-apple-ios/release/libkdf.a
           zip $NAME target/aarch64-apple-ios/release/libkdf.a -j
           SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
+          mkdir $SAFE_DIR_NAME
           mv $NAME ./$SAFE_DIR_NAME/
 
       - name: Upload build artifact
@@ -458,6 +464,7 @@ jobs:
           mv target/aarch64-linux-android/release/libkdflib.a target/aarch64-linux-android/release/libkdf.a
           zip $NAME target/aarch64-linux-android/release/libkdf.a -j
           SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
+          mkdir $SAFE_DIR_NAME
           mv $NAME ./$SAFE_DIR_NAME/
 
       - name: Upload build artifact
@@ -524,6 +531,7 @@ jobs:
           mv target/armv7-linux-androideabi/release/libkdflib.a target/armv7-linux-androideabi/release/libkdf.a
           zip $NAME target/armv7-linux-androideabi/release/libkdf.a -j
           SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
+          mkdir $SAFE_DIR_NAME
           mv $NAME ./$SAFE_DIR_NAME/
 
       - name: Upload build artifact

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -51,17 +51,6 @@ jobs:
       - name: Build
         run: cargo build --release
 
-      - name: Compress mm2 build output
-        env:
-          AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
-        if: ${{ env.AVAILABLE != '' }}
-        run: |
-          NAME="mm2_$KDF_BUILD_TAG-linux-x86-64.zip"
-          zip $NAME target/release/mm2 -j
-          SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
-          mkdir $SAFE_DIR_NAME
-          mv $NAME ./$SAFE_DIR_NAME/
-
       - name: Compress kdf build output
         env:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
@@ -125,16 +114,6 @@ jobs:
       - name: Build
         run: cargo build --release --target x86_64-apple-darwin
 
-      - name: Compress mm2 build output
-        env:
-          AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
-        if: ${{ env.AVAILABLE != '' }}
-        run: |
-          NAME="mm2_$KDF_BUILD_TAG-mac-x86-64.zip"
-          zip $NAME target/x86_64-apple-darwin/release/mm2 -j
-          SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
-          mkdir $SAFE_DIR_NAME
-          mv $NAME ./$SAFE_DIR_NAME/
       - name: Compress kdf build output
         env:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
@@ -186,17 +165,6 @@ jobs:
       - name: Build
         run: cargo build --release --target aarch64-apple-darwin
 
-      - name: Compress mm2 build output
-        env:
-          AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
-        if: ${{ env.AVAILABLE != '' }}
-        run: |
-          NAME="mm2_$KDF_BUILD_TAG-mac-arm64.zip"
-          zip $NAME target/aarch64-apple-darwin/release/mm2 -j
-          SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
-          mkdir $SAFE_DIR_NAME
-          mv $NAME ./$SAFE_DIR_NAME/
-
       - name: Compress kdf build output
         env:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
@@ -246,17 +214,6 @@ jobs:
 
       - name: Build
         run: cargo build --release
-
-      - name: Compress mm2 build output
-        env:
-          AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
-        if: ${{ env.AVAILABLE != '' }}
-        run: |
-          $NAME="mm2_$Env:KDF_BUILD_TAG-win-x86-64.zip"
-          7z a $NAME .\target\release\mm2.exe .\target\release\*.dll
-          $SAFE_DIR_NAME = $Env:BRANCH_NAME -replace '/', '-'
-          mkdir $SAFE_DIR_NAME
-          mv $NAME ./$SAFE_DIR_NAME/
 
       - name: Compress kdf build output
         env:
@@ -308,18 +265,6 @@ jobs:
 
       - name: Build
         run: cargo rustc --target x86_64-apple-darwin --lib --release --package mm2_bin_lib --crate-type=staticlib
-
-      - name: Compress mm2 build output
-        env:
-          AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
-        if: ${{ env.AVAILABLE != '' }}
-        run: |
-          NAME="mm2_$KDF_BUILD_TAG-mac-dylib-x86-64.zip"
-          cp target/x86_64-apple-darwin/release/libkdflib.a target/x86_64-apple-darwin/release/libmm2.a
-          zip $NAME target/x86_64-apple-darwin/release/libmm2.a -j
-          SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
-          mkdir $SAFE_DIR_NAME
-          mv $NAME ./$SAFE_DIR_NAME/
 
       - name: Compress kdf build output
         env:
@@ -438,18 +383,6 @@ jobs:
       - name: Build
         run: cargo rustc --target aarch64-apple-ios --lib --release --package mm2_bin_lib --crate-type=staticlib
 
-      - name: Compress mm2 build output
-        env:
-          AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
-        if: ${{ env.AVAILABLE != '' }}
-        run: |
-          NAME="mm2_$KDF_BUILD_TAG-ios-aarch64.zip"
-          cp target/aarch64-apple-ios/release/libkdflib.a target/aarch64-apple-ios/release/libmm2.a
-          zip $NAME target/aarch64-apple-ios/release/libmm2.a -j
-          SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
-          mkdir $SAFE_DIR_NAME
-          mv $NAME ./$SAFE_DIR_NAME/
-
       - name: Compress kdf build output
         env:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
@@ -516,18 +449,6 @@ jobs:
           export PATH=$PATH:/android-ndk/bin
           CC_aarch64_linux_android=aarch64-linux-android21-clang CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=aarch64-linux-android21-clang cargo rustc --target=aarch64-linux-android --lib --release --crate-type=staticlib --package mm2_bin_lib
 
-      - name: Compress mm2 build output
-        env:
-          AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
-        if: ${{ env.AVAILABLE != '' }}
-        run: |
-          NAME="mm2_$KDF_BUILD_TAG-android-aarch64.zip"
-          cp target/aarch64-linux-android/release/libkdflib.a target/aarch64-linux-android/release/libmm2.a
-          zip $NAME target/aarch64-linux-android/release/libmm2.a -j
-          SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
-          mkdir $SAFE_DIR_NAME
-          mv $NAME ./$SAFE_DIR_NAME/
-
       - name: Compress kdf build output
         env:
           AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
@@ -593,18 +514,6 @@ jobs:
         run: |
           export PATH=$PATH:/android-ndk/bin
           CC_armv7_linux_androideabi=armv7a-linux-androideabi21-clang CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=armv7a-linux-androideabi21-clang cargo rustc --target=armv7-linux-androideabi --lib --release --crate-type=staticlib --package mm2_bin_lib
-
-      - name: Compress mm2 build output
-        env:
-          AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
-        if: ${{ env.AVAILABLE != '' }}
-        run: |
-          NAME="mm2_$KDF_BUILD_TAG-android-armv7.zip"
-          cp target/armv7-linux-androideabi/release/libkdflib.a target/armv7-linux-androideabi/release/libmm2.a
-          zip $NAME target/armv7-linux-androideabi/release/libmm2.a -j
-          SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
-          mkdir $SAFE_DIR_NAME
-          mv $NAME ./$SAFE_DIR_NAME/
 
       - name: Compress kdf build output
         env:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -51,14 +51,6 @@ jobs:
       - name: Build
         run: cargo build --release
 
-      - name: Compress mm2 build output
-        run: |
-          NAME="mm2_$KDF_BUILD_TAG-linux-x86-64.zip"
-          zip $NAME target/release/mm2 -j
-          SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
-          mkdir $SAFE_DIR_NAME
-          mv $NAME ./$SAFE_DIR_NAME/
-
       - name: Compress kdf build output
         run: |
           NAME="kdf_$KDF_BUILD_TAG-linux-x86-64.zip"
@@ -116,14 +108,6 @@ jobs:
       - name: Build
         run: cargo build --release --target x86_64-apple-darwin
 
-      - name: Compress mm2 build output
-        run: |
-          NAME="mm2_$KDF_BUILD_TAG-mac-x86-64.zip"
-          zip $NAME target/x86_64-apple-darwin/release/mm2 -j
-          SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
-          mkdir $SAFE_DIR_NAME
-          mv $NAME ./$SAFE_DIR_NAME/
-
       - name: Compress kdf build output
         run: |
           NAME="kdf_$KDF_BUILD_TAG-mac-x86-64.zip"
@@ -172,14 +156,6 @@ jobs:
       - name: Build
         run: cargo build --release --target aarch64-apple-darwin
 
-      - name: Compress mm2 build output
-        run: |
-          NAME="mm2_$KDF_BUILD_TAG-mac-arm64.zip"
-          zip $NAME target/aarch64-apple-darwin/release/mm2 -j
-          SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
-          mkdir $SAFE_DIR_NAME
-          mv $NAME ./$SAFE_DIR_NAME/
-
       - name: Compress kdf build output
         run: |
           NAME="kdf_$KDF_BUILD_TAG-mac-arm64.zip"
@@ -226,14 +202,6 @@ jobs:
 
       - name: Build
         run: cargo build --release
-
-      - name: Compress mm2 build output
-        run: |
-          $NAME="mm2_$Env:KDF_BUILD_TAG-win-x86-64.zip"
-          7z a $NAME .\target\release\mm2.exe .\target\release\*.dll
-          $SAFE_DIR_NAME = $Env:BRANCH_NAME -replace '/', '-'
-          mkdir $SAFE_DIR_NAME
-          mv $NAME ./$SAFE_DIR_NAME/
 
       - name: Compress kdf build output
         run: |
@@ -282,15 +250,6 @@ jobs:
 
       - name: Build
         run: cargo rustc --target x86_64-apple-darwin --lib --release --package mm2_bin_lib --crate-type=staticlib
-
-      - name: Compress mm2 build output
-        run: |
-          NAME="mm2_$KDF_BUILD_TAG-mac-dylib-x86-64.zip"
-          cp target/x86_64-apple-darwin/release/libkdflib.a target/x86_64-apple-darwin/release/libmm2.a
-          zip $NAME target/x86_64-apple-darwin/release/libmm2.a -j
-          SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
-          mkdir $SAFE_DIR_NAME
-          mv $NAME ./$SAFE_DIR_NAME/
 
       - name: Compress kdf build output
         run: |
@@ -403,15 +362,6 @@ jobs:
       - name: Build
         run: cargo rustc --target aarch64-apple-ios --lib --release --package mm2_bin_lib --crate-type=staticlib
 
-      - name: Compress mm2 build output
-        run: |
-          NAME="mm2_$KDF_BUILD_TAG-ios-aarch64.zip"
-          mv target/aarch64-apple-ios/release/libkdflib.a target/aarch64-apple-ios/release/libmm2.a
-          zip $NAME target/aarch64-apple-ios/release/libmm2.a -j
-          SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
-          mkdir $SAFE_DIR_NAME
-          mv $NAME ./$SAFE_DIR_NAME/
-
       - name: Compress kdf build output
         run: |
           NAME="kdf_$KDF_BUILD_TAG-ios-aarch64.zip"
@@ -475,15 +425,6 @@ jobs:
           export PATH=$PATH:/android-ndk/bin
           CC_aarch64_linux_android=aarch64-linux-android21-clang CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=aarch64-linux-android21-clang cargo rustc --target=aarch64-linux-android --lib --release --crate-type=staticlib --package mm2_bin_lib
 
-      - name: Compress mm2 build output
-        run: |
-          NAME="mm2_$KDF_BUILD_TAG-android-aarch64.zip"
-          mv target/aarch64-linux-android/release/libkdflib.a target/aarch64-linux-android/release/libmm2.a
-          zip $NAME target/aarch64-linux-android/release/libmm2.a -j
-          SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
-          mkdir $SAFE_DIR_NAME
-          mv $NAME ./$SAFE_DIR_NAME/
-
       - name: Compress kdf build output
         run: |
           NAME="kdf_$KDF_BUILD_TAG-android-aarch64.zip"
@@ -546,15 +487,6 @@ jobs:
         run: |
           export PATH=$PATH:/android-ndk/bin
           CC_armv7_linux_androideabi=armv7a-linux-androideabi21-clang CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=armv7a-linux-androideabi21-clang cargo rustc --target=armv7-linux-androideabi --lib --release --crate-type=staticlib --package mm2_bin_lib
-
-      - name: Compress mm2 build output
-        run: |
-          NAME="mm2_$KDF_BUILD_TAG-android-armv7.zip"
-          mv target/armv7-linux-androideabi/release/libkdflib.a target/armv7-linux-androideabi/release/libmm2.a
-          zip $NAME target/armv7-linux-androideabi/release/libmm2.a -j
-          SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
-          mkdir $SAFE_DIR_NAME
-          mv $NAME ./$SAFE_DIR_NAME/
 
       - name: Compress kdf build output
         run: |

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -56,6 +56,7 @@ jobs:
           NAME="kdf_$KDF_BUILD_TAG-linux-x86-64.zip"
           zip $NAME target/release/kdf -j
           SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
+          mkdir $SAFE_DIR_NAME
           mv $NAME ./$SAFE_DIR_NAME/
 
       - name: Upload build artifact
@@ -113,6 +114,7 @@ jobs:
           NAME="kdf_$KDF_BUILD_TAG-mac-x86-64.zip"
           zip $NAME target/x86_64-apple-darwin/release/kdf -j
           SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
+          mkdir $SAFE_DIR_NAME
           mv $NAME ./$SAFE_DIR_NAME/
 
       - name: Upload build artifact
@@ -161,6 +163,7 @@ jobs:
           NAME="kdf_$KDF_BUILD_TAG-mac-arm64.zip"
           zip $NAME target/aarch64-apple-darwin/release/kdf -j
           SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
+          mkdir $SAFE_DIR_NAME
           mv $NAME ./$SAFE_DIR_NAME/
 
       - name: Upload build artifact
@@ -208,6 +211,7 @@ jobs:
           $NAME="kdf_$Env:KDF_BUILD_TAG-win-x86-64.zip"
           7z a $NAME .\target\release\kdf.exe .\target\release\*.dll
           $SAFE_DIR_NAME = $Env:BRANCH_NAME -replace '/', '-'
+          mkdir $SAFE_DIR_NAME
           mv $NAME ./$SAFE_DIR_NAME/
 
       - name: Upload build artifact
@@ -257,6 +261,7 @@ jobs:
           mv target/x86_64-apple-darwin/release/libkdflib.a target/x86_64-apple-darwin/release/libkdf.a
           zip $NAME target/x86_64-apple-darwin/release/libkdf.a -j
           SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
+          mkdir $SAFE_DIR_NAME
           mv $NAME ./$SAFE_DIR_NAME/
 
       - name: Upload build artifact
@@ -368,6 +373,7 @@ jobs:
           mv target/aarch64-apple-ios/release/libkdflib.a target/aarch64-apple-ios/release/libkdf.a
           zip $NAME target/aarch64-apple-ios/release/libkdf.a -j
           SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
+          mkdir $SAFE_DIR_NAME
           mv $NAME ./$SAFE_DIR_NAME/
 
       - name: Upload build artifact
@@ -431,6 +437,7 @@ jobs:
           mv target/aarch64-linux-android/release/libkdflib.a target/aarch64-linux-android/release/libkdf.a
           zip $NAME target/aarch64-linux-android/release/libkdf.a  -j
           SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
+          mkdir $SAFE_DIR_NAME
           mv $NAME ./$SAFE_DIR_NAME/
 
       - name: Upload build artifact
@@ -494,6 +501,7 @@ jobs:
           mv target/armv7-linux-androideabi/release/libkdflib.a target/armv7-linux-androideabi/release/libkdf.a
           zip $NAME target/armv7-linux-androideabi/release/libkdf.a   -j
           SAFE_DIR_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')
+          mkdir $SAFE_DIR_NAME
           mv $NAME ./$SAFE_DIR_NAME/
 
       - name: Upload build artifact

--- a/mm2src/mm2_bin_lib/Cargo.toml
+++ b/mm2src/mm2_bin_lib/Cargo.toml
@@ -18,13 +18,6 @@ zhtlc-native-tests = ["mm2_main/zhtlc-native-tests"]
 test-ext-api = ["mm2_main/test-ext-api"]
 
 [[bin]]
-name = "mm2"
-path = "src/mm2_bin.rs"
-test = false
-doctest = false
-bench = false
-
-[[bin]]
 name = "kdf"
 path = "src/mm2_bin.rs"
 test = false


### PR DESCRIPTION
It's been a long time since we did the renaming. We kept the old name to avoid breaking the existing build flow for downstream users. Since it's been quite a while, they should have already migrated to the new name. We can't keep these old artifacts forever, so let's remove them now.