### PR TITLE
deps(timed-map): bump to 1.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7106,9 +7106,9 @@ dependencies = [
 
 [[package]]
 name = "timed-map"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74a5331850dc3b08de854b57674af757b6e286e7ef930baf71e0a196f53790"
+checksum = "6f664a6b916d03d3e32c312c3b6ce31c24697c0f7ea6d87e20eb6372053ddf29"
 dependencies = [
  "rustc-hash",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,7 +197,7 @@ testcontainers = "0.15.0"
 tiny-bip39 = "0.8.0"
 thiserror = "1.0.40"
 time = "0.3.20"
-timed-map = { version = "1.4", features = ["rustc-hash", "wasm"] }
+timed-map = { version = "1.4", features = ["rustc-hash", "serde", "wasm"] }
 tokio = { version = "1.20",  default-features = false }
 tokio-rustls = { version = "0.24", default-features = false }
 tokio-tungstenite-wasm = { git = "https://github.com/KomodoPlatform/tokio-tungstenite-wasm", rev = "8fc7e2f", defautl-features = false, features = ["rustls-tls-native-roots"]}


### PR DESCRIPTION
Bumps to [`timed-map@1.4.1`](https://github.com/ozmann-industries/timed-map/releases/tag/v.1.4.1), which fixes https://github.com/KomodoPlatform/komodo-defi-framework/issues/2478.