### PR TITLE
improvement(orders): remove BTC specific volume from min_trading_vol logic

### DIFF
--- a/mm2src/coins/utxo/utxo_common.rs
+++ b/mm2src/coins/utxo/utxo_common.rs
@@ -76,7 +76,6 @@ pub const DEFAULT_FEE_VOUT: usize = 0;
 pub const DEFAULT_SWAP_TX_SPEND_SIZE: u64 = 496; // TODO: checking with komodo-like tx size, included the burn output
 pub const DEFAULT_SWAP_VOUT: usize = 0;
 pub const DEFAULT_SWAP_VIN: usize = 0;
-const MIN_BTC_TRADING_VOL: &str = "0.00777";
 
 macro_rules! return_err_if {
     ($cond: expr, $etype: expr) => {
@@ -3252,9 +3251,6 @@ pub fn min_tx_amount(coin: &UtxoCoinFields) -> BigDecimal {
 }
 
 pub fn min_trading_vol(coin: &UtxoCoinFields) -> MmNumber {
-    if coin.conf.ticker == "BTC" {
-        return MmNumber::from(MIN_BTC_TRADING_VOL);
-    }
     let dust_multiplier = MmNumber::from(10);
     dust_multiplier * min_tx_amount(coin).into()
 }


### PR DESCRIPTION
The removed logic is quite unnecessary today. With this patch, the minimum trading volume becomes 0.0001, which is around the equivalent of 10 USD and is roughly 10 times the average transaction fee on the BTC network.

Closes #2480 and #1935

cc @cipig 