### PR TITLE
improvement(event-streaming): impl DeriveStreamerId trait for all streamers

### DIFF
--- a/mm2src/coins/tendermint/tendermint_tx_history_v2.rs
+++ b/mm2src/coins/tendermint/tendermint_tx_history_v2.rs
@@ -18,7 +18,7 @@ use cosmrs::tendermint::abci::{Code as TxCode, EventAttribute};
 use cosmrs::tx::Fee;
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::prelude::MmResult;
-use mm2_event_stream::StreamingManager;
+use mm2_event_stream::{DeriveStreamerId, StreamingManager};
 use mm2_number::BigDecimal;
 use mm2_state_machine::prelude::*;
 use mm2_state_machine::state_machine::StateMachineTrait;

--- a/mm2src/coins/utxo/rpc_clients/electrum_rpc/client.rs
+++ b/mm2src/coins/utxo/rpc_clients/electrum_rpc/client.rs
@@ -51,7 +51,7 @@ use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use futures01::Future;
 use itertools::Itertools;
-use mm2_event_stream::{StreamingManager, StreamingManagerError};
+use mm2_event_stream::{DeriveStreamerId, StreamingManager, StreamingManagerError};
 use serde_json::{self as json, Value as Json};
 
 type ElectrumTxHistory = Vec<ElectrumTxHistoryItem>;

--- a/mm2src/coins/utxo/tx_history_events.rs
+++ b/mm2src/coins/utxo/tx_history_events.rs
@@ -1,5 +1,5 @@
 use crate::TransactionDetails;
-use mm2_event_stream::{Broadcaster, Event, EventStreamer, StreamHandlerInput, StreamerId};
+use mm2_event_stream::{Broadcaster, DeriveStreamerId, Event, EventStreamer, StreamHandlerInput, StreamerId};
 
 use async_trait::async_trait;
 use futures::channel::oneshot;
@@ -9,12 +9,14 @@ pub struct TxHistoryEventStreamer {
     coin: String,
 }
 
