### PR TITLE
feat(ibc-routing-part-2): supporting entire Cosmos network for swaps

### DIFF
--- a/mm2src/coins/tendermint/htlc/mod.rs
+++ b/mm2src/coins/tendermint/htlc/mod.rs
@@ -33,8 +33,8 @@ impl FromStr for HtlcType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "iaa" => Ok(HtlcType::Iris),
-            "nuc" => Ok(HtlcType::Nucleus),
+            super::IRIS_PREFIX => Ok(HtlcType::Iris),
+            super::NUCLEUS_PREFIX => Ok(HtlcType::Nucleus),
             unsupported => Err(io::Error::new(
                 io::ErrorKind::Unsupported,
                 format!("Account type '{unsupported}' is not supported for HTLCs"),

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -418,7 +418,6 @@ pub enum TendermintInitErrorKind {
     EmptyRpcUrls,
     RpcClientInitError(String),
     InvalidChainId(String),
-    InvalidDenom(String),
     InvalidProtocolData(String),
     InvalidPathToAddress(String),
     #[display(fmt = "'derivation_path' field is not found in config")]

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -105,6 +105,8 @@ const ABCI_DELEGATOR_UNDELEGATIONS_PATH: &str = "/cosmos.staking.v1beta1.Query/D
 const ABCI_DELEGATION_REWARDS_PATH: &str = "/cosmos.distribution.v1beta1.Query/DelegationRewards";
 const ABCI_IBC_CHANNEL_QUERY_PATH: &str = "/ibc.core.channel.v1.Query/Channel";
 
+pub(crate) const DEFAULT_MIN_BALANCE_FOR_IBC_ROUTING: f32 = 2.0;
+
 pub(crate) const MIN_TX_SATOSHIS: i64 = 1;
 
 // ABCI Request Defaults
@@ -193,10 +195,13 @@ pub struct TendermintFeeDetails {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TendermintProtocolInfo {
     pub decimals: u8,
-    denom: String,
+    pub(crate) denom: Denom,
+    min_balance_for_ibc_routing: Option<f32>,
     pub account_prefix: String,
-    chain_id: String,
+    chain_id: ChainId,
     gas_price: Option<f64>,
+    /// Key represents the account prefix of the target chain and
+    /// the value is the channel ID used for sending transactions.
     #[serde(default)]
     ibc_channels: HashMap<String, ChannelId>,
 }
@@ -378,12 +383,7 @@ pub struct TendermintCoinImpl {
     avg_blocktime: u8,
     /// My address
     pub account_id: AccountId,
-    pub(super) account_prefix: String,
     pub activation_policy: TendermintActivationPolicy,
-    pub(crate) decimals: u8,
-    pub(super) denom: Denom,
-    chain_id: ChainId,
-    gas_price: Option<f64>,
     pub tokens_info: PaMutex<HashMap<String, ActivatedTokenInfo>>,
     /// This spawner is used to spawn coin's related futures that should be aborted on coin deactivation
     /// or on [`MmArc::stop`].
@@ -392,9 +392,7 @@ pub struct TendermintCoinImpl {
     client: TendermintRpcClient,
     pub(crate) ctx: MmWeak,
     pub(crate) is_keplr_from_ledger: bool,
-    /// Key represents the account prefix of the target chain and
-    /// the value is the channel ID used for sending transactions.
-    ibc_channels: HashMap<String, ChannelId>,
+    pub(crate) protocol_info: TendermintProtocolInfo,
 }
 
 #[derive(Clone)]
@@ -632,7 +630,7 @@ impl From<DecodeError> for SearchForSwapTxSpendErr {
 
 #[async_trait]
 impl TendermintCommons for TendermintCoin {
-    fn platform_denom(&self) -> &Denom { &self.denom }
+    fn platform_denom(&self) -> &Denom { &self.protocol_info.denom }
 
     fn set_history_sync_state(&self, new_state: HistorySyncState) {
         *self.history_sync_state.lock().unwrap() = new_state;
@@ -647,7 +645,7 @@ impl TendermintCommons for TendermintCoin {
     }
 
     fn denom_to_ticker(&self, denom: &str) -> Option<String> {
-        if self.denom.as_ref() == denom {
+        if self.protocol_info.denom.as_ref() == denom {
             return Some(self.ticker.clone());
         }
 
@@ -663,9 +661,9 @@ impl TendermintCommons for TendermintCoin {
 
     async fn get_all_balances(&self) -> MmResult<AllBalancesResult, TendermintCoinRpcError> {
         let platform_balance_denom = self
-            .account_balance_for_denom(&self.account_id, self.denom.to_string())
+            .account_balance_for_denom(&self.account_id, self.protocol_info.denom.to_string())
             .await?;
-        let platform_balance = big_decimal_from_sat_unsigned(platform_balance_denom, self.decimals);
+        let platform_balance = big_decimal_from_sat_unsigned(platform_balance_denom, self.protocol_info.decimals);
         let ibc_assets_info = self.tokens_info.lock().clone();
 
         let mut requests = Vec::with_capacity(ibc_assets_info.len());
@@ -728,16 +726,6 @@ impl TendermintCoin {
 
         let client_impl = TendermintRpcClientImpl { rpc_clients };
 
-        let chain_id = ChainId::try_from(protocol_info.chain_id).map_to_mm(|e| TendermintInitError {
-            ticker: ticker.clone(),
-            kind: TendermintInitErrorKind::InvalidChainId(e.to_string()),
-        })?;
-
-        let denom = Denom::from_str(&protocol_info.denom).map_to_mm(|e| TendermintInitError {
-            ticker: ticker.clone(),
-            kind: TendermintInitErrorKind::InvalidDenom(e.to_string()),
-        })?;
-
         let history_sync_state = if tx_history {
             HistorySyncState::NotStarted
         } else {
@@ -757,18 +745,13 @@ impl TendermintCoin {
         Ok(TendermintCoin(Arc::new(TendermintCoinImpl {
             ticker,
             account_id,
-            account_prefix: protocol_info.account_prefix,
             activation_policy,
-            decimals: protocol_info.decimals,
-            denom,
-            chain_id,
-            gas_price: protocol_info.gas_price,
             avg_blocktime: conf.avg_blocktime,
             tokens_info: PaMutex::new(HashMap::new()),
             abortable_system,
             history_sync_state: Mutex::new(history_sync_state),
             client: TendermintRpcClient(AsyncMutex::new(client_impl)),
-            ibc_channels: protocol_info.ibc_channels,
+            protocol_info,
             ctx: ctx.weak(),
             is_keplr_from_ledger,
         })))
@@ -816,12 +799,11 @@ impl TendermintCoin {
         // ref: https://github.com/cosmos/ibc-go/blob/7f34724b982581435441e0bb70598c3e3a77f061/proto/ibc/core/channel/v1/channel.proto#L51-L68
         const STATE_OPEN: i32 = 3;
 
-        let channel_id = *self
-            .ibc_channels
-            .get(address_prefix)
-            .ok_or_else(|| IBCError::IBCChannelCouldNotBeFound {
+        let channel_id = *self.protocol_info.ibc_channels.get(address_prefix).ok_or_else(|| {
+            IBCError::IBCChannelCouldNotBeFound {
                 address_prefix: address_prefix.to_owned(),
-            })?;
+            }
+        })?;
 
         let channel = self.query_ibc_channel(channel_id, "transfer").await?;
 
@@ -838,7 +820,7 @@ impl TendermintCoin {
     }
 
     #[inline(always)]
-    fn gas_price(&self) -> f64 { self.gas_price.unwrap_or(DEFAULT_GAS_PRICE) }
+    fn gas_price(&self) -> f64 { self.protocol_info.gas_price.unwrap_or(DEFAULT_GAS_PRICE) }
 
     #[allow(unused)]
     async fn get_latest_block(&self) -> MmResult<GetLatestBlockResponse, TendermintCoinRpcError> {
@@ -882,7 +864,7 @@ impl TendermintCoin {
         memo: &str,
     ) -> cosmrs::Result<Vec<u8>> {
         let fee_amount = Coin {
-            denom: self.denom.clone(),
+            denom: self.protocol_info.denom.clone(),
             amount: 0_u64.into(),
         };
 
@@ -891,7 +873,12 @@ impl TendermintCoin {
         let signkey = SigningKey::from_slice(priv_key.as_slice())?;
         let tx_body = tx::Body::new(vec![tx_payload], memo, timeout_height as u32);
         let auth_info = SignerInfo::single_direct(Some(signkey.public_key()), account_info.sequence).auth_info(fee);
-        let sign_doc = SignDoc::new(&tx_body, &auth_info, &self.chain_id, account_info.account_number)?;
+        let sign_doc = SignDoc::new(
+            &tx_body,
+            &auth_info,
+            &self.protocol_info.chain_id,
+            account_info.account_number,
+        )?;
         sign_doc.sign(&signkey)?.to_bytes()
     }
 
@@ -1197,7 +1184,7 @@ impl TendermintCoin {
             .account
             .or_mm_err(|| TendermintCoinRpcError::InvalidResponse("Account is None".into()))?;
 
-        let account_prefix = self.account_prefix.clone();
+        let account_prefix = self.protocol_info.account_prefix.clone();
         let base_account = match BaseAccount::decode(account.value.as_slice()) {
             Ok(account) => account,
             Err(err) if account_prefix.as_str() == "iaa" => {
@@ -1267,7 +1254,7 @@ impl TendermintCoin {
                     .hd_wallet_derived_priv_key_or_err(&path_to_address)
                     .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
 
-                let account_id = account_id_from_privkey(priv_key.as_slice(), &self.account_prefix)
+                let account_id = account_id_from_privkey(priv_key.as_slice(), &self.protocol_info.account_prefix)
                     .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
                 Ok((account_id, Some(priv_key)))
             },
@@ -1322,10 +1309,10 @@ impl TendermintCoin {
         let amount = vec![Coin { denom, amount }];
         let timestamp = 0_u64;
 
-        let htlc_type = HtlcType::from_str(&self.account_prefix).map_err(|_| {
+        let htlc_type = HtlcType::from_str(&self.protocol_info.account_prefix).map_err(|_| {
             TxMarshalingErr::NotSupported(format!(
                 "Account type '{}' is not supported for HTLCs",
-                self.account_prefix
+                self.protocol_info.account_prefix
             ))
         })?;
 
@@ -1350,10 +1337,10 @@ impl TendermintCoin {
     }
 
     fn gen_claim_htlc_tx(&self, htlc_id: String, secret: &[u8]) -> MmResult<TendermintHtlc, TxMarshalingErr> {
-        let htlc_type = HtlcType::from_str(&self.account_prefix).map_err(|_| {
+        let htlc_type = HtlcType::from_str(&self.protocol_info.account_prefix).map_err(|_| {
             TxMarshalingErr::NotSupported(format!(
                 "Account type '{}' is not supported for HTLCs",
-                self.account_prefix
+                self.protocol_info.account_prefix
             ))
         })?;
 
@@ -1379,7 +1366,12 @@ impl TendermintCoin {
         let signkey = SigningKey::from_slice(priv_key.as_slice())?;
         let tx_body = tx::Body::new(vec![tx_payload], memo, timeout_height as u32);
         let auth_info = SignerInfo::single_direct(Some(signkey.public_key()), account_info.sequence).auth_info(fee);
-        let sign_doc = SignDoc::new(&tx_body, &auth_info, &self.chain_id, account_info.account_number)?;
+        let sign_doc = SignDoc::new(
+            &tx_body,
+            &auth_info,
+            &self.protocol_info.chain_id,
+            account_info.account_number,
+        )?;
         sign_doc.sign(&signkey)
     }
 
@@ -1394,7 +1386,12 @@ impl TendermintCoin {
         let tx_body = tx::Body::new(vec![tx_payload], memo, timeout_height as u32);
         let pubkey = self.activation_policy.public_key()?.into();
         let auth_info = SignerInfo::single_direct(Some(pubkey), account_info.sequence).auth_info(fee);
-        let sign_doc = SignDoc::new(&tx_body, &auth_info, &self.chain_id, account_info.account_number)?;
+        let sign_doc = SignDoc::new(
+            &tx_body,
+            &auth_info,
+            &self.protocol_info.chain_id,
+            account_info.account_number,
+        )?;
 
         let tx_json = json!({
             "sign_doc": {
@@ -1480,7 +1477,7 @@ impl TendermintCoin {
         let tx_json = serde_json::json!({
             "legacy_amino_json": {
                 "account_number": account_info.account_number.to_string(),
-                "chain_id": self.chain_id.to_string(),
+                "chain_id": self.protocol_info.chain_id.to_string(),
                 "fee": {
                     "amount": fee_amount,
                     "gas": fee.gas_limit.to_string()
@@ -1523,7 +1520,10 @@ impl TendermintCoin {
         }];
 
         let pubkey_hash = dhash160(other_pub);
-        let to_address = try_fus!(AccountId::new(&self.account_prefix, pubkey_hash.as_slice()));
+        let to_address = try_fus!(AccountId::new(
+            &self.protocol_info.account_prefix,
+            pubkey_hash.as_slice()
+        ));
 
         let htlc_id = self.calculate_htlc_id(&self.account_id, &to_address, &amount, secret_hash);
 
@@ -1567,7 +1567,7 @@ impl TendermintCoin {
                 let deserialized_tx = try_s!(cosmrs::Tx::from_bytes(&tx.tx));
                 let msg = try_s!(deserialized_tx.body.messages.first().ok_or("Tx body couldn't be read."));
                 let htlc = try_s!(CreateHtlcProto::decode(
-                    try_s!(HtlcType::from_str(&coin.account_prefix)),
+                    try_s!(HtlcType::from_str(&coin.protocol_info.account_prefix)),
                     msg.value.as_slice()
                 ));
 
@@ -1599,7 +1599,10 @@ impl TendermintCoin {
         decimals: u8,
     ) -> TransactionFut {
         let pubkey_hash = dhash160(other_pub);
-        let to = try_tx_fus!(AccountId::new(&self.account_prefix, pubkey_hash.as_slice()));
+        let to = try_tx_fus!(AccountId::new(
+            &self.protocol_info.account_prefix,
+            pubkey_hash.as_slice()
+        ));
 
         let amount_as_u64 = try_tx_fus!(sat_from_big_decimal(&amount, decimals));
         let amount = cosmrs::Amount::from(amount_as_u64);
@@ -1655,8 +1658,14 @@ impl TendermintCoin {
         let from_address = self.account_id.clone();
         let dex_pubkey_hash = dhash160(self.dex_pubkey());
         let burn_pubkey_hash = dhash160(self.burn_pubkey());
-        let dex_address = try_tx_fus!(AccountId::new(&self.account_prefix, dex_pubkey_hash.as_slice()));
-        let burn_address = try_tx_fus!(AccountId::new(&self.account_prefix, burn_pubkey_hash.as_slice()));
+        let dex_address = try_tx_fus!(AccountId::new(
+            &self.protocol_info.account_prefix,
+            dex_pubkey_hash.as_slice()
+        ));
+        let burn_address = try_tx_fus!(AccountId::new(
+            &self.protocol_info.account_prefix,
+            burn_pubkey_hash.as_slice()
+        ));
 
         let fee_amount_as_u64 = try_tx_fus!(dex_fee.fee_amount_as_u64(decimals));
         let fee_amount = vec![Coin {
@@ -1757,8 +1766,11 @@ impl TendermintCoin {
             .to_string();
 
         let sender_pubkey_hash = dhash160(expected_sender);
-        let expected_sender_address = try_f!(AccountId::new(&self.account_prefix, sender_pubkey_hash.as_slice())
-            .map_to_mm(|r| ValidatePaymentError::InvalidParameter(r.to_string())));
+        let expected_sender_address = try_f!(AccountId::new(
+            &self.protocol_info.account_prefix,
+            sender_pubkey_hash.as_slice()
+        )
+        .map_to_mm(|r| ValidatePaymentError::InvalidParameter(r.to_string())));
 
         let coin = self.clone();
         let dex_fee = dex_fee.clone();
@@ -1826,10 +1838,10 @@ impl TendermintCoin {
                 "Payment tx must have exactly one message".into(),
             ));
         }
-        let htlc_type = HtlcType::from_str(&self.account_prefix).map_err(|_| {
+        let htlc_type = HtlcType::from_str(&self.protocol_info.account_prefix).map_err(|_| {
             ValidatePaymentError::InvalidParameter(format!(
                 "Account type '{}' is not supported for HTLCs",
-                self.account_prefix
+                self.protocol_info.account_prefix
             ))
         })?;
 
@@ -1839,7 +1851,7 @@ impl TendermintCoin {
             .map_to_mm(|e| ValidatePaymentError::WrongPaymentTx(e.to_string()))?;
 
         let sender_pubkey_hash = dhash160(&input.other_pub);
-        let sender = AccountId::new(&self.account_prefix, sender_pubkey_hash.as_slice())
+        let sender = AccountId::new(&self.protocol_info.account_prefix, sender_pubkey_hash.as_slice())
             .map_to_mm(|e| ValidatePaymentError::InvalidParameter(e.to_string()))?;
 
         let amount = sat_from_big_decimal(&input.amount, decimals)?;
@@ -1906,7 +1918,7 @@ impl TendermintCoin {
         }
 
         let dex_pubkey_hash = dhash160(self.dex_pubkey());
-        let expected_dex_address = AccountId::new(&self.account_prefix, dex_pubkey_hash.as_slice())
+        let expected_dex_address = AccountId::new(&self.protocol_info.account_prefix, dex_pubkey_hash.as_slice())
             .map_to_mm(|r| ValidatePaymentError::InvalidParameter(r.to_string()))?;
 
         let fee_amount_as_u64 = dex_fee.fee_amount_as_u64(decimals)?;
@@ -1958,11 +1970,11 @@ impl TendermintCoin {
         }
 
         let dex_pubkey_hash = dhash160(self.dex_pubkey());
-        let expected_dex_address = AccountId::new(&self.account_prefix, dex_pubkey_hash.as_slice())
+        let expected_dex_address = AccountId::new(&self.protocol_info.account_prefix, dex_pubkey_hash.as_slice())
             .map_to_mm(|r| ValidatePaymentError::InvalidParameter(r.to_string()))?;
 
         let burn_pubkey_hash = dhash160(self.burn_pubkey());
-        let expected_burn_address = AccountId::new(&self.account_prefix, burn_pubkey_hash.as_slice())
+        let expected_burn_address = AccountId::new(&self.protocol_info.account_prefix, burn_pubkey_hash.as_slice())
             .map_to_mm(|r| ValidatePaymentError::InvalidParameter(r.to_string()))?;
 
         let fee_amount_as_u64 = dex_fee.fee_amount_as_u64(decimals)?;
@@ -2050,7 +2062,7 @@ impl TendermintCoin {
         common::os_rng(&mut sec).map_err(|e| MmError::new(TradePreimageError::InternalError(e.to_string())))?;
         drop_mutability!(sec);
 
-        let to_address = account_id_from_pubkey_hex(&self.account_prefix, DEX_FEE_ADDR_PUBKEY)
+        let to_address = account_id_from_pubkey_hex(&self.protocol_info.account_prefix, DEX_FEE_ADDR_PUBKEY)
             .map_err(|e| MmError::new(TradePreimageError::InternalError(e.to_string())))?;
 
         let amount = sat_from_big_decimal(&amount, decimals)?;
@@ -2084,7 +2096,7 @@ impl TendermintCoin {
             )
             .await?;
 
-        let fee_amount = big_decimal_from_sat_unsigned(fee_uamount, self.decimals);
+        let fee_amount = big_decimal_from_sat_unsigned(fee_uamount, self.protocol_info.decimals);
 
         Ok(TradeFee {
             coin: ticker,
@@ -2100,7 +2112,7 @@ impl TendermintCoin {
         decimals: u8,
         dex_fee_amount: DexFee,
     ) -> TradePreimageResult<TradeFee> {
-        let to_address = account_id_from_pubkey_hex(&self.account_prefix, DEX_FEE_ADDR_PUBKEY)
+        let to_address = account_id_from_pubkey_hex(&self.protocol_info.account_prefix, DEX_FEE_ADDR_PUBKEY)
             .map_err(|e| MmError::new(TradePreimageError::InternalError(e.to_string())))?;
         let amount = sat_from_big_decimal(&dex_fee_amount.fee_amount().into(), decimals)?;
 
@@ -2209,10 +2221,11 @@ impl TendermintCoin {
     }
 
     pub(crate) async fn query_htlc(&self, id: String) -> MmResult<QueryHtlcResponse, TendermintCoinRpcError> {
-        let htlc_type =
-            HtlcType::from_str(&self.account_prefix).map_err(|_| TendermintCoinRpcError::UnexpectedAccountType {
-                prefix: self.account_prefix.clone(),
-            })?;
+        let htlc_type = HtlcType::from_str(&self.protocol_info.account_prefix).map_err(|_| {
+            TendermintCoinRpcError::UnexpectedAccountType {
+                prefix: self.protocol_info.account_prefix.clone(),
+            }
+        })?;
 
         let request = QueryHtlcRequestProto { id };
         let response = self
@@ -2246,10 +2259,11 @@ impl TendermintCoin {
             .first()
             .or_mm_err(|| SearchForSwapTxSpendErr::TxMessagesEmpty)?;
 
-        let htlc_type =
-            HtlcType::from_str(&self.account_prefix).map_err(|_| SearchForSwapTxSpendErr::UnexpectedAccountType {
-                prefix: self.account_prefix.clone(),
-            })?;
+        let htlc_type = HtlcType::from_str(&self.protocol_info.account_prefix).map_err(|_| {
+            SearchForSwapTxSpendErr::UnexpectedAccountType {
+                prefix: self.protocol_info.account_prefix.clone(),
+            }
+        })?;
 
         let htlc_proto = CreateHtlcProto::decode(htlc_type, first_message.value.as_slice())?;
         let htlc = CreateHtlcMsg::try_from(htlc_proto)?;
@@ -2317,8 +2331,8 @@ impl TendermintCoin {
     }
 
     pub(crate) fn active_ticker_and_decimals_from_denom(&self, denom: &str) -> Option<(String, u8)> {
-        if self.denom.as_ref() == denom {
-            return Some((self.ticker.clone(), self.decimals));
+        if self.protocol_info.denom.as_ref() == denom {
+            return Some((self.ticker.clone(), self.protocol_info.decimals));
         }
 
         let tokens = self.tokens_info.lock();
@@ -2412,7 +2426,7 @@ impl TendermintCoin {
                 return Err(not_sufficient(total));
             }
 
-            let amount_u64 = sat_from_big_decimal(&request_amount, coin.decimals)
+            let amount_u64 = sat_from_big_decimal(&request_amount, coin.protocol_info.decimals)
                 .map_err(|e| DelegationError::InternalError(e.to_string()))?;
 
             Ok((amount_u64, total))
@@ -2426,13 +2440,13 @@ impl TendermintCoin {
             .map_err(|e| DelegationError::InternalError(e.to_string()))?;
 
         let (balance_u64, balance_dec) = self
-            .get_balance_as_unsigned_and_decimal(&delegator_address, &self.denom, self.decimals())
+            .get_balance_as_unsigned_and_decimal(&delegator_address, &self.protocol_info.denom, self.decimals())
             .await?;
 
         let amount_u64 = if req.max {
             balance_u64
         } else {
-            sat_from_big_decimal(&req.amount, self.decimals)
+            sat_from_big_decimal(&req.amount, self.protocol_info.decimals)
                 .map_err(|e| DelegationError::InternalError(e.to_string()))?
         };
 
@@ -2440,7 +2454,7 @@ impl TendermintCoin {
         let msg_for_fee_prediction = generate_message(
             delegator_address.clone(),
             validator_address.clone(),
-            self.denom.clone(),
+            self.protocol_info.denom.clone(),
             amount_u64.into(),
         )
         .map_err(|e| DelegationError::InternalError(e.to_string()))?;
@@ -2471,7 +2485,7 @@ impl TendermintCoin {
 
         let fee = Fee::from_amount_and_gas(
             Coin {
-                denom: self.denom.clone(),
+                denom: self.protocol_info.denom.clone(),
                 amount: fee_amount_u64.into(),
             },
             gas_limit,
@@ -2490,7 +2504,7 @@ impl TendermintCoin {
         let msg_for_actual_tx = generate_message(
             delegator_address.clone(),
             validator_address.clone(),
-            self.denom.clone(),
+            self.protocol_info.denom.clone(),
             amount_u64.into(),
         )
         .map_err(|e| DelegationError::InternalError(e.to_string()))?;
@@ -2571,14 +2585,14 @@ impl TendermintCoin {
                 });
             };
 
-            sat_from_big_decimal(&req.amount, self.decimals)
+            sat_from_big_decimal(&req.amount, self.protocol_info.decimals)
                 .map_err(|e| DelegationError::InternalError(e.to_string()))?
         };
 
         let undelegate_msg = generate_message(
             delegator_address.clone(),
             validator_address.clone(),
-            self.denom.clone(),
+            self.protocol_info.denom.clone(),
             uamount_to_undelegate.into(),
         )
         .map_err(|e| DelegationError::InternalError(e.to_string()))?;
@@ -2619,7 +2633,7 @@ impl TendermintCoin {
 
         let fee = Fee::from_amount_and_gas(
             Coin {
-                denom: self.denom.clone(),
+                denom: self.protocol_info.denom.clone(),
                 amount: fee_amount_u64.into(),
             },
             gas_limit,
@@ -2746,9 +2760,9 @@ impl TendermintCoin {
         match decoded_response
             .rewards
             .iter()
-            .find(|t| t.denom == self.denom.to_string())
+            .find(|t| t.denom == self.protocol_info.denom.to_string())
         {
-            Some(dec_coin) => extract_big_decimal_from_dec_coin(dec_coin, self.decimals as u32)
+            Some(dec_coin) => extract_big_decimal_from_dec_coin(dec_coin, self.protocol_info.decimals as u32)
                 .map_to_mm(|e| DelegationError::InternalError(e.to_string())),
             None => MmError::err(DelegationError::NothingToClaim {
                 coin: self.ticker.clone(),
@@ -2825,7 +2839,7 @@ impl TendermintCoin {
 
         let fee = Fee::from_amount_and_gas(
             Coin {
-                denom: self.denom.clone(),
+                denom: self.protocol_info.denom.clone(),
                 amount: fee_amount_u64.into(),
             },
             gas_limit,
@@ -3068,24 +3082,28 @@ impl MmCoin for TendermintCoin {
             let to_address =
                 AccountId::from_str(&req.to).map_to_mm(|e| WithdrawError::InvalidAddress(e.to_string()))?;
 
-            let is_ibc_transfer = to_address.prefix() != coin.account_prefix || req.ibc_source_channel.is_some();
+            let is_ibc_transfer =
+                to_address.prefix() != coin.protocol_info.account_prefix || req.ibc_source_channel.is_some();
 
             let (account_id, maybe_priv_key) = coin
                 .extract_account_id_and_private_key(req.from)
                 .map_err(|e| WithdrawError::InternalError(e.to_string()))?;
 
             let (balance_denom, balance_dec) = coin
-                .get_balance_as_unsigned_and_decimal(&account_id, &coin.denom, coin.decimals())
+                .get_balance_as_unsigned_and_decimal(&account_id, &coin.protocol_info.denom, coin.decimals())
                 .await?;
 
             let (amount_denom, amount_dec) = if req.max {
                 let amount_denom = balance_denom;
-                (amount_denom, big_decimal_from_sat_unsigned(amount_denom, coin.decimals))
+                (
+                    amount_denom,
+                    big_decimal_from_sat_unsigned(amount_denom, coin.decimals()),
+                )
             } else {
-                (sat_from_big_decimal(&req.amount, coin.decimals)?, req.amount.clone())
+                (sat_from_big_decimal(&req.amount, coin.decimals())?, req.amount.clone())
             };
 
-            if !coin.is_tx_amount_enough(coin.decimals, &amount_dec) {
+            if !coin.is_tx_amount_enough(coin.decimals(), &amount_dec) {
                 return MmError::err(WithdrawError::AmountTooLow {
                     amount: amount_dec,
                     threshold: coin.min_tx_amount(),
@@ -3110,7 +3128,7 @@ impl MmCoin for TendermintCoin {
             let msg_payload = create_withdraw_msg_as_any(
                 account_id.clone(),
                 to_address.clone(),
-                &coin.denom,
+                &coin.protocol_info.denom,
                 amount_denom,
                 channel_id,
             )
@@ -3159,7 +3177,7 @@ impl MmCoin for TendermintCoin {
             let fee_amount_dec = big_decimal_from_sat_unsigned(fee_amount_u64, coin.decimals());
 
             let fee_amount = Coin {
-                denom: coin.denom.clone(),
+                denom: coin.protocol_info.denom.clone(),
                 amount: fee_amount_u64.into(),
             };
 
@@ -3185,13 +3203,13 @@ impl MmCoin for TendermintCoin {
                     });
                 }
 
-                (sat_from_big_decimal(&req.amount, coin.decimals)?, total)
+                (sat_from_big_decimal(&req.amount, coin.decimals())?, total)
             };
 
             let msg_payload = create_withdraw_msg_as_any(
                 account_id.clone(),
                 to_address.clone(),
-                &coin.denom,
+                &coin.protocol_info.denom,
                 amount_denom,
                 channel_id,
             )
@@ -3266,7 +3284,7 @@ impl MmCoin for TendermintCoin {
         Box::new(fut.boxed().compat())
     }
 
-    fn decimals(&self) -> u8 { self.decimals }
+    fn decimals(&self) -> u8 { self.protocol_info.decimals }
 
     fn convert_to_address(&self, from: &str, to_address_format: Json) -> Result<String, String> {
         // TODO
@@ -3306,13 +3324,18 @@ impl MmCoin for TendermintCoin {
         let amount = match value {
             TradePreimageValue::Exact(decimal) | TradePreimageValue::UpperBound(decimal) => decimal,
         };
-        self.get_sender_trade_fee_for_denom(self.ticker.clone(), self.denom.clone(), self.decimals, amount)
-            .await
+        self.get_sender_trade_fee_for_denom(
+            self.ticker.clone(),
+            self.protocol_info.denom.clone(),
+            self.protocol_info.decimals,
+            amount,
+        )
+        .await
     }
 
     /// Overrides the default `pre_check_for_order_creation` implementation with
     /// additional IBC-related logic on top of the default behavior.
-    #[cfg(feature = "ibc-routing-for-swaps")]
+    // #[cfg(feature = "ibc-routing-for-swaps")]
     async fn pre_check_for_order_creation(
         &self,
         ctx: &MmArc,
@@ -3380,7 +3403,7 @@ impl MmCoin for TendermintCoin {
             });
         }
 
-        let supports_htlc = matches!(self.account_prefix.as_str(), "nuc" | "iaa");
+        let supports_htlc = matches!(self.protocol_info.account_prefix.as_str(), "nuc" | "iaa");
 
         if supports_htlc {
             return Ok(());
@@ -3404,14 +3427,18 @@ impl MmCoin for TendermintCoin {
             .map_err(|e| OrderCreationPreCheckError::InternalError { reason: e.to_string() })?
             .spendable;
 
-        // TODO: Take this value from the coins file.
-        let min = BigDecimal::from(2);
+        let min_balance_for_ibc_routing = htlc_coin
+            .protocol_info
+            .min_balance_for_ibc_routing
+            .unwrap_or(DEFAULT_MIN_BALANCE_FOR_IBC_ROUTING);
+        let min_balance_for_ibc_routing = BigDecimal::from_str(&format!("{min_balance_for_ibc_routing}"))
+            .map_err(|e| OrderCreationPreCheckError::InternalError { reason: e.to_string() })?;
 
-        if min > my_balance {
+        if min_balance_for_ibc_routing > my_balance {
             let htlc_ticker = htlc_coin.ticker();
             let self_ticker = self.ticker();
             let reason = format!(
-                "Insufficient balance on HTLC coin ({htlc_ticker}) for making orders with {self_ticker}. Minimum required expected balance {min}, current balance {my_balance}.",
+                "Insufficient balance on HTLC coin ({htlc_ticker}) for making orders with {self_ticker}. Minimum required expected balance {min_balance_for_ibc_routing}, current balance {my_balance}.",
             );
             return MmError::err(OrderCreationPreCheckError::PreCheckFailed { reason });
         }
@@ -3426,8 +3453,8 @@ impl MmCoin for TendermintCoin {
             // Since create and claim htlc fees are almost same, we can simply simulate create htlc tx.
             coin.get_sender_trade_fee_for_denom(
                 coin.ticker.clone(),
-                coin.denom.clone(),
-                coin.decimals,
+                coin.protocol_info.denom.clone(),
+                coin.decimals(),
                 coin.min_tx_amount(),
             )
             .await
@@ -3440,8 +3467,13 @@ impl MmCoin for TendermintCoin {
         dex_fee_amount: DexFee,
         _stage: FeeApproxStage,
     ) -> TradePreimageResult<TradeFee> {
-        self.get_fee_to_send_taker_fee_for_denom(self.ticker.clone(), self.denom.clone(), self.decimals, dex_fee_amount)
-            .await
+        self.get_fee_to_send_taker_fee_for_denom(
+            self.ticker.clone(),
+            self.protocol_info.denom.clone(),
+            self.protocol_info.decimals,
+            dex_fee_amount,
+        )
+        .await
     }
 
     fn required_confirmations(&self) -> u64 { 0 }
@@ -3484,7 +3516,7 @@ impl MarketCoinOps for TendermintCoin {
     fn my_address(&self) -> MmResult<String, MyAddressError> { Ok(self.account_id.to_string()) }
 
     fn address_from_pubkey(&self, pubkey: &H264Json) -> MmResult<String, AddressFromPubkeyError> {
-        let address = account_id_from_raw_pubkey(&self.account_prefix, &pubkey.0)
+        let address = account_id_from_raw_pubkey(&self.protocol_info.account_prefix, &pubkey.0)
             .map_err(|e| AddressFromPubkeyError::InternalError(e.to_string()))?;
         Ok(address.to_string())
     }
@@ -3514,10 +3546,10 @@ impl MarketCoinOps for TendermintCoin {
         let coin = self.clone();
         let fut = async move {
             let balance_denom = coin
-                .account_balance_for_denom(&coin.account_id, coin.denom.to_string())
+                .account_balance_for_denom(&coin.account_id, coin.protocol_info.denom.to_string())
                 .await?;
             Ok(CoinBalance {
-                spendable: big_decimal_from_sat_unsigned(balance_denom, coin.decimals),
+                spendable: big_decimal_from_sat_unsigned(balance_denom, coin.decimals()),
                 unspendable: BigDecimal::default(),
             })
         };
@@ -3616,7 +3648,7 @@ impl MarketCoinOps for TendermintCoin {
         let tx = try_tx_s!(cosmrs::Tx::from_bytes(args.tx_bytes));
         let first_message = try_tx_s!(tx.body.messages.first().ok_or("Tx body couldn't be read."));
         let htlc_proto = try_tx_s!(CreateHtlcProto::decode(
-            try_tx_s!(HtlcType::from_str(&self.account_prefix)),
+            try_tx_s!(HtlcType::from_str(&self.protocol_info.account_prefix)),
             first_message.value.as_slice()
         ));
         let htlc = try_tx_s!(CreateHtlcMsg::try_from(htlc_proto));
@@ -3675,7 +3707,7 @@ impl MarketCoinOps for TendermintCoin {
     }
 
     #[inline]
-    fn min_tx_amount(&self) -> BigDecimal { big_decimal_from_sat(MIN_TX_SATOSHIS, self.decimals) }
+    fn min_tx_amount(&self) -> BigDecimal { big_decimal_from_sat(MIN_TX_SATOSHIS, self.protocol_info.decimals) }
 
     #[inline]
     fn min_trading_vol(&self) -> MmNumber { self.min_tx_amount().into() }
@@ -3695,9 +3727,15 @@ impl MarketCoinOps for TendermintCoin {
 #[allow(unused_variables)]
 impl SwapOps for TendermintCoin {
     async fn send_taker_fee(&self, dex_fee: DexFee, uuid: &[u8], expire_at: u64) -> TransactionResult {
-        self.send_taker_fee_for_denom(&dex_fee, self.denom.clone(), self.decimals, uuid, expire_at)
-            .compat()
-            .await
+        self.send_taker_fee_for_denom(
+            &dex_fee,
+            self.protocol_info.denom.clone(),
+            self.protocol_info.decimals,
+            uuid,
+            expire_at,
+        )
+        .compat()
+        .await
     }
 
     async fn send_maker_payment(&self, maker_payment_args: SendPaymentArgs<'_>) -> TransactionResult {
@@ -3706,8 +3744,8 @@ impl SwapOps for TendermintCoin {
             maker_payment_args.other_pubkey,
             maker_payment_args.secret_hash,
             maker_payment_args.amount,
-            self.denom.clone(),
-            self.decimals,
+            self.protocol_info.denom.clone(),
+            self.protocol_info.decimals,
         )
         .compat()
         .await
@@ -3719,8 +3757,8 @@ impl SwapOps for TendermintCoin {
             taker_payment_args.other_pubkey,
             taker_payment_args.secret_hash,
             taker_payment_args.amount,
-            self.denom.clone(),
-            self.decimals,
+            self.protocol_info.denom.clone(),
+            self.protocol_info.decimals,
         )
         .compat()
         .await
@@ -3739,7 +3777,7 @@ impl SwapOps for TendermintCoin {
         let msg = try_tx_s!(tx.body.messages.first().ok_or("Tx body couldn't be read."));
 
         let htlc_proto = try_tx_s!(CreateHtlcProto::decode(
-            try_tx_s!(HtlcType::from_str(&self.account_prefix)),
+            try_tx_s!(HtlcType::from_str(&self.protocol_info.account_prefix)),
             msg.value.as_slice()
         ));
         let htlc = try_tx_s!(CreateHtlcMsg::try_from(htlc_proto));
@@ -3795,7 +3833,7 @@ impl SwapOps for TendermintCoin {
         let msg = try_tx_s!(tx.body.messages.first().ok_or("Tx body couldn't be read."));
 
         let htlc_proto = try_tx_s!(CreateHtlcProto::decode(
-            try_tx_s!(HtlcType::from_str(&self.account_prefix)),
+            try_tx_s!(HtlcType::from_str(&self.protocol_info.account_prefix)),
             msg.value.as_slice()
         ));
         let htlc = try_tx_s!(CreateHtlcMsg::try_from(htlc_proto));
@@ -3860,21 +3898,21 @@ impl SwapOps for TendermintCoin {
             validate_fee_args.fee_tx,
             validate_fee_args.expected_sender,
             validate_fee_args.dex_fee,
-            self.decimals,
+            self.protocol_info.decimals,
             validate_fee_args.uuid,
-            self.denom.to_string(),
+            self.protocol_info.denom.to_string(),
         )
         .compat()
         .await
     }
 
     async fn validate_maker_payment(&self, input: ValidatePaymentInput) -> ValidatePaymentResult<()> {
-        self.validate_payment_for_denom(input, self.denom.clone(), self.decimals)
+        self.validate_payment_for_denom(input, self.protocol_info.denom.clone(), self.protocol_info.decimals)
             .await
     }
 
     async fn validate_taker_payment(&self, input: ValidatePaymentInput) -> ValidatePaymentResult<()> {
-        self.validate_payment_for_denom(input, self.denom.clone(), self.decimals)
+        self.validate_payment_for_denom(input, self.protocol_info.denom.clone(), self.protocol_info.decimals)
             .await
     }
 
@@ -3883,8 +3921,8 @@ impl SwapOps for TendermintCoin {
         if_my_payment_sent_args: CheckIfMyPaymentSentArgs<'_>,
     ) -> Result<Option<TransactionEnum>, String> {
         self.check_if_my_payment_sent_for_denom(
-            self.decimals,
-            self.denom.clone(),
+            self.protocol_info.decimals,
+            self.protocol_info.denom.clone(),
             if_my_payment_sent_args.other_pub,
             if_my_payment_sent_args.secret_hash,
             if_my_payment_sent_args.amount,
@@ -3917,7 +3955,7 @@ impl SwapOps for TendermintCoin {
         let msg = try_s!(tx.body.messages.first().ok_or("Tx body couldn't be read."));
 
         let htlc_proto = try_s!(ClaimHtlcProto::decode(
-            try_s!(HtlcType::from_str(&self.account_prefix)),
+            try_s!(HtlcType::from_str(&self.protocol_info.account_prefix)),
             msg.value.as_slice()
         ));
         let htlc = try_s!(ClaimHtlcMsg::try_from(htlc_proto));
@@ -4123,9 +4161,10 @@ pub mod tendermint_coin_tests {
     fn get_iris_usdc_ibc_protocol() -> TendermintProtocolInfo {
         TendermintProtocolInfo {
             decimals: 6,
-            denom: String::from("ibc/5C465997B4F582F602CD64E12031C6A6E18CAF1E6EDC9B5D808822DC0B5F850C"),
+            denom: Denom::from_str("ibc/5C465997B4F582F602CD64E12031C6A6E18CAF1E6EDC9B5D808822DC0B5F850C").unwrap(),
+            min_balance_for_ibc_routing: None,
             account_prefix: String::from("iaa"),
-            chain_id: String::from("nyancat-9"),
+            chain_id: ChainId::from_str("nyancat-9").unwrap(),
             gas_price: None,
             ibc_channels: HashMap::new(),
         }
@@ -4137,9 +4176,10 @@ pub mod tendermint_coin_tests {
 
         TendermintProtocolInfo {
             decimals: 6,
-            denom: String::from("unyan"),
+            denom: Denom::from_str("unyan").unwrap(),
+            min_balance_for_ibc_routing: None,
             account_prefix: String::from("iaa"),
-            chain_id: String::from("nyancat-9"),
+            chain_id: ChainId::from_str("nyancat-9").unwrap(),
             gas_price: None,
             ibc_channels,
         }
@@ -4148,9 +4188,10 @@ pub mod tendermint_coin_tests {
     fn get_iris_ibc_nucleus_protocol() -> TendermintProtocolInfo {
         TendermintProtocolInfo {
             decimals: 6,
-            denom: String::from("ibc/F7F28FF3C09024A0225EDBBDB207E5872D2B4EF2FB874FE47B05EF9C9A7D211C"),
+            denom: Denom::from_str("ibc/F7F28FF3C09024A0225EDBBDB207E5872D2B4EF2FB874FE47B05EF9C9A7D211C").unwrap(),
+            min_balance_for_ibc_routing: None,
             account_prefix: String::from("nuc"),
-            chain_id: String::from("nucleus-testnet"),
+            chain_id: ChainId::from_str("nucleus-testnet").unwrap(),
             gas_price: None,
             ibc_channels: HashMap::new(),
         }
@@ -4208,7 +4249,7 @@ pub mod tendermint_coin_tests {
         // << BEGIN HTLC CREATION
         let to: AccountId = IRIS_TESTNET_HTLC_PAIR2_ADDRESS.parse().unwrap();
         let amount = 1;
-        let amount_dec = big_decimal_from_sat_unsigned(amount, coin.decimals);
+        let amount_dec = big_decimal_from_sat_unsigned(amount, coin.decimals());
 
         let mut sec = [0u8; 32];
         common::os_rng(&mut sec).unwrap();
@@ -4218,7 +4259,7 @@ pub mod tendermint_coin_tests {
 
         let create_htlc_tx = coin
             .gen_create_htlc_tx(
-                coin.denom.clone(),
+                coin.protocol_info.denom.clone(),
                 &to,
                 amount.into(),
                 sha256(&sec).as_slice(),

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -3593,7 +3593,7 @@ impl MmCoin for TendermintCoin {
             .protocol_info
             .min_balance_for_ibc_routing
             .unwrap_or(DEFAULT_MIN_BALANCE_FOR_IBC_ROUTING);
-        let min_balance_for_ibc_routing = BigDecimal::from_str(&format!("{min_balance_for_ibc_routing}"))
+        let min_balance_for_ibc_routing = BigDecimal::try_from(min_balance_for_ibc_routing)
             .map_err(|e| OrderCreationPreCheckError::InternalError { reason: e.to_string() })?;
 
         if min_balance_for_ibc_routing > my_balance {

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -105,7 +105,8 @@ const ABCI_DELEGATOR_UNDELEGATIONS_PATH: &str = "/cosmos.staking.v1beta1.Query/D
 const ABCI_DELEGATION_REWARDS_PATH: &str = "/cosmos.distribution.v1beta1.Query/DelegationRewards";
 const ABCI_IBC_CHANNEL_QUERY_PATH: &str = "/ibc.core.channel.v1.Query/Channel";
 
-pub(crate) const DEFAULT_MIN_BALANCE_FOR_IBC_ROUTING: f32 = 2.0;
+#[cfg(feature = "ibc-routing-for-swaps")]
+const DEFAULT_MIN_BALANCE_FOR_IBC_ROUTING: f32 = 2.0;
 
 pub(crate) const MIN_TX_SATOSHIS: i64 = 1;
 
@@ -3355,7 +3356,7 @@ impl MmCoin for TendermintCoin {
 
     /// Overrides the default `pre_check_for_order_creation` implementation with
     /// additional IBC-related logic on top of the default behavior.
-    // #[cfg(feature = "ibc-routing-for-swaps")]
+    #[cfg(feature = "ibc-routing-for-swaps")]
     async fn pre_check_for_order_creation(
         &self,
         ctx: &MmArc,

--- a/mm2src/coins/tendermint/tendermint_token.rs
+++ b/mm2src/coins/tendermint/tendermint_token.rs
@@ -376,14 +376,15 @@ impl MmCoin for TendermintToken {
             let to_address =
                 AccountId::from_str(&req.to).map_to_mm(|e| WithdrawError::InvalidAddress(e.to_string()))?;
 
-            let is_ibc_transfer = to_address.prefix() != platform.account_prefix || req.ibc_source_channel.is_some();
+            let is_ibc_transfer =
+                to_address.prefix() != platform.protocol_info.account_prefix || req.ibc_source_channel.is_some();
 
             let (account_id, maybe_priv_key) = platform
                 .extract_account_id_and_private_key(req.from)
                 .map_err(|e| WithdrawError::InternalError(e.to_string()))?;
 
             let (base_denom_balance, base_denom_balance_dec) = platform
-                .get_balance_as_unsigned_and_decimal(&account_id, &platform.denom, token.decimals())
+                .get_balance_as_unsigned_and_decimal(&account_id, &platform.protocol_info.denom, token.decimals())
                 .await?;
 
             let (balance_denom, balance_dec) = platform
@@ -484,7 +485,7 @@ impl MmCoin for TendermintToken {
             }
 
             let fee_amount = Coin {
-                denom: platform.denom.clone(),
+                denom: platform.protocol_info.denom.clone(),
                 amount: fee_amount_u64.into(),
             };
 

--- a/mm2src/coins/tendermint/tendermint_token.rs
+++ b/mm2src/coins/tendermint/tendermint_token.rs
@@ -59,7 +59,7 @@ impl Deref for TendermintToken {
 pub struct TendermintTokenProtocolInfo {
     pub platform: String,
     pub decimals: u8,
-    pub denom: String,
+    pub denom: Denom,
 }
 
 #[derive(Clone, Deserialize)]
@@ -67,7 +67,6 @@ pub struct TendermintTokenActivationParams {}
 
 pub enum TendermintTokenInitError {
     Internal(String),
-    InvalidDenom(String),
     MyAddressError(String),
     CouldNotFetchBalance(String),
 }
@@ -85,9 +84,8 @@ impl TendermintToken {
         ticker: String,
         platform_coin: TendermintCoin,
         decimals: u8,
-        denom: String,
+        denom: Denom,
     ) -> MmResult<Self, TendermintTokenInitError> {
-        let denom = Denom::from_str(&denom).map_to_mm(|e| TendermintTokenInitError::InvalidDenom(e.to_string()))?;
         let token_impl = TendermintTokenImpl {
             abortable_system: platform_coin.abortable_system.create_subsystem()?,
             ticker,

--- a/mm2src/coins/tendermint/tendermint_token.rs
+++ b/mm2src/coins/tendermint/tendermint_token.rs
@@ -429,7 +429,7 @@ impl MmCoin for TendermintToken {
                     Some(_) => req.ibc_source_channel,
                     None => Some(
                         platform
-                            .get_healthy_ibc_channel_for_address(to_address.prefix())
+                            .get_healthy_ibc_channel_for_address_prefix(to_address.prefix())
                             .await?,
                     ),
                 }

--- a/mm2src/coins_activation/src/tendermint_token_activation.rs
+++ b/mm2src/coins_activation/src/tendermint_token_activation.rs
@@ -13,7 +13,6 @@ use std::collections::HashMap;
 impl From<TendermintTokenInitError> for EnableTokenError {
     fn from(err: TendermintTokenInitError) -> Self {
         match err {
-            TendermintTokenInitError::InvalidDenom(e) => EnableTokenError::InvalidConfig(e),
             TendermintTokenInitError::MyAddressError(e) | TendermintTokenInitError::Internal(e) => {
                 EnableTokenError::Internal(e)
             },

--- a/mm2src/coins_activation/src/tendermint_with_assets_activation.rs
+++ b/mm2src/coins_activation/src/tendermint_with_assets_activation.rs
@@ -112,10 +112,7 @@ struct TendermintTokenInitializer {
     platform_coin: TendermintCoin,
 }
 
-struct TendermintTokenInitializerErr {
-    ticker: String,
-    inner: TendermintTokenInitError,
-}
+struct TendermintTokenInitializerErr(TendermintTokenInitError);
 
 #[async_trait]
 impl TokenInitializer for TendermintTokenInitializer {
@@ -137,14 +134,13 @@ impl TokenInitializer for TendermintTokenInitializer {
         params
             .into_iter()
             .map(|param| {
-                let ticker = param.ticker.clone();
                 TendermintToken::new(
                     param.ticker,
                     self.platform_coin.clone(),
                     param.protocol.decimals,
                     param.protocol.denom,
                 )
-                .mm_err(|inner| TendermintTokenInitializerErr { ticker, inner })
+                .mm_err(TendermintTokenInitializerErr)
             })
             .collect()
     }
@@ -172,11 +168,7 @@ impl TryFromCoinProtocol for TendermintTokenProtocolInfo {
 
 impl From<TendermintTokenInitializerErr> for InitTokensAsMmCoinsError {
     fn from(err: TendermintTokenInitializerErr) -> Self {
-        match err.inner {
-            TendermintTokenInitError::InvalidDenom(error) => InitTokensAsMmCoinsError::TokenProtocolParseError {
-                ticker: err.ticker,
-                error,
-            },
+        match err.0 {
             TendermintTokenInitError::MyAddressError(error) | TendermintTokenInitError::Internal(error) => {
                 InitTokensAsMmCoinsError::Internal(error)
             },

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -1744,6 +1744,8 @@ pub struct MakerOrder {
     /// A custom priv key for more privacy to prevent linking orders of the same node between each other
     /// Commonly used with privacy coins (ARRR, ZCash, etc.)
     p2p_privkey: Option<SerializableSecp256k1Keypair>,
+    /// TODO: Move this into the `OrderMetadata` type when we are doing BC
+    /// on orders already.
     #[serde(default, skip_serializing_if = "SwapVersion::is_legacy")]
     pub swap_version: SwapVersion,
     #[cfg(feature = "ibc-routing-for-swaps")]
@@ -1760,8 +1762,6 @@ pub struct MakerOrderBuilder<'a> {
     rel_orderbook_ticker: Option<String>,
     conf_settings: Option<OrderConfirmationsSettings>,
     save_in_history: bool,
-    /// TODO: Move this into the `OrderMetadata` type when we are doing BC
-    /// on orders already.
     swap_version: u8,
     #[cfg(feature = "ibc-routing-for-swaps")]
     order_metadata: OrderMetadata,

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -4247,6 +4247,10 @@ pub async fn lp_auto_buy(
         rel_confs: input.rel_confs.unwrap_or_else(|| rel_coin.required_confirmations()),
         rel_nota: input.rel_nota.unwrap_or_else(|| rel_coin.requires_notarization()),
     };
+
+    // TODO: For non-HTLC tendermint swap orders, include the channel information which
+    // will be used on the maker side.
+
     let mut order_builder = TakerOrderBuilder::new(base_coin, rel_coin)
         .with_base_amount(input.volume)
         .with_rel_amount(rel_volume)
@@ -4996,7 +5000,7 @@ pub async fn create_maker_order(ctx: &MmArc, req: SetPriceReq) -> Result<MakerOr
         rel_nota: req.rel_nota.unwrap_or_else(|| rel_coin.requires_notarization()),
     };
 
-    // TODO: For non-HTLC tendermint swap orders, include the channel informations which
+    // TODO: For non-HTLC tendermint swap orders, include the channel information which
     // will be used on the taker side.
 
     let mut builder = MakerOrderBuilder::new(&base_coin, &rel_coin)

--- a/mm2src/mm2_main/src/lp_ordermatch/my_orders_storage.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch/my_orders_storage.rs
@@ -726,6 +726,7 @@ mod tests {
             rel_orderbook_ticker: None,
             p2p_privkey: None,
             swap_version: SwapVersion::default(),
+            #[cfg(feature = "ibc-routing-for-swaps")]
             order_metadata: crate::lp_ordermatch::OrderMetadata::default(),
         }
     }
@@ -756,6 +757,7 @@ mod tests {
             base_orderbook_ticker: None,
             rel_orderbook_ticker: None,
             p2p_privkey: None,
+            #[cfg(feature = "ibc-routing-for-swaps")]
             order_metadata: crate::lp_ordermatch::OrderMetadata::default(),
         }
     }

--- a/mm2src/mm2_main/src/lp_ordermatch/my_orders_storage.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch/my_orders_storage.rs
@@ -726,6 +726,7 @@ mod tests {
             rel_orderbook_ticker: None,
             p2p_privkey: None,
             swap_version: SwapVersion::default(),
+            order_metadata: crate::lp_ordermatch::OrderMetadata::default(),
         }
     }
 
@@ -755,6 +756,7 @@ mod tests {
             base_orderbook_ticker: None,
             rel_orderbook_ticker: None,
             p2p_privkey: None,
+            order_metadata: crate::lp_ordermatch::OrderMetadata::default(),
         }
     }
 

--- a/mm2src/mm2_main/src/lp_swap/maker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap.rs
@@ -2356,9 +2356,6 @@ pub async fn maker_swap_trade_preimage(
         rel_nota: rel_coin.requires_notarization(),
     };
 
-    // TODO: For non-HTLC tendermint swap orders, include the channel information which
-    // will be used on the taker side.
-
     let builder = MakerOrderBuilder::new(&base_coin, &rel_coin)
         .with_max_base_vol(volume.clone())
         .with_price(req.price)

--- a/mm2src/mm2_main/src/lp_swap/maker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap.rs
@@ -2355,6 +2355,10 @@ pub async fn maker_swap_trade_preimage(
         rel_confs: rel_coin.required_confirmations(),
         rel_nota: rel_coin.requires_notarization(),
     };
+
+    // TODO: For non-HTLC tendermint swap orders, include the channel information which
+    // will be used on the taker side.
+
     let builder = MakerOrderBuilder::new(&base_coin, &rel_coin)
         .with_max_base_vol(volume.clone())
         .with_price(req.price)

--- a/mm2src/mm2_main/src/lp_swap/recreate_swap_data.rs
+++ b/mm2src/mm2_main/src/lp_swap/recreate_swap_data.rs
@@ -122,6 +122,7 @@ async fn recreate_maker_swap(ctx: MmArc, taker_swap: TakerSavedSwap) -> Recreate
 
     let mut taker_p2p_pubkey = [0; 32];
     taker_p2p_pubkey.copy_from_slice(&started_event.my_persistent_pub.0[1..33]);
+
     let maker_started_event = MakerSwapEvent::Started(MakerSwapData {
         taker_coin: started_event.taker_coin,
         maker_coin: started_event.maker_coin.clone(),

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -2659,9 +2659,6 @@ pub async fn taker_swap_trade_preimage(
     };
     let our_public_id = CryptoCtx::from_ctx(ctx)?.mm2_internal_public_id();
 
-    // TODO: For non-HTLC tendermint swap orders, include the channel information which
-    // will be used on the maker side.
-
     let order_builder = TakerOrderBuilder::new(&base_coin, &rel_coin)
         .with_base_amount(base_amount)
         .with_rel_amount(rel_amount)
@@ -2669,6 +2666,8 @@ pub async fn taker_swap_trade_preimage(
         .with_match_by(MatchBy::Any)
         .with_conf_settings(conf_settings)
         .with_sender_pubkey(H256Json::from(our_public_id.bytes));
+
+    // perform an additional validation
     let _ = order_builder
         .build()
         .map_to_mm(|e| TradePreimageRpcError::from_taker_order_build_error(e, &req.base, &req.rel))?;

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -2658,6 +2658,10 @@ pub async fn taker_swap_trade_preimage(
         rel_nota: rel_coin.requires_notarization(),
     };
     let our_public_id = CryptoCtx::from_ctx(ctx)?.mm2_internal_public_id();
+
+    // TODO: For non-HTLC tendermint swap orders, include the channel information which
+    // will be used on the maker side.
+
     let order_builder = TakerOrderBuilder::new(&base_coin, &rel_coin)
         .with_base_amount(base_amount)
         .with_rel_amount(rel_amount)

--- a/mm2src/mm2_main/src/ordermatch_tests.rs
+++ b/mm2src/mm2_main/src/ordermatch_tests.rs
@@ -40,6 +40,7 @@ fn test_match_maker_order_and_taker_request() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     let request = TakerRequest {
@@ -80,6 +81,7 @@ fn test_match_maker_order_and_taker_request() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     let request = TakerRequest {
@@ -120,6 +122,7 @@ fn test_match_maker_order_and_taker_request() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     let request = TakerRequest {
@@ -160,6 +163,7 @@ fn test_match_maker_order_and_taker_request() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     let request = TakerRequest {
@@ -200,6 +204,7 @@ fn test_match_maker_order_and_taker_request() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     let request = TakerRequest {
@@ -240,6 +245,7 @@ fn test_match_maker_order_and_taker_request() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     let request = TakerRequest {
@@ -282,6 +288,7 @@ fn test_match_maker_order_and_taker_request() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
     let request = TakerRequest {
         base: "KMD".to_owned(),
@@ -324,6 +331,7 @@ fn test_match_maker_order_and_taker_request() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
     let request = TakerRequest {
         base: "REL".to_owned(),
@@ -397,6 +405,7 @@ fn test_maker_order_available_amount() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
     maker.matches.insert(new_uuid(), MakerMatch {
         request: TakerRequest {
@@ -503,6 +512,7 @@ fn test_taker_match_reserved() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        order_metadata: OrderMetadata::default(),
     };
 
     let reserved = MakerReserved {
@@ -549,6 +559,7 @@ fn test_taker_match_reserved() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        order_metadata: OrderMetadata::default(),
     };
 
     let reserved = MakerReserved {
@@ -595,6 +606,7 @@ fn test_taker_match_reserved() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        order_metadata: OrderMetadata::default(),
     };
 
     let reserved = MakerReserved {
@@ -641,6 +653,7 @@ fn test_taker_match_reserved() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        order_metadata: OrderMetadata::default(),
     };
 
     let reserved = MakerReserved {
@@ -687,6 +700,7 @@ fn test_taker_match_reserved() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        order_metadata: OrderMetadata::default(),
     };
 
     let reserved = MakerReserved {
@@ -733,6 +747,7 @@ fn test_taker_match_reserved() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        order_metadata: OrderMetadata::default(),
     };
 
     let reserved = MakerReserved {
@@ -779,6 +794,7 @@ fn test_taker_match_reserved() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        order_metadata: OrderMetadata::default(),
     };
 
     let reserved = MakerReserved {
@@ -825,6 +841,7 @@ fn test_taker_match_reserved() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        order_metadata: OrderMetadata::default(),
     };
 
     let reserved = MakerReserved {
@@ -871,6 +888,7 @@ fn test_taker_match_reserved() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        order_metadata: OrderMetadata::default(),
     };
 
     let reserved = MakerReserved {
@@ -920,6 +938,7 @@ fn test_taker_order_cancellable() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        order_metadata: OrderMetadata::default(),
     };
 
     assert!(order.is_cancellable());
@@ -951,6 +970,7 @@ fn test_taker_order_cancellable() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        order_metadata: OrderMetadata::default(),
     };
 
     order.matches.insert(new_uuid(), TakerMatch {
@@ -1017,6 +1037,7 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
             rel_orderbook_ticker: None,
             p2p_privkey: None,
             swap_version: SwapVersion::default(),
+            order_metadata: OrderMetadata::default(),
         },
         None,
     );
@@ -1040,6 +1061,7 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
             rel_orderbook_ticker: None,
             p2p_privkey: None,
             swap_version: SwapVersion::default(),
+            order_metadata: OrderMetadata::default(),
         },
         None,
     );
@@ -1063,6 +1085,7 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
             rel_orderbook_ticker: None,
             p2p_privkey: None,
             swap_version: SwapVersion::default(),
+            order_metadata: OrderMetadata::default(),
         },
         None,
     );
@@ -1091,6 +1114,7 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        order_metadata: OrderMetadata::default(),
     });
     rx
 }
@@ -1199,6 +1223,7 @@ fn test_taker_order_match_by() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
+        order_metadata: OrderMetadata::default(),
     };
 
     let reserved = MakerReserved {
@@ -1255,6 +1280,7 @@ fn test_maker_order_was_updated() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
     let mut update_msg = MakerOrderUpdated::new(maker_order.uuid);
     update_msg.with_new_price(BigRational::from_integer(2.into()));
@@ -3265,6 +3291,7 @@ fn test_maker_order_balance_loops() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     let morty_order = MakerOrder {
@@ -3285,6 +3312,7 @@ fn test_maker_order_balance_loops() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     assert!(!maker_orders_ctx.balance_loop_exists(rick_ticker));
@@ -3318,6 +3346,7 @@ fn test_maker_order_balance_loops() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     maker_orders_ctx.add_order(ctx.weak(), rick_order_2.clone(), None);

--- a/mm2src/mm2_main/src/ordermatch_tests.rs
+++ b/mm2src/mm2_main/src/ordermatch_tests.rs
@@ -40,6 +40,7 @@ fn test_match_maker_order_and_taker_request() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -57,6 +58,7 @@ fn test_match_maker_order_and_taker_request() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -82,6 +84,7 @@ fn test_match_maker_order_and_taker_request() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -99,6 +102,7 @@ fn test_match_maker_order_and_taker_request() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -124,6 +128,7 @@ fn test_match_maker_order_and_taker_request() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -141,6 +146,7 @@ fn test_match_maker_order_and_taker_request() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -166,6 +172,7 @@ fn test_match_maker_order_and_taker_request() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -183,6 +190,7 @@ fn test_match_maker_order_and_taker_request() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -208,6 +216,7 @@ fn test_match_maker_order_and_taker_request() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -225,6 +234,7 @@ fn test_match_maker_order_and_taker_request() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -250,6 +260,7 @@ fn test_match_maker_order_and_taker_request() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -267,6 +278,7 @@ fn test_match_maker_order_and_taker_request() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -294,6 +306,7 @@ fn test_match_maker_order_and_taker_request() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
     let request = TakerRequest {
@@ -310,6 +323,7 @@ fn test_match_maker_order_and_taker_request() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
     let actual = maker.match_with_request(&request);
@@ -338,6 +352,7 @@ fn test_match_maker_order_and_taker_request() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
     let request = TakerRequest {
@@ -354,6 +369,7 @@ fn test_match_maker_order_and_taker_request() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
     let actual = maker.match_with_request(&request);
@@ -413,6 +429,7 @@ fn test_maker_order_available_amount() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
     maker.matches.insert(new_uuid(), MakerMatch {
@@ -430,6 +447,7 @@ fn test_maker_order_available_amount() {
             base_protocol_info: None,
             rel_protocol_info: None,
             swap_version: SwapVersion::default(),
+            #[cfg(feature = "ibc-routing-for-swaps")]
             order_metadata: OrderMetadata::default(),
         },
         reserved: MakerReserved {
@@ -445,6 +463,7 @@ fn test_maker_order_available_amount() {
             base_protocol_info: None,
             rel_protocol_info: None,
             swap_version: SwapVersion::default(),
+            #[cfg(feature = "ibc-routing-for-swaps")]
             order_metadata: OrderMetadata::default(),
         },
         connect: None,
@@ -466,6 +485,7 @@ fn test_maker_order_available_amount() {
             base_protocol_info: None,
             rel_protocol_info: None,
             swap_version: SwapVersion::default(),
+            #[cfg(feature = "ibc-routing-for-swaps")]
             order_metadata: OrderMetadata::default(),
         },
         reserved: MakerReserved {
@@ -481,6 +501,7 @@ fn test_maker_order_available_amount() {
             base_protocol_info: None,
             rel_protocol_info: None,
             swap_version: SwapVersion::default(),
+            #[cfg(feature = "ibc-routing-for-swaps")]
             order_metadata: OrderMetadata::default(),
         },
         connect: None,
@@ -511,6 +532,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -540,6 +562,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -559,6 +582,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -588,6 +612,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -607,6 +632,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -636,6 +662,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -655,6 +682,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -684,6 +712,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -703,6 +732,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -732,6 +762,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -751,6 +782,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -780,6 +812,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -799,6 +832,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -828,6 +862,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -847,6 +882,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -876,6 +912,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -899,6 +936,7 @@ fn test_taker_match_reserved() {
             base_protocol_info: None,
             rel_protocol_info: None,
             swap_version: SwapVersion::default(),
+            #[cfg(feature = "ibc-routing-for-swaps")]
             order_metadata: OrderMetadata::default(),
         },
         matches: HashMap::new(),
@@ -923,7 +961,9 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: SwapVersion::default(),order_metadata: OrderMetadata::default(),
+        swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
+        order_metadata: OrderMetadata::default(),
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -945,6 +985,7 @@ fn test_taker_order_cancellable() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -977,6 +1018,7 @@ fn test_taker_order_cancellable() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -1008,6 +1050,7 @@ fn test_taker_order_cancellable() {
             base_protocol_info: None,
             rel_protocol_info: None,
             swap_version: SwapVersion::default(),
+            #[cfg(feature = "ibc-routing-for-swaps")]
             order_metadata: OrderMetadata::default(),
         },
         connect: TakerConnect {
@@ -1058,6 +1101,7 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
             rel_orderbook_ticker: None,
             p2p_privkey: None,
             swap_version: SwapVersion::default(),
+            #[cfg(feature = "ibc-routing-for-swaps")]
             order_metadata: OrderMetadata::default(),
         },
         None,
@@ -1082,6 +1126,7 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
             rel_orderbook_ticker: None,
             p2p_privkey: None,
             swap_version: SwapVersion::default(),
+            #[cfg(feature = "ibc-routing-for-swaps")]
             order_metadata: OrderMetadata::default(),
         },
         None,
@@ -1106,6 +1151,7 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
             rel_orderbook_ticker: None,
             p2p_privkey: None,
             swap_version: SwapVersion::default(),
+            #[cfg(feature = "ibc-routing-for-swaps")]
             order_metadata: OrderMetadata::default(),
         },
         None,
@@ -1127,6 +1173,7 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
             base_protocol_info: None,
             rel_protocol_info: None,
             swap_version: SwapVersion::default(),
+            #[cfg(feature = "ibc-routing-for-swaps")]
             order_metadata: OrderMetadata::default(),
         },
         order_type: OrderType::GoodTillCancelled,
@@ -1231,6 +1278,7 @@ fn test_taker_order_match_by() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -1260,6 +1308,7 @@ fn test_taker_order_match_by() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -1302,6 +1351,7 @@ fn test_maker_order_was_updated() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
     let mut update_msg = MakerOrderUpdated::new(maker_order.uuid);
@@ -3313,6 +3363,7 @@ fn test_maker_order_balance_loops() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -3334,6 +3385,7 @@ fn test_maker_order_balance_loops() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 
@@ -3368,6 +3420,7 @@ fn test_maker_order_balance_loops() {
         rel_orderbook_ticker: None,
         p2p_privkey: None,
         swap_version: SwapVersion::default(),
+        #[cfg(feature = "ibc-routing-for-swaps")]
         order_metadata: OrderMetadata::default(),
     };
 

--- a/mm2src/mm2_main/src/ordermatch_tests.rs
+++ b/mm2src/mm2_main/src/ordermatch_tests.rs
@@ -57,6 +57,7 @@ fn test_match_maker_order_and_taker_request() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     let actual = maker.match_with_request(&request);
@@ -98,6 +99,7 @@ fn test_match_maker_order_and_taker_request() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     let actual = maker.match_with_request(&request);
@@ -139,6 +141,7 @@ fn test_match_maker_order_and_taker_request() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     let actual = maker.match_with_request(&request);
@@ -180,6 +183,7 @@ fn test_match_maker_order_and_taker_request() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     let actual = maker.match_with_request(&request);
@@ -221,6 +225,7 @@ fn test_match_maker_order_and_taker_request() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     let actual = maker.match_with_request(&request);
@@ -262,6 +267,7 @@ fn test_match_maker_order_and_taker_request() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     let actual = maker.match_with_request(&request);
@@ -304,6 +310,7 @@ fn test_match_maker_order_and_taker_request() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
     let actual = maker.match_with_request(&request);
     assert_eq!(actual, OrderMatchResult::NotMatched);
@@ -347,6 +354,7 @@ fn test_match_maker_order_and_taker_request() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
     let actual = maker.match_with_request(&request);
     let expected_base_amount = MmNumber::from(3);
@@ -422,6 +430,7 @@ fn test_maker_order_available_amount() {
             base_protocol_info: None,
             rel_protocol_info: None,
             swap_version: SwapVersion::default(),
+            order_metadata: OrderMetadata::default(),
         },
         reserved: MakerReserved {
             base: "BASE".into(),
@@ -436,6 +445,7 @@ fn test_maker_order_available_amount() {
             base_protocol_info: None,
             rel_protocol_info: None,
             swap_version: SwapVersion::default(),
+            order_metadata: OrderMetadata::default(),
         },
         connect: None,
         connected: None,
@@ -456,6 +466,7 @@ fn test_maker_order_available_amount() {
             base_protocol_info: None,
             rel_protocol_info: None,
             swap_version: SwapVersion::default(),
+            order_metadata: OrderMetadata::default(),
         },
         reserved: MakerReserved {
             base: "BASE".into(),
@@ -470,6 +481,7 @@ fn test_maker_order_available_amount() {
             base_protocol_info: None,
             rel_protocol_info: None,
             swap_version: SwapVersion::default(),
+            order_metadata: OrderMetadata::default(),
         },
         connect: None,
         connected: None,
@@ -499,6 +511,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     let order = TakerOrder {
@@ -512,7 +525,6 @@ fn test_taker_match_reserved() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        order_metadata: OrderMetadata::default(),
     };
 
     let reserved = MakerReserved {
@@ -528,6 +540,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -546,6 +559,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     let order = TakerOrder {
@@ -559,7 +573,6 @@ fn test_taker_match_reserved() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        order_metadata: OrderMetadata::default(),
     };
 
     let reserved = MakerReserved {
@@ -575,6 +588,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -593,6 +607,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     let order = TakerOrder {
@@ -606,7 +621,6 @@ fn test_taker_match_reserved() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        order_metadata: OrderMetadata::default(),
     };
 
     let reserved = MakerReserved {
@@ -622,6 +636,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -640,6 +655,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     let order = TakerOrder {
@@ -653,7 +669,6 @@ fn test_taker_match_reserved() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        order_metadata: OrderMetadata::default(),
     };
 
     let reserved = MakerReserved {
@@ -669,6 +684,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     assert_eq!(MatchReservedResult::NotMatched, order.match_reserved(&reserved));
@@ -687,6 +703,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     let order = TakerOrder {
@@ -700,7 +717,6 @@ fn test_taker_match_reserved() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        order_metadata: OrderMetadata::default(),
     };
 
     let reserved = MakerReserved {
@@ -716,6 +732,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -734,6 +751,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     let order = TakerOrder {
@@ -747,7 +765,6 @@ fn test_taker_match_reserved() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        order_metadata: OrderMetadata::default(),
     };
 
     let reserved = MakerReserved {
@@ -763,6 +780,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -781,6 +799,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     let order = TakerOrder {
@@ -794,7 +813,6 @@ fn test_taker_match_reserved() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        order_metadata: OrderMetadata::default(),
     };
 
     let reserved = MakerReserved {
@@ -810,6 +828,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -828,6 +847,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     let order = TakerOrder {
@@ -841,7 +861,6 @@ fn test_taker_match_reserved() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        order_metadata: OrderMetadata::default(),
     };
 
     let reserved = MakerReserved {
@@ -857,6 +876,7 @@ fn test_taker_match_reserved() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     assert_eq!(MatchReservedResult::NotMatched, order.match_reserved(&reserved));
@@ -879,6 +899,7 @@ fn test_taker_match_reserved() {
             base_protocol_info: None,
             rel_protocol_info: None,
             swap_version: SwapVersion::default(),
+            order_metadata: OrderMetadata::default(),
         },
         matches: HashMap::new(),
         order_type: OrderType::GoodTillCancelled,
@@ -888,7 +909,6 @@ fn test_taker_match_reserved() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        order_metadata: OrderMetadata::default(),
     };
 
     let reserved = MakerReserved {
@@ -903,7 +923,7 @@ fn test_taker_match_reserved() {
         conf_settings: None,
         base_protocol_info: None,
         rel_protocol_info: None,
-        swap_version: SwapVersion::default(),
+        swap_version: SwapVersion::default(),order_metadata: OrderMetadata::default(),
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -925,6 +945,7 @@ fn test_taker_order_cancellable() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     let order = TakerOrder {
@@ -938,7 +959,6 @@ fn test_taker_order_cancellable() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        order_metadata: OrderMetadata::default(),
     };
 
     assert!(order.is_cancellable());
@@ -957,6 +977,7 @@ fn test_taker_order_cancellable() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     let mut order = TakerOrder {
@@ -970,7 +991,6 @@ fn test_taker_order_cancellable() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        order_metadata: OrderMetadata::default(),
     };
 
     order.matches.insert(new_uuid(), TakerMatch {
@@ -988,6 +1008,7 @@ fn test_taker_order_cancellable() {
             base_protocol_info: None,
             rel_protocol_info: None,
             swap_version: SwapVersion::default(),
+            order_metadata: OrderMetadata::default(),
         },
         connect: TakerConnect {
             sender_pubkey: H256Json::default(),
@@ -1106,6 +1127,7 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
             base_protocol_info: None,
             rel_protocol_info: None,
             swap_version: SwapVersion::default(),
+            order_metadata: OrderMetadata::default(),
         },
         order_type: OrderType::GoodTillCancelled,
         min_volume: 0.into(),
@@ -1114,7 +1136,6 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        order_metadata: OrderMetadata::default(),
     });
     rx
 }
@@ -1210,6 +1231,7 @@ fn test_taker_order_match_by() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     let mut order = TakerOrder {
@@ -1223,7 +1245,6 @@ fn test_taker_order_match_by() {
         base_orderbook_ticker: None,
         rel_orderbook_ticker: None,
         p2p_privkey: None,
-        order_metadata: OrderMetadata::default(),
     };
 
     let reserved = MakerReserved {
@@ -1239,6 +1260,7 @@ fn test_taker_order_match_by() {
         base_protocol_info: None,
         rel_protocol_info: None,
         swap_version: SwapVersion::default(),
+        order_metadata: OrderMetadata::default(),
     };
 
     assert_eq!(MatchReservedResult::NotMatched, order.match_reserved(&reserved));

--- a/mm2src/mm2_main/tests/docker_tests/eth_docker_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/eth_docker_tests.rs
@@ -2672,7 +2672,9 @@ fn test_enable_custom_erc20() {
     .unwrap();
     assert!(!buy.0.is_success(), "buy success, but should fail: {}", buy.1);
     assert!(
-        buy.1.contains(&format!("Rel coin {} is wallet only", ticker)),
+        buy.1.contains(&format!(
+            "'{ticker}' is a wallet only asset and can't be used in orders."
+        )),
         "Expected error message indicating that the token is wallet only, but got: {}",
         buy.1
     );

--- a/mm2src/mm2_test_helpers/src/electrums.rs
+++ b/mm2src/mm2_test_helpers/src/electrums.rs
@@ -73,11 +73,7 @@ pub fn tbtc_electrums() -> Vec<Json> {
 }
 
 #[cfg(target_arch = "wasm32")]
-pub fn tqtum_electrums() -> Vec<Json> {
-    vec![
-        json!({ "url": "electrum3.cipig.net:30071", "protocol": "WSS" }),
-    ]
-}
+pub fn tqtum_electrums() -> Vec<Json> { vec![json!({ "url": "electrum3.cipig.net:30071", "protocol": "WSS" })] }
 
 #[cfg(not(target_arch = "wasm32"))]
 pub fn tqtum_electrums() -> Vec<Json> {

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -186,6 +186,8 @@ pub const DOC_ELECTRUM_ADDRS: &[&str] = &[
     "electrum2.cipig.net:10020",
     "electrum3.cipig.net:10020",
 ];
+
+/// NOTE: These are websocket servers.
 #[cfg(target_arch = "wasm32")]
 pub const DOC_ELECTRUM_ADDRS: &[&str] = &[
     "electrum1.cipig.net:30020",


### PR DESCRIPTION
The continuation of [feat(ibc-routing-part-1): supporting entire Cosmos network for swaps #2459](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2459).

The items that are implemented in this part include:

1. Adds a new field `order_metadata`, to the taker and maker order types used at the pre-swap stage. This field is intended to store information unrelated to users specifically (e.g. swap version, protocol details, etc.), which also includes IBC channel information for non-HTLC Tendermint swaps. This information will be used to validate IBC channels before starting the swap process ([see here](https://github.com/KomodoPlatform/komodo-defi-framework/blob/db06a3b2ff9a83bc92d9cca759f5914749df9dea/mm2src/mm2_main/src/lp_ordermatch.rs#L3094-L3104) and [here](https://github.com/KomodoPlatform/komodo-defi-framework/blob/db06a3b2ff9a83bc92d9cca759f5914749df9dea/mm2src/mm2_main/src/lp_ordermatch.rs#L3340-L3350)). This means that before starting the swap process, both taker and maker must validate their IBC channels to not start a swap that will fail due to using invalid/wrong IBC channels. This means that KDF will make sure users can only swap if their IBC matches the counterparty's IBC, which will prevent fund loss.
2. Adds `pre_check_for_order_creation` (implemented in [part 1](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2459)) calls inside the `buy` and `sell` functions.
3. Refactors various Tendermint types to avoid writing messy code in order to implement item 1.

**Note**: This feature does not affect KDF builds yet. All IBC routing changes are gated behind the `ibc-routing-for-swaps` feature.