### PR TITLE
fix(startup): don't initialize WalletConnect during startup

### DIFF
--- a/mm2src/mm2_main/src/lp_native_dex.rs
+++ b/mm2src/mm2_main/src/lp_native_dex.rs
@@ -35,7 +35,6 @@ use common::log::{info, warn};
 use crypto::{from_hw_error, CryptoCtx, HwError, HwProcessingError, HwRpcError, WithHwRpcError};
 use derive_more::Display;
 use enum_derives::EnumFromTrait;
-use kdf_walletconnect::WalletConnectCtx;
 use mm2_core::mm_ctx::{MmArc, MmCtx};
 use mm2_err_handle::common_errors::InternalError;
 use mm2_err_handle::prelude::*;
@@ -418,10 +417,6 @@ pub async fn lp_init_continue(ctx: MmArc) -> MmInitResult<()> {
 
     #[cfg(target_arch = "wasm32")]
     init_wasm_event_streaming(&ctx);
-
-    // This function spawns related WalletConnect related tasks needed for initialization before
-    // WalletConnect can be usable in KDF.
-    WalletConnectCtx::from_ctx(&ctx).mm_err(|err| MmInitError::WalletInitError(err.to_string()))?;
 
     ctx.spawner().spawn(clean_memory_loop(ctx.weak()));
 


### PR DESCRIPTION
We should call `WalletConnectCtx::from_ctx` only when necessary not during the KDF startup.

Currently, it seems like we are already calling it in several places:

![image](https://github.com/user-attachments/assets/9779e552-8422-422d-a8bd-b615473782fa)

Each of these calls attempts to initialize the `WalletConnection`, meaning the startup call is unnecessary. If something breaks, it indicates that we are missing the `WalletConnectCtx::from_ctx` call somewhere in the WalletConnect logic.

Fixes #2484