### PR TITLE
feat(db-arch): implement global DB uuid to address_dir map

### DIFF
--- a/mm2src/mm2_main/src/database/global.rs
+++ b/mm2src/mm2_main/src/database/global.rs
@@ -1,0 +1,52 @@
+use db_common::{async_sql_conn::AsyncConnError,
+                sqlite::{query_single_row, rusqlite::params}};
+use mm2_core::mm_ctx::MmArc;
+use uuid::Uuid;
+
+// TODO: Let's let this table be called `ongoing_swaps` and remove the `is_finished` column.
+//       And we might also add a new table `completed_swaps` that hold a copy of all the completed swaps for all the coins.
+const INIT_GLOBAL_DB_TABLES: &str = "
+    CREATE TABLE IF NOT EXISTS swaps (
+        uuid VARCHAR(255) PRIMARY KEY,
+        maker_address VARCHAR(255),
+        is_finished BOOLEAN
+    );
+";
+
+const SELECT_ADDRESS_FOR_SWAP_UUID: &str = "SELECT maker_address FROM swaps WHERE uuid = ?1";
+
+/// Errors that can occur when interacting with the global database.
+#[derive(Debug, Display)]
+pub enum GlobalDBError {
+    SqlError(AsyncConnError),
+}
+
+impl From<AsyncConnError> for GlobalDBError {
+    fn from(err: AsyncConnError) -> Self { GlobalDBError::SqlError(err) }
+}
+
+/// Initializes the global database with the necessary tables.
+pub async fn init_global_db(ctx: &MmArc) -> Result<(), GlobalDBError> {
+    let conn = ctx.async_global_db().await;
+    conn.lock()
+        .await
+        .call(|conn| conn.execute_batch(INIT_GLOBAL_DB_TABLES).map_err(|e| e.into()))
+        .await?;
+    Ok(())
+}
+
+/// Gets the maker address for a given swap UUID from the global database.
+///
+/// Returns `Ok(Some(addr))` if the UUID is found, `Ok(None)` if the UUID is not found, and `Err(e)` if there was an error.
+pub async fn get_address_for_swap_uuid(ctx: &MmArc, uuid: &Uuid) -> Result<Option<String>, GlobalDBError> {
+    let conn = ctx.async_global_db().await;
+    let uuid = uuid.to_string();
+    let address: Option<String> = conn
+        .lock()
+        .await
+        .call(move |conn| {
+            query_single_row(conn, SELECT_ADDRESS_FOR_SWAP_UUID, params![uuid], |row| row.get(0)).map_err(|e| e.into())
+        })
+        .await?;
+    Ok(address)
+}