-impl TxHistoryEventStreamer {
-    #[inline(always)]
-    pub fn new(coin: String) -> Self { Self { coin } }
+impl<'a> DeriveStreamerId<'a> for TxHistoryEventStreamer {
+    type InitParam = String;
+    type DeriveParam = &'a str;
+
+    fn new(coin: Self::InitParam) -> Self { Self { coin } }
 
     #[inline(always)]
-    pub fn derive_streamer_id(coin: &str) -> StreamerId { StreamerId::TxHistory { coin: coin.to_string() } }
+    fn derive_streamer_id(coin: Self::DeriveParam) -> StreamerId { StreamerId::TxHistory { coin: coin.to_string() } }
 }
 
 #[async_trait]

--- a/mm2src/coins/utxo/utxo_balance_events.rs
+++ b/mm2src/coins/utxo/utxo_balance_events.rs
@@ -12,7 +12,7 @@ use common::log;
 use futures::channel::oneshot;
 use futures::StreamExt;
 use keys::Address;
-use mm2_event_stream::{Broadcaster, Event, EventStreamer, StreamHandlerInput, StreamerId};
+use mm2_event_stream::{Broadcaster, DeriveStreamerId, Event, EventStreamer, StreamHandlerInput, StreamerId};
 use std::collections::{HashMap, HashSet};
 
 macro_rules! try_or_continue {
@@ -31,8 +31,11 @@ pub struct UtxoBalanceEventStreamer {
     coin: UtxoStandardCoin,
 }
 
-impl UtxoBalanceEventStreamer {
-    pub fn new(utxo_arc: UtxoArc) -> Self {
+impl<'a> DeriveStreamerId<'a> for UtxoBalanceEventStreamer {
+    type InitParam = UtxoArc;
+    type DeriveParam = &'a str;
+
+    fn new(utxo_arc: Self::InitParam) -> Self {
         Self {
             // We wrap the UtxoArc in a UtxoStandardCoin for easier method accessibility.
             // The UtxoArc might belong to a different coin type though.
@@ -40,7 +43,7 @@ impl UtxoBalanceEventStreamer {
         }
     }
 
-    pub fn derive_streamer_id(coin: &str) -> StreamerId { StreamerId::Balance { coin: coin.to_string() } }
+    fn derive_streamer_id(coin: Self::DeriveParam) -> StreamerId { StreamerId::Balance { coin: coin.to_string() } }
 }
 
 #[async_trait]

--- a/mm2src/coins/utxo/utxo_tx_history_v2.rs
+++ b/mm2src/coins/utxo/utxo_tx_history_v2.rs
@@ -15,7 +15,7 @@ use common::log::{error, info};
 use derive_more::Display;
 use keys::Address;
 use mm2_err_handle::prelude::*;
-use mm2_event_stream::StreamingManager;
+use mm2_event_stream::{DeriveStreamerId, StreamingManager};
 use mm2_metrics::MetricsArc;
 use mm2_number::BigDecimal;
 use mm2_state_machine::prelude::*;

--- a/mm2src/coins/z_coin/storage/blockdb/blockdb_sql_storage.rs
+++ b/mm2src/coins/z_coin/storage/blockdb/blockdb_sql_storage.rs
@@ -11,6 +11,7 @@ use db_common::sqlite::{query_single_row, run_optimization_pragmas, rusqlite};
 use itertools::Itertools;
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::prelude::*;
+use mm2_event_stream::DeriveStreamerId;
 use protobuf::Message;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};

--- a/mm2src/coins/z_coin/tx_history_events.rs
+++ b/mm2src/coins/z_coin/tx_history_events.rs
@@ -4,7 +4,7 @@ use crate::utxo::rpc_clients::UtxoRpcError;
 use crate::MarketCoinOps;
 use common::log;
 use mm2_err_handle::prelude::MmError;
-use mm2_event_stream::{Broadcaster, Event, EventStreamer, StreamHandlerInput, StreamerId};
+use mm2_event_stream::{Broadcaster, DeriveStreamerId, Event, EventStreamer, StreamHandlerInput, StreamerId};
 use rpc::v1::types::H256 as H256Json;
 
 use async_trait::async_trait;
@@ -18,12 +18,14 @@ pub struct ZCoinTxHistoryEventStreamer {
     coin: ZCoin,
 }
 
-impl ZCoinTxHistoryEventStreamer {
-    #[inline(always)]
-    pub fn new(coin: ZCoin) -> Self { Self { coin } }
+impl<'a> DeriveStreamerId<'a> for ZCoinTxHistoryEventStreamer {
+    type InitParam = ZCoin;
+    type DeriveParam = &'a str;
+
+    fn new(coin: Self::InitParam) -> Self { Self { coin } }
 
     #[inline(always)]
-    pub fn derive_streamer_id(coin: &str) -> StreamerId { StreamerId::TxHistory { coin: coin.to_string() } }
+    fn derive_streamer_id(coin: Self::DeriveParam) -> StreamerId { StreamerId::TxHistory { coin: coin.to_string() } }
 }
 
 #[async_trait]

--- a/mm2src/coins/z_coin/tx_streaming_tests/native.rs
+++ b/mm2src/coins/z_coin/tx_streaming_tests/native.rs
@@ -7,6 +7,7 @@ use crate::{CoinProtocol, DexFee, MarketCoinOps, MmCoin, PrivKeyBuildPolicy};
 use common::custom_futures::timeout::FutureTimerExt;
 use common::{block_on, Future01CompatExt};
 use mm2_core::mm_ctx::MmCtxBuilder;
+use mm2_event_stream::DeriveStreamerId;
 use mm2_test_helpers::for_tests::{pirate_conf, ARRR};
 use std::time::Duration;
 

--- a/mm2src/coins/z_coin/z_balance_streaming.rs
+++ b/mm2src/coins/z_coin/z_balance_streaming.rs
@@ -6,18 +6,20 @@ use async_trait::async_trait;
 use common::log::error;
 use futures::channel::oneshot;
 use futures_util::StreamExt;
-use mm2_event_stream::{Broadcaster, Event, EventStreamer, StreamHandlerInput, StreamerId};
+use mm2_event_stream::{Broadcaster, DeriveStreamerId, Event, EventStreamer, StreamHandlerInput, StreamerId};
 
 pub struct ZCoinBalanceEventStreamer {
     coin: ZCoin,
 }
 
-impl ZCoinBalanceEventStreamer {
-    #[inline(always)]
-    pub fn new(coin: ZCoin) -> Self { Self { coin } }
+impl<'a> DeriveStreamerId<'a> for ZCoinBalanceEventStreamer {
+    type InitParam = ZCoin;
+    type DeriveParam = &'a str;
+
+    fn new(coin: Self::InitParam) -> Self { Self { coin } }
 
     #[inline(always)]
-    pub fn derive_streamer_id(coin: &str) -> StreamerId { StreamerId::Balance { coin: coin.to_string() } }
+    fn derive_streamer_id(coin: Self::DeriveParam) -> StreamerId { StreamerId::Balance { coin: coin.to_string() } }
 }
 
 #[async_trait]

--- a/mm2src/mm2_event_stream/src/lib.rs
+++ b/mm2src/mm2_event_stream/src/lib.rs
@@ -8,5 +8,5 @@ pub mod streamer_ids;
 pub use configuration::EventStreamingConfiguration;
 pub use event::Event;
 pub use manager::{StreamingManager, StreamingManagerError};
-pub use streamer::{Broadcaster, EventStreamer, NoDataIn, StreamHandlerInput};
+pub use streamer::{Broadcaster, DeriveStreamerId, EventStreamer, NoDataIn, StreamHandlerInput};
 pub use streamer_ids::StreamerId;

--- a/mm2src/mm2_event_stream/src/streamer.rs
+++ b/mm2src/mm2_event_stream/src/streamer.rs
@@ -39,6 +39,14 @@ where
     );
 }
 
+pub trait DeriveStreamerId<'a> {
+    type InitParam;
+    type DeriveParam: 'a;
+
+    fn new(param: Self::InitParam) -> Self;
+    fn derive_streamer_id(param: Self::DeriveParam) -> StreamerId;
+}
+
 /// Spawns the [`EventStreamer::handle`] in a separate task using [`WeakSpawner`].
 ///
 /// Returns a [`oneshot::Sender`] to shutdown the handler and an optional [`mpsc::UnboundedSender`]

--- a/mm2src/mm2_main/src/lp_ordermatch/order_events.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch/order_events.rs
@@ -1,5 +1,5 @@
 use super::{MakerMatch, TakerMatch};
-use mm2_event_stream::{Broadcaster, Event, EventStreamer, StreamHandlerInput, StreamerId};
+use mm2_event_stream::{Broadcaster, DeriveStreamerId, Event, EventStreamer, StreamHandlerInput, StreamerId};
 
 use async_trait::async_trait;
 use futures::channel::oneshot;
@@ -7,12 +7,13 @@ use futures::StreamExt;
 
 pub struct OrderStatusStreamer;
 
-impl OrderStatusStreamer {
-    #[inline(always)]
-    pub fn new() -> Self { Self }
+impl DeriveStreamerId<'_> for OrderStatusStreamer {
+    type InitParam = ();
+    type DeriveParam = ();
 
-    #[inline(always)]
-    pub const fn derive_streamer_id() -> StreamerId { StreamerId::OrderStatus }
+    fn new(_: Self::InitParam) -> Self { Self }
+
+    fn derive_streamer_id(_: Self::DeriveParam) -> StreamerId { StreamerId::OrderStatus }
 }
 
 #[derive(Serialize)]
@@ -28,7 +29,7 @@ pub enum OrderStatusEvent {
 impl EventStreamer for OrderStatusStreamer {
     type DataInType = OrderStatusEvent;
 
-    fn streamer_id(&self) -> StreamerId { Self::derive_streamer_id() }
+    fn streamer_id(&self) -> StreamerId { Self::derive_streamer_id(()) }
 
     async fn handle(
         self,

--- a/mm2src/mm2_main/src/lp_ordermatch/orderbook_events.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch/orderbook_events.rs
@@ -1,7 +1,7 @@
 use super::{orderbook_topic_from_base_rel, subscribe_to_orderbook_topic, OrderbookP2PItem};
 use coins::{is_wallet_only_ticker, lp_coinfind};
 use mm2_core::mm_ctx::MmArc;
-use mm2_event_stream::{Broadcaster, Event, EventStreamer, StreamHandlerInput, StreamerId};
+use mm2_event_stream::{Broadcaster, DeriveStreamerId, Event, EventStreamer, StreamHandlerInput, StreamerId};
 
 use async_trait::async_trait;
 use futures::channel::oneshot;
@@ -14,10 +14,13 @@ pub struct OrderbookStreamer {
     rel: String,
 }
 
-impl OrderbookStreamer {
-    pub fn new(ctx: MmArc, base: String, rel: String) -> Self { Self { ctx, base, rel } }
+impl<'a> DeriveStreamerId<'a> for OrderbookStreamer {
+    type InitParam = (MmArc, String, String);
+    type DeriveParam = (&'a str, &'a str);
 
-    pub fn derive_streamer_id(base: &str, rel: &str) -> StreamerId {
+    fn new((ctx, base, rel): Self::InitParam) -> Self { Self { ctx, base, rel } }
+
+    fn derive_streamer_id((base, rel): Self::DeriveParam) -> StreamerId {
         StreamerId::OrderbookUpdate {
             topic: orderbook_topic_from_base_rel(base, rel),
         }
@@ -38,7 +41,7 @@ pub enum OrderbookItemChangeEvent {
 impl EventStreamer for OrderbookStreamer {
     type DataInType = OrderbookItemChangeEvent;
 
-    fn streamer_id(&self) -> StreamerId { Self::derive_streamer_id(&self.base, &self.rel) }
+    fn streamer_id(&self) -> StreamerId { Self::derive_streamer_id((&self.base, &self.rel)) }
 
     async fn handle(
         self,

--- a/mm2src/mm2_main/src/lp_swap/maker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap.rs
@@ -31,6 +31,7 @@ use futures::{compat::Future01CompatExt, select, FutureExt};
 use keys::KeyPair;
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::prelude::*;
+use mm2_event_stream::DeriveStreamerId;
 use mm2_number::{BigDecimal, MmNumber};
 use mm2_rpc::data::legacy::OrderConfirmationsSettings;
 use parking_lot::Mutex as PaMutex;
@@ -2190,9 +2191,11 @@ pub async fn run_maker_swap(swap: RunMakerSwapInput, ctx: MmArc) {
                     drop(dispatcher);
                     // Send a notification to the swap status streamer about a new event.
                     ctx.event_stream_manager
-                        .send_fn(&SwapStatusStreamer::derive_streamer_id(), || SwapStatusEvent::MakerV1 {
-                            uuid: running_swap.uuid,
-                            event: to_save.clone(),
+                        .send_fn(&SwapStatusStreamer::derive_streamer_id(()), || {
+                            SwapStatusEvent::MakerV1 {
+                                uuid: running_swap.uuid,
+                                event: to_save.clone(),
+                            }
                         })
                         .ok();
                     save_my_maker_swap_event(&ctx, &running_swap, to_save)

--- a/mm2src/mm2_main/src/lp_swap/maker_swap_v2.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap_v2.rs
@@ -23,6 +23,7 @@ use crypto::secret_hash_algo::SecretHashAlgo;
 use keys::KeyPair;
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::prelude::*;
+use mm2_event_stream::DeriveStreamerId;
 use mm2_libp2p::Secp256k1PubkeySerialize;
 use mm2_number::MmNumber;
 use mm2_state_machine::prelude::*;
@@ -792,9 +793,11 @@ impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOp
         // Send a notification to the swap status streamer about a new event.
         self.ctx
             .event_stream_manager
-            .send_fn(&SwapStatusStreamer::derive_streamer_id(), || SwapStatusEvent::MakerV2 {
-                uuid: self.uuid,
-                event: event.clone(),
+            .send_fn(&SwapStatusStreamer::derive_streamer_id(()), || {
+                SwapStatusEvent::MakerV2 {
+                    uuid: self.uuid,
+                    event: event.clone(),
+                }
             })
             .ok();
     }

--- a/mm2src/mm2_main/src/lp_swap/swap_events.rs
+++ b/mm2src/mm2_main/src/lp_swap/swap_events.rs
@@ -2,7 +2,7 @@ use super::maker_swap::MakerSavedEvent;
 use super::maker_swap_v2::MakerSwapEvent;
 use super::taker_swap::TakerSavedEvent;
 use super::taker_swap_v2::TakerSwapEvent;
-use mm2_event_stream::{Broadcaster, Event, EventStreamer, StreamHandlerInput, StreamerId};
+use mm2_event_stream::{Broadcaster, DeriveStreamerId, Event, EventStreamer, StreamHandlerInput, StreamerId};
 
 use async_trait::async_trait;
 use futures::channel::oneshot;
@@ -11,12 +11,13 @@ use uuid::Uuid;
 
 pub struct SwapStatusStreamer;
 
-impl SwapStatusStreamer {
-    #[inline(always)]
-    pub fn new() -> Self { Self }
+impl DeriveStreamerId<'_> for SwapStatusStreamer {
+    type InitParam = ();
+    type DeriveParam = ();
 
-    #[inline(always)]
-    pub const fn derive_streamer_id() -> StreamerId { StreamerId::SwapStatus }
+    fn new(_: Self::InitParam) -> Self { Self }
+
+    fn derive_streamer_id(_: Self::DeriveParam) -> StreamerId { StreamerId::SwapStatus }
 }
 
 #[derive(Serialize)]
@@ -32,7 +33,7 @@ pub enum SwapStatusEvent {
 impl EventStreamer for SwapStatusStreamer {
     type DataInType = SwapStatusEvent;
 
-    fn streamer_id(&self) -> StreamerId { Self::derive_streamer_id() }
+    fn streamer_id(&self) -> StreamerId { Self::derive_streamer_id(()) }
 
     async fn handle(
         self,

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -31,6 +31,7 @@ use http::Response;
 use keys::KeyPair;
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::prelude::*;
+use mm2_event_stream::DeriveStreamerId;
 use mm2_number::{BigDecimal, MmNumber};
 use mm2_rpc::data::legacy::{MatchBy, OrderConfirmationsSettings, TakerAction};
 use parking_lot::Mutex as PaMutex;
@@ -491,9 +492,11 @@ pub async fn run_taker_swap(swap: RunTakerSwapInput, ctx: MmArc) {
 
                     // Send a notification to the swap status streamer about a new event.
                     ctx.event_stream_manager
-                        .send_fn(&SwapStatusStreamer::derive_streamer_id(), || SwapStatusEvent::TakerV1 {
-                            uuid: running_swap.uuid,
-                            event: to_save.clone(),
+                        .send_fn(&SwapStatusStreamer::derive_streamer_id(()), || {
+                            SwapStatusEvent::TakerV1 {
+                                uuid: running_swap.uuid,
+                                event: to_save.clone(),
+                            }
                         })
                         .ok();
                     save_my_taker_swap_event(&ctx, &running_swap, to_save)

--- a/mm2src/mm2_main/src/lp_swap/taker_swap_v2.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap_v2.rs
@@ -23,6 +23,7 @@ use crypto::secret_hash_algo::SecretHashAlgo;
 use keys::KeyPair;
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::prelude::*;
+use mm2_event_stream::DeriveStreamerId;
 use mm2_libp2p::Secp256k1PubkeySerialize;
 use mm2_number::MmNumber;
 use mm2_state_machine::prelude::*;
@@ -909,9 +910,11 @@ impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOp
         // Send a notification to the swap status streamer about a new event.
         self.ctx
             .event_stream_manager
-            .send_fn(&SwapStatusStreamer::derive_streamer_id(), || SwapStatusEvent::TakerV2 {
-                uuid: self.uuid,
-                event: event.clone(),
+            .send_fn(&SwapStatusStreamer::derive_streamer_id(()), || {
+                SwapStatusEvent::TakerV2 {
+                    uuid: self.uuid,
+                    event: event.clone(),
+                }
             })
             .ok();
     }

--- a/mm2src/mm2_main/src/rpc/streaming_activations/balance.rs
+++ b/mm2src/mm2_main/src/rpc/streaming_activations/balance.rs
@@ -10,6 +10,7 @@ use common::HttpStatusCode;
 use http::StatusCode;
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::{map_to_mm::MapToMmResult, mm_error::MmResult};
+use mm2_event_stream::DeriveStreamerId;
 
 use serde_json::Value as Json;
 

--- a/mm2src/mm2_main/src/rpc/streaming_activations/orderbook.rs
+++ b/mm2src/mm2_main/src/rpc/streaming_activations/orderbook.rs
@@ -3,6 +3,7 @@ use super::EnableStreamingResponse;
 use crate::lp_ordermatch::orderbook_events::OrderbookStreamer;
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::{map_to_mm::MapToMmResult, mm_error::MmResult};
+use mm2_event_stream::DeriveStreamerId;
 
 use common::HttpStatusCode;
 use http::StatusCode;
@@ -28,7 +29,7 @@ pub async fn enable_orderbook(
     ctx: MmArc,
     req: EnableOrderbookStreamingRequest,
 ) -> MmResult<EnableStreamingResponse, OrderbookStreamingRequestError> {
-    let order_status_streamer = OrderbookStreamer::new(ctx.clone(), req.base, req.rel);
+    let order_status_streamer = OrderbookStreamer::new((ctx.clone(), req.base, req.rel));
     ctx.event_stream_manager
         .add(req.client_id, order_status_streamer, ctx.spawner())
         .await

--- a/mm2src/mm2_main/src/rpc/streaming_activations/orders.rs
+++ b/mm2src/mm2_main/src/rpc/streaming_activations/orders.rs
@@ -3,6 +3,7 @@ use super::{EnableStreamingRequest, EnableStreamingResponse};
 use crate::lp_ordermatch::order_events::OrderStatusStreamer;
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::{map_to_mm::MapToMmResult, mm_error::MmResult};
+use mm2_event_stream::DeriveStreamerId;
 
 use common::HttpStatusCode;
 use http::StatusCode;
@@ -21,7 +22,7 @@ pub async fn enable_order_status(
     ctx: MmArc,
     req: EnableStreamingRequest<()>,
 ) -> MmResult<EnableStreamingResponse, OrderStatusStreamingRequestError> {
-    let order_status_streamer = OrderStatusStreamer::new();
+    let order_status_streamer = OrderStatusStreamer::new(());
     ctx.event_stream_manager
         .add(req.client_id, order_status_streamer, ctx.spawner())
         .await

--- a/mm2src/mm2_main/src/rpc/streaming_activations/swaps.rs
+++ b/mm2src/mm2_main/src/rpc/streaming_activations/swaps.rs
@@ -3,6 +3,7 @@ use super::{EnableStreamingRequest, EnableStreamingResponse};
 use crate::lp_swap::swap_events::SwapStatusStreamer;
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::{map_to_mm::MapToMmResult, mm_error::MmResult};
+use mm2_event_stream::DeriveStreamerId;
 
 use common::HttpStatusCode;
 use http::StatusCode;
@@ -26,7 +27,7 @@ pub async fn enable_swap_status(
     req: EnableStreamingRequest<()>,
 ) -> MmResult<EnableStreamingResponse, SwapStatusStreamingRequestError> {
     ctx.event_stream_manager
-        .add(req.client_id, SwapStatusStreamer::new(), ctx.spawner())
+        .add(req.client_id, SwapStatusStreamer::new(()), ctx.spawner())
         .await
         .map(EnableStreamingResponse::new)
         .map_to_mm(|e| SwapStatusStreamingRequestError::EnableError(format!("{e:?}")))

--- a/mm2src/mm2_main/src/rpc/streaming_activations/tx_history.rs
+++ b/mm2src/mm2_main/src/rpc/streaming_activations/tx_history.rs
@@ -8,6 +8,7 @@ use common::HttpStatusCode;
 use http::StatusCode;
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::{map_to_mm::MapToMmResult, mm_error::MmResult};
+use mm2_event_stream::DeriveStreamerId;
 
 #[derive(Deserialize)]
 pub struct EnableTxHistoryStreamingRequest {


### PR DESCRIPTION
As disccused [#2441](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2441#discussion_r2081449834), This PR introduces the DeriveStreamerId trait to standardize the initialization and streamer ID derivation for all event streamers in the mm2_event_stream module ensuring consistency across all streamer implementations.