### PR TITLE
feat(tests): allow RUST_LOG with multiple tags for native executables

### DIFF
--- a/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
+++ b/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
@@ -5487,11 +5487,12 @@ fn test_peer_time_sync_validation() {
     let timeoffset_tolerable = TryInto::<i64>::try_into(MAX_TIME_GAP_FOR_CONNECTED_PEER).unwrap() - 1;
     let timeoffset_too_big = TryInto::<i64>::try_into(MAX_TIME_GAP_FOR_CONNECTED_PEER).unwrap() + 1;
 
-    let start_peers_with_time_offset = |offset: i64| -> (Json, Json) {
+    let start_peers_with_time_offset = |offset: i64, skip_seednodes_check: bool| -> (Json, Json) {
         let (_ctx, _, bob_priv_key) = generate_utxo_coin_with_random_privkey("MYCOIN", 10.into());
         let (_ctx, _, alice_priv_key) = generate_utxo_coin_with_random_privkey("MYCOIN1", 10.into());
         let coins = json!([mycoin_conf(1000), mycoin1_conf(1000)]);
-        let bob_conf = Mm2TestConf::seednode(&hex::encode(bob_priv_key), &coins);
+        let mut bob_conf = Mm2TestConf::seednode(&hex::encode(bob_priv_key), &coins);
+        bob_conf.conf["skip_seednodes_check"] = skip_seednodes_check.into();
         let mut mm_bob = block_on(MarketMakerIt::start_with_envs(
             bob_conf.conf,
             bob_conf.rpc_password,
@@ -5501,8 +5502,9 @@ fn test_peer_time_sync_validation() {
         .unwrap();
         let (_bob_dump_log, _bob_dump_dashboard) = mm_dump(&mm_bob.log_path);
         block_on(mm_bob.wait_for_log(22., |log| log.contains(">>>>>>>>> DEX stats "))).unwrap();
-        let alice_conf =
+        let mut alice_conf =
             Mm2TestConf::light_node(&hex::encode(alice_priv_key), &coins, &[mm_bob.ip.to_string().as_str()]);
+        alice_conf.conf["skip_seednodes_check"] = skip_seednodes_check.into();
         let mut mm_alice = block_on(MarketMakerIt::start_with_envs(
             alice_conf.conf,
             alice_conf.rpc_password,
@@ -5539,7 +5541,7 @@ fn test_peer_time_sync_validation() {
     };
 
     // check with small time offset:
-    let (bob_peers, alice_peers) = start_peers_with_time_offset(timeoffset_tolerable);
+    let (bob_peers, alice_peers) = start_peers_with_time_offset(timeoffset_tolerable, false);
     assert!(
         bob_peers["result"].as_object().unwrap().len() == 1,
         "bob must have one peer"
@@ -5550,7 +5552,7 @@ fn test_peer_time_sync_validation() {
     );
 
     // check with too big time offset:
-    let (bob_peers, alice_peers) = start_peers_with_time_offset(timeoffset_too_big);
+    let (bob_peers, alice_peers) = start_peers_with_time_offset(timeoffset_too_big, true); // skip_seednodes_check = true as there should not be connected peers
     assert!(
         bob_peers["result"].as_object().unwrap().is_empty(),
         "bob must have no peers"

--- a/mm2src/mm2_main/tests/integration_tests_common/mod.rs
+++ b/mm2src/mm2_main/tests/integration_tests_common/mod.rs
@@ -1,5 +1,5 @@
 use common::executor::Timer;
-use common::log::LogLevel;
+#[cfg(target_arch = "wasm32")] use common::log::LogLevel;
 use common::{block_on, log, now_ms, wait_until_ms};
 use crypto::privkey::key_pair_from_seed;
 use mm2_main::{lp_main, lp_run, LpMainParams};
@@ -12,7 +12,7 @@ use mm2_test_helpers::structs::{CreateNewAccountStatus, HDAccountAddressId, HDAc
 use serde_json::{self as json, Value as Json};
 use std::collections::HashMap;
 use std::env::var;
-use std::str::FromStr;
+#[cfg(target_arch = "wasm32")] use std::str::FromStr;
 
 /// This is not a separate test but a helper used by `MarketMakerIt` to run the MarketMaker from the test binary.
 #[test]
@@ -21,15 +21,19 @@ fn test_mm_start() { test_mm_start_impl(); }
 
 pub fn test_mm_start_impl() {
     if let Ok(conf) = var("_MM2_TEST_CONF") {
-        if let Ok(log_var) = var("RUST_LOG") {
-            if let Ok(filter) = LogLevel::from_str(&log_var) {
-                log!("test_mm_start] Starting the MarketMaker...");
-                let conf: Json = json::from_str(&conf).unwrap();
-                let params = LpMainParams::with_conf(conf).log_filter(Some(filter));
-                let ctx = block_on(lp_main(params, &|_ctx| (), "TEST".into(), "TEST".into())).unwrap();
-                block_on(lp_run(ctx))
-            }
-        }
+        log!("test_mm_start] Starting the MarketMaker...");
+        let conf: Json = json::from_str(&conf).unwrap();
+        #[cfg(not(target_arch = "wasm32"))]
+        let filter = None;
+        #[cfg(target_arch = "wasm32")]
+        let filter = if let Ok(log_var) = var("RUST_LOG") {
+            LogLevel::from_str(&log_var).ok(); // Actually filter is used for wasm only. For native RUST_LOG is parsed by env_logger directly, allowing setting multiple targets
+        } else {
+            None
+        };
+        let params = LpMainParams::with_conf(conf).log_filter(filter);
+        let ctx = block_on(lp_main(params, &|_ctx| (), "TEST".into(), "TEST".into())).unwrap();
+        block_on(lp_run(ctx))
     }
 }
 


### PR DESCRIPTION
This PR removes unneeded RUST_LOG parsing for test mm2 startup code, native platform. (For native we don't need to do this as RUST_LOG is parsed by env_logger itself.) This allows to use arbitrary RUST_LOG, with multiple tags (like RUST_LOG=off or RUST_LOG="debug,libp2p_gossipsub=info,rustls=error,mm2_main::database=error,mm2_p2p=info,multistream_select=error") for native mm2 executable in docker and other tests. 
Useful to hide unneeded debug logs.
The fix ensures the p2p module has info log level (needed for wait_for_log fn, used in tests).
The fix also refactors the check_seednodes test fn: instead of querying debug log it queries get_directly_connected_peers to ensured the peers are connected.