--- a/mm2src/mm2_main/src/database/global.rs
+++ b/mm2src/mm2_main/src/database/global.rs
@@ -38,7 +38,7 @@ pub async fn init_global_db(ctx: &MmArc) -> Result<(), GlobalDBError> {
 /// Gets the maker address for a given swap UUID from the global database.
 ///
 /// Returns `Ok(Some(addr))` if the UUID is found, `Ok(None)` if the UUID is not found, and `Err(e)` if there was an error.
-pub async fn get_address_for_swap_uuid(ctx: &MmArc, uuid: &Uuid) -> Result<Option<String>, GlobalDBError> {
+pub async fn get_maker_address_for_swap_uuid(ctx: &MmArc, uuid: &Uuid) -> Result<Option<String>, GlobalDBError> {
     let conn = ctx.async_global_db().await;
     let uuid = uuid.to_string();
     let address: Option<String> = conn

--- a/mm2src/mm2_main/src/database/global.rs
+++ b/mm2src/mm2_main/src/database/global.rs
@@ -8,8 +8,7 @@ use uuid::Uuid;
 const INIT_GLOBAL_DB_TABLES: &str = "
     CREATE TABLE IF NOT EXISTS swaps (
         uuid VARCHAR(255) PRIMARY KEY,
-        maker_address VARCHAR(255),
-        is_finished BOOLEAN
+        maker_address VARCHAR(255) NOT NULL
     );
 ";
 

--- a/mm2src/mm2_main/src/database/mod.rs
+++ b/mm2src/mm2_main/src/database/mod.rs
@@ -1,5 +1,7 @@
 /// The module responsible to work with SQLite database
 ///
+#[cfg(feature = "new-db-arch")]
+pub mod global;
 pub mod my_orders;
 pub mod my_swaps;
 pub mod stats_nodes;

--- a/mm2src/mm2_main/src/database/my_swaps.rs
+++ b/mm2src/mm2_main/src/database/my_swaps.rs
@@ -68,7 +68,7 @@ const INSERT_MY_SWAP: &str =
     "INSERT INTO my_swaps (my_coin, other_coin, uuid, started_at, swap_type) VALUES (?1, ?2, ?3, ?4, ?5)";
 
 pub fn insert_new_swap(
-    ctx: &MmArc,
+    conn: &Connection,
     my_coin: &str,
     other_coin: &str,
     uuid: &str,
@@ -76,7 +76,6 @@ pub fn insert_new_swap(
     swap_type: u8,
 ) -> SqlResult<()> {
     debug!("Inserting new swap {} to the SQLite database", uuid);
-    let conn = ctx.sqlite_connection();
     let params = [my_coin, other_coin, uuid, started_at, &swap_type.to_string()];
     conn.execute(INSERT_MY_SWAP, params).map(|_| ())
 }

--- a/mm2src/mm2_main/src/lp_native_dex.rs
+++ b/mm2src/mm2_main/src/lp_native_dex.rs
@@ -18,6 +18,8 @@
 //  marketmaker
 //
 
+#[cfg(all(not(target_arch = "wasm32"), feature = "new-db-arch"))]
+use crate::database::global::init_global_db;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::database::init_and_migrate_sql_db;
 use crate::lp_healthcheck::peer_healthcheck_topic;
@@ -457,6 +459,9 @@ pub async fn lp_init_continue(ctx: MmArc) -> MmInitResult<()> {
             ctx.init_global_and_wallet_db()
                 .await
                 .map_to_mm(MmInitError::ErrorSqliteInitializing)?;
+            init_global_db(&ctx)
+                .await
+                .map_to_mm(|e| MmInitError::ErrorSqliteInitializing(e.to_string()))?;
         }
     }
 

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -3166,6 +3166,10 @@ async fn start_maker_legacy_swap(
 ) {
     if let Err(e) = insert_new_swap_to_db(
         ctx.clone(),
+        &params
+            .maker_coin
+            .address_from_pubkey(&(*params.my_persistent_pub).into())
+            .unwrap(),
         params.maker_coin.ticker(),
         params.taker_coin.ticker(),
         *params.uuid,
@@ -3404,6 +3408,10 @@ async fn start_taker_legacy_swap(
 
     if let Err(e) = insert_new_swap_to_db(
         ctx.clone(),
+        &params
+            .maker_coin
+            .address_from_pubkey(&(*params.my_persistent_pub).into())
+            .unwrap(),
         params.taker_coin.ticker(),
         params.maker_coin.ticker(),
         *params.uuid,

--- a/mm2src/mm2_main/src/lp_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap.rs
@@ -58,8 +58,6 @@
 //
 
 use super::lp_network::P2PRequestResult;
-#[cfg(all(not(target_arch = "wasm32"), feature = "new-db-arch"))]
-use crate::database::global::insert_swap;
 use crate::lp_network::{broadcast_p2p_msg, Libp2pPeerId, P2PProcessError, P2PProcessResult, P2PRequestError};
 use crate::lp_swap::maker_swap_v2::MakerSwapStorage;
 use crate::lp_swap::taker_swap_v2::TakerSwapStorage;
@@ -973,19 +971,15 @@ pub fn my_swap_file_path(ctx: &MmArc, address: &str, uuid: &Uuid) -> PathBuf {
 
 pub async fn insert_new_swap_to_db(
     ctx: MmArc,
-    _maker_address: &str,
+    maker_address: &str,
     my_coin: &str,
     other_coin: &str,
     uuid: Uuid,
     started_at: u64,
     swap_type: u8,
 ) -> Result<(), String> {
-    #[cfg(all(not(target_arch = "wasm32"), feature = "new-db-arch"))]
-    insert_swap(&ctx, &uuid, _maker_address)
-        .await
-        .map_err(|e| ERRL!("{}", e))?;
     MySwapsStorage::new(ctx)
-        .save_new_swap(my_coin, other_coin, uuid, started_at, swap_type)
+        .save_new_swap(my_coin, other_coin, maker_address, uuid, started_at, swap_type)
         .await
         .map_err(|e| ERRL!("{}", e))
 }

--- a/mm2src/mm2_main/src/lp_swap/saved_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/saved_swap.rs
@@ -245,7 +245,7 @@ mod native_impl {
         async fn load_all_my_swaps_from_db(ctx: &MmArc) -> SavedSwapResult<Vec<SavedSwap>> {
             #[cfg(feature = "new-db-arch")]
             {
-                // This method is solely used for migrations. Which we should ditch or refactor with the new DB architecture.
+                // TODO: This method is solely used for migrations. Which we should ditch or refactor with the new DB architecture.
                 // If we ditch the old migrations, this method should never be called (and should be deleted when we are
                 // done with the incremental architecture change).
                 todo!("Fix the dummy address directory in `my_swaps_dir` below or remove this method all together");

--- a/mm2src/mm2_main/src/lp_swap/saved_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/saved_swap.rs
@@ -199,7 +199,7 @@ pub trait SavedSwapIo {
 mod native_impl {
     use super::*;
     #[cfg(feature = "new-db-arch")]
-    use crate::database::global::{get_maker_address_for_swap_uuid, insert_swap};
+    use crate::database::global::get_maker_address_for_swap_uuid;
     use crate::lp_swap::maker_swap::{stats_maker_swap_dir, stats_maker_swap_file_path};
     use crate::lp_swap::taker_swap::{stats_taker_swap_dir, stats_taker_swap_file_path};
     use crate::lp_swap::{my_swap_file_path, my_swaps_dir};
@@ -256,13 +256,7 @@ mod native_impl {
 
         async fn save_to_db(&self, ctx: &MmArc) -> SavedSwapResult<()> {
             #[cfg(feature = "new-db-arch")]
-            let address_dir = {
-                let address_dir = self.maker_address();
-                insert_swap(ctx, self.uuid(), address_dir)
-                    .await
-                    .map_err(|e| SavedSwapError::ErrorSaving(e.to_string()))?;
-                address_dir
-            };
+            let address_dir = self.maker_address();
             #[cfg(not(feature = "new-db-arch"))]
             let address_dir = "no address directory for old DB architecture (has no effect)";
             let path = my_swap_file_path(ctx, address_dir, self.uuid());

--- a/mm2src/mm2_main/src/lp_swap/swap_v2_common.rs
+++ b/mm2src/mm2_main/src/lp_swap/swap_v2_common.rs
@@ -66,6 +66,7 @@ pub enum SwapStateMachineError {
     SerdeError(String),
     SwapLockAlreadyAcquired,
     SwapLock(SwapLockError),
+    InternalError(String),
     #[cfg(target_arch = "wasm32")]
     NoSwapWithUuid(Uuid),
 }


### PR DESCRIPTION
This implements the global DB's UUID -> maker_address mapping.

When the swap is started or imported (via `import_swaps` rpc), the uuid to maker_address mapping gets stored in the global DB. When the uuid is queried, we fetch the maker_address from that global DB map to get the address directory that hosts the data related to that uuid.

This touches only v1 swaps for now.