### PR TITLE
feat(wallet): Add `delete_wallet` RPC

### DIFF
--- a/mm2src/mm2_main/src/lp_wallet.rs
+++ b/mm2src/mm2_main/src/lp_wallet.rs
@@ -14,14 +14,14 @@ cfg_wasm32! {
     use crate::lp_wallet::mnemonics_wasm_db::{WalletsDb, WalletsDBError};
     use mm2_core::mm_ctx::from_ctx;
     use mm2_db::indexed_db::{ConstructibleDb, DbLocked, InitDbResult};
-    use mnemonics_wasm_db::{read_all_wallet_names, read_encrypted_passphrase_if_available, save_encrypted_passphrase};
+    use mnemonics_wasm_db::{delete_wallet, read_all_wallet_names, read_encrypted_passphrase, save_encrypted_passphrase};
     use std::sync::Arc;
 
     type WalletsDbLocked<'a> = DbLocked<'a, WalletsDb>;
 }
 
 cfg_native! {
-    use mnemonics_storage::{read_all_wallet_names, read_encrypted_passphrase_if_available, save_encrypted_passphrase, WalletsStorageError};
+    use mnemonics_storage::{delete_wallet, read_all_wallet_names, read_encrypted_passphrase, save_encrypted_passphrase, WalletsStorageError};
 }
 #[cfg(not(target_arch = "wasm32"))] mod mnemonics_storage;
 #[cfg(target_arch = "wasm32")] mod mnemonics_wasm_db;
@@ -69,6 +69,8 @@ pub enum ReadPassphraseError {
     WalletsStorageError(String),
     #[display(fmt = "Error decrypting passphrase: {}", _0)]
     DecryptionError(String),
+    #[display(fmt = "Internal error: {}", _0)]
+    Internal(String),
 }
 
 impl From<ReadPassphraseError> for WalletInitError {
@@ -76,6 +78,7 @@ impl From<ReadPassphraseError> for WalletInitError {
         match e {
             ReadPassphraseError::WalletsStorageError(e) => WalletInitError::WalletsStorageError(e),
             ReadPassphraseError::DecryptionError(e) => WalletInitError::MnemonicError(e),
+            ReadPassphraseError::Internal(e) => WalletInitError::InternalError(e),
         }
     }
 }
@@ -121,25 +124,39 @@ async fn encrypt_and_save_passphrase(
         .mm_err(|e| WalletInitError::WalletsStorageError(e.to_string()))
 }
 
-/// Reads and decrypts the passphrase from a file associated with the given wallet name, if available.
-///
-/// This function first checks if a passphrase is available. If a passphrase is found,
-/// since it is stored in an encrypted format, it decrypts it before returning. If no passphrase is found,
-/// it returns `None`.
-///
-/// # Returns
-/// `MmInitResult<String>` - The decrypted passphrase or an error if any operation fails.
-///
-/// # Errors
-/// Returns specific `MmInitError` variants for different failure scenarios.
-async fn read_and_decrypt_passphrase_if_available(
+/// A convenience wrapper that calls [`try_load_wallet_passphrase`] for the currently active wallet.
+async fn try_load_active_wallet_passphrase(
     ctx: &MmArc,
     wallet_password: &str,
 ) -> MmResult<Option<String>, ReadPassphraseError> {
-    match read_encrypted_passphrase_if_available(ctx)
+    let wallet_name = ctx
+        .wallet_name
+        .get()
+        .ok_or(ReadPassphraseError::Internal(
+            "`wallet_name` not initialized yet!".to_string(),
+        ))?
+        .clone()
+        .ok_or_else(|| {
+            ReadPassphraseError::Internal("Cannot read stored passphrase: no active wallet is set.".to_string())
+        })?;
+
+    try_load_wallet_passphrase(ctx, &wallet_name, wallet_password).await
+}
+
+/// Loads (reads from storage and decrypts) a passphrase for a specific wallet by name.
+///
+/// Returns `Ok(None)` if the passphrase is not found in storage. This is an expected
+/// outcome for a new wallet or when using a legacy config where the passphrase is not saved.
+async fn try_load_wallet_passphrase(
+    ctx: &MmArc,
+    wallet_name: &str,
+    wallet_password: &str,
+) -> MmResult<Option<String>, ReadPassphraseError> {
+    let encrypted = read_encrypted_passphrase(ctx, wallet_name)
         .await
-        .mm_err(|e| ReadPassphraseError::WalletsStorageError(e.to_string()))?
-    {
+        .mm_err(|e| ReadPassphraseError::WalletsStorageError(e.to_string()))?;
+
+    match encrypted {
         Some(encrypted_passphrase) => {
             let mnemonic = decrypt_mnemonic(&encrypted_passphrase, wallet_password)
                 .mm_err(|e| ReadPassphraseError::DecryptionError(e.to_string()))?;
@@ -171,7 +188,7 @@ async fn retrieve_or_create_passphrase(
     wallet_name: &str,
     wallet_password: &str,
 ) -> WalletInitResult<Option<String>> {
-    match read_and_decrypt_passphrase_if_available(ctx, wallet_password).await? {
+    match try_load_active_wallet_passphrase(ctx, wallet_password).await? {
         Some(passphrase_from_file) => {
             // If an existing passphrase is found, return it
             Ok(Some(passphrase_from_file))
@@ -202,7 +219,7 @@ async fn confirm_or_encrypt_and_store_passphrase(
     passphrase: &str,
     wallet_password: &str,
 ) -> WalletInitResult<Option<String>> {
-    match read_and_decrypt_passphrase_if_available(ctx, wallet_password).await? {
+    match try_load_active_wallet_passphrase(ctx, wallet_password).await? {
         Some(passphrase_from_file) if passphrase == passphrase_from_file => {
             // If an existing passphrase is found and it matches the provided passphrase, return it
             Ok(Some(passphrase_from_file))
@@ -238,7 +255,7 @@ async fn decrypt_validate_or_save_passphrase(
     // Decrypt the provided encrypted passphrase
     let decrypted_passphrase = decrypt_mnemonic(&encrypted_passphrase_data, wallet_password)?;
 
-    match read_and_decrypt_passphrase_if_available(ctx, wallet_password).await? {
+    match try_load_active_wallet_passphrase(ctx, wallet_password).await? {
         Some(passphrase_from_file) if decrypted_passphrase == passphrase_from_file => {
             // If an existing passphrase is found and it matches the decrypted passphrase, return it
             Ok(Some(decrypted_passphrase))
@@ -476,7 +493,13 @@ impl From<WalletsDBError> for MnemonicRpcError {
 }
 
 impl From<ReadPassphraseError> for MnemonicRpcError {
-    fn from(e: ReadPassphraseError) -> Self { MnemonicRpcError::WalletsStorageError(e.to_string()) }
+    fn from(e: ReadPassphraseError) -> Self {
+        match e {
+            ReadPassphraseError::DecryptionError(e) => MnemonicRpcError::InvalidPassword(e),
+            ReadPassphraseError::WalletsStorageError(e) => MnemonicRpcError::WalletsStorageError(e),
+            ReadPassphraseError::Internal(e) => MnemonicRpcError::Internal(e),
+        }
+    }
 }
 
 /// Retrieves the wallet mnemonic in the requested format.
@@ -513,7 +536,19 @@ impl From<ReadPassphraseError> for MnemonicRpcError {
 pub async fn get_mnemonic_rpc(ctx: MmArc, req: GetMnemonicRequest) -> MmResult<GetMnemonicResponse, MnemonicRpcError> {
     match req.mnemonic_format {
         MnemonicFormat::Encrypted => {
-            let encrypted_mnemonic = read_encrypted_passphrase_if_available(&ctx)
+            let wallet_name = ctx
+                .wallet_name
+                .get()
+                .ok_or(MnemonicRpcError::Internal(
+                    "`wallet_name` not initialized yet!".to_string(),
+                ))?
+                .as_ref()
+                .ok_or_else(|| {
+                    MnemonicRpcError::Internal(
+                        "Cannot get encrypted mnemonic: This operation requires an active named wallet.".to_string(),
+                    )
+                })?;
+            let encrypted_mnemonic = read_encrypted_passphrase(&ctx, wallet_name)
                 .await?
                 .ok_or_else(|| MnemonicRpcError::InvalidRequest("Wallet mnemonic file not found".to_string()))?;
             Ok(GetMnemonicResponse {
@@ -521,7 +556,7 @@ pub async fn get_mnemonic_rpc(ctx: MmArc, req: GetMnemonicRequest) -> MmResult<G
             })
         },
         MnemonicFormat::PlainText(wallet_password) => {
-            let plaintext_mnemonic = read_and_decrypt_passphrase_if_available(&ctx, &wallet_password)
+            let plaintext_mnemonic = try_load_active_wallet_passphrase(&ctx, &wallet_password)
                 .await?
                 .ok_or_else(|| MnemonicRpcError::InvalidRequest("Wallet mnemonic file not found".to_string()))?;
             Ok(GetMnemonicResponse {
@@ -584,7 +619,7 @@ pub async fn change_mnemonic_password(ctx: MmArc, req: ChangeMnemonicPasswordReq
         .as_ref()
         .ok_or_else(|| MnemonicRpcError::Internal("`wallet_name` cannot be None!".to_string()))?;
     // read mnemonic for a wallet_name using current user's password.
-    let mnemonic = read_and_decrypt_passphrase_if_available(&ctx, &req.current_password)
+    let mnemonic = try_load_active_wallet_passphrase(&ctx, &req.current_password)
         .await?
         .ok_or(MmError::new(MnemonicRpcError::Internal(format!(
             "{wallet_name}: wallet mnemonic file not found"
@@ -595,4 +630,49 @@ pub async fn change_mnemonic_password(ctx: MmArc, req: ChangeMnemonicPasswordReq
     save_encrypted_passphrase(&ctx, wallet_name, &encrypted_data).await?;
 
     Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DeleteWalletRequest {
+    /// The name of the wallet to be deleted.
+    pub wallet_name: String,
+    /// The password to confirm wallet deletion.
+    pub password: String,
+}
+
+/// Deletes a wallet. Requires password confirmation.
+/// The active wallet cannot be deleted.
+pub async fn delete_wallet_rpc(ctx: MmArc, req: DeleteWalletRequest) -> MmResult<(), MnemonicRpcError> {
+    let active_wallet = ctx
+        .wallet_name
+        .get()
+        .ok_or(MnemonicRpcError::Internal(
+            "`wallet_name` not initialized yet!".to_string(),
+        ))?
+        .as_ref();
+
+    if active_wallet == Some(&req.wallet_name) {
+        return MmError::err(MnemonicRpcError::InvalidRequest(format!(
+            "Cannot delete wallet '{}' as it is currently active.",
+            req.wallet_name
+        )));
+    }
+
+    // Verify the password by attempting to decrypt the mnemonic.
+    let maybe_mnemonic = try_load_wallet_passphrase(&ctx, &req.wallet_name, &req.password).await?;
+
+    match maybe_mnemonic {
+        Some(_) => {
+            // Password is correct, proceed with deletion.
+            delete_wallet(&ctx, &req.wallet_name).await?;
+            Ok(())
+        },
+        None => {
+            // This case implies no mnemonic file was found for the given wallet.
+            MmError::err(MnemonicRpcError::InvalidRequest(format!(
+                "Wallet '{}' not found.",
+                req.wallet_name
+            )))
+        },
+    }
 }

--- a/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
+++ b/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
@@ -11,7 +11,7 @@ use crate::lp_stats::{add_node_to_version_stat, remove_node_from_version_stat, s
                       stop_version_stat_collection, update_version_stat_collection};
 use crate::lp_swap::swap_v2_rpcs::{active_swaps_rpc, my_recent_swaps_rpc, my_swap_status_rpc};
 use crate::lp_swap::{get_locked_amount_rpc, max_maker_vol, recreate_swap_data, trade_preimage_rpc};
-use crate::lp_wallet::{change_mnemonic_password, get_mnemonic_rpc, get_wallet_names_rpc};
+use crate::lp_wallet::{change_mnemonic_password, delete_wallet_rpc, get_mnemonic_rpc, get_wallet_names_rpc};
 use crate::rpc::lp_commands::db_id::get_shared_db_id;
 use crate::rpc::lp_commands::one_inch::rpcs::{one_inch_v6_0_classic_swap_contract_rpc,
                                               one_inch_v6_0_classic_swap_create_rpc,
@@ -201,6 +201,7 @@ async fn dispatcher_v2(request: MmRpcRequest, ctx: MmArc) -> DispatcherResult<Re
         "get_token_allowance" => handle_mmrpc(ctx, request, get_token_allowance_rpc).await,
         "best_orders" => handle_mmrpc(ctx, request, best_orders_rpc_v2).await,
         "clear_nft_db" => handle_mmrpc(ctx, request, clear_nft_db).await,
+        "delete_wallet" => handle_mmrpc(ctx, request, delete_wallet_rpc).await,
         "enable_bch_with_tokens" => handle_mmrpc(ctx, request, enable_platform_coin_with_tokens::<BchCoin>).await,
         "enable_slp" => handle_mmrpc(ctx, request, enable_token::<SlpToken>).await,
         "enable_eth_with_tokens" => handle_mmrpc(ctx, request, enable_platform_coin_with_tokens::<EthCoin>).await,

--- a/mm2src/mm2_main/src/wasm_tests.rs
+++ b/mm2src/mm2_main/src/wasm_tests.rs
@@ -2,11 +2,12 @@ use crate::{lp_init, lp_run};
 use common::executor::{spawn, spawn_abortable, spawn_local_abortable, AbortOnDropHandle, Timer};
 use common::log::warn;
 use common::log::wasm_log::register_wasm_log;
+use http::StatusCode;
 use mm2_core::mm_ctx::MmArc;
 use mm2_number::BigDecimal;
 use mm2_rpc::data::legacy::OrderbookResponse;
 use mm2_test_helpers::electrums::{doc_electrums, marty_electrums};
-use mm2_test_helpers::for_tests::{check_recent_swaps, enable_electrum_json, enable_utxo_v2_electrum,
+use mm2_test_helpers::for_tests::{check_recent_swaps, delete_wallet, enable_electrum_json, enable_utxo_v2_electrum,
                                   enable_z_coin_light, get_wallet_names, morty_conf, pirate_conf, rick_conf,
                                   start_swaps, test_qrc20_history_impl, wait_for_swaps_finish_and_check_status,
                                   MarketMakerIt, Mm2InitPrivKeyPolicy, Mm2TestConf, Mm2TestConfForSwap, ARRR, MORTY,
@@ -298,6 +299,80 @@ async fn test_get_wallet_names() {
     assert_eq!(get_wallet_names_2.activated_wallet.unwrap(), "wallet_2");
 
     // Stop the second wallet
+    mm_wallet_2
+        .stop_and_wait_for_ctx_is_dropped(STOP_TIMEOUT_MS)
+        .await
+        .unwrap();
+}
+
+#[wasm_bindgen_test]
+async fn test_delete_wallet_rpc() {
+    const DB_NAMESPACE_NUM: u64 = 2;
+
+    let coins = json!([]);
+    let wallet_1_name = "wallet_to_be_deleted";
+    let wallet_1_pass = "pass1";
+    let wallet_1_conf = Mm2TestConf::seednode_with_wallet_name(&coins, wallet_1_name, wallet_1_pass);
+    let mm_wallet_1 = MarketMakerIt::start_with_db(
+        wallet_1_conf.conf,
+        wallet_1_conf.rpc_password,
+        Some(wasm_start),
+        DB_NAMESPACE_NUM,
+    )
+    .await
+    .unwrap();
+
+    let get_wallet_names_1 = get_wallet_names(&mm_wallet_1).await;
+    assert_eq!(get_wallet_names_1.wallet_names, vec![wallet_1_name]);
+    assert_eq!(get_wallet_names_1.activated_wallet.as_deref(), Some(wallet_1_name));
+
+    mm_wallet_1
+        .stop_and_wait_for_ctx_is_dropped(STOP_TIMEOUT_MS)
+        .await
+        .unwrap();
+
+    let wallet_2_name = "active_wallet";
+    let wallet_2_pass = "pass2";
+    let wallet_2_conf = Mm2TestConf::seednode_with_wallet_name(&coins, wallet_2_name, wallet_2_pass);
+    let mm_wallet_2 = MarketMakerIt::start_with_db(
+        wallet_2_conf.conf,
+        wallet_2_conf.rpc_password,
+        Some(wasm_start),
+        DB_NAMESPACE_NUM,
+    )
+    .await
+    .unwrap();
+
+    let mut wallet_names = get_wallet_names(&mm_wallet_2).await.wallet_names;
+    wallet_names.sort();
+    assert_eq!(wallet_names, vec![wallet_1_name, wallet_2_name]);
+    let activated_wallet = get_wallet_names(&mm_wallet_2).await.activated_wallet;
+    assert_eq!(activated_wallet.as_deref(), Some(wallet_2_name));
+
+    // Try to delete the active wallet - should fail
+    let (status, body, _) = delete_wallet(&mm_wallet_2, wallet_2_name, wallet_2_pass).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(body.contains("Cannot delete wallet 'active_wallet' as it is currently active."));
+
+    // Try to delete with the wrong password - should fail
+    let (status, body, _) = delete_wallet(&mm_wallet_2, wallet_1_name, "wrong_pass").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(body.contains("Invalid password"));
+
+    // Try to delete a non-existent wallet - should fail
+    let (status, body, _) = delete_wallet(&mm_wallet_2, "non_existent_wallet", "any_pass").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(body.contains("Wallet 'non_existent_wallet' not found."));
+
+    // Delete the inactive wallet with the correct password - should succeed
+    let (status, body, _) = delete_wallet(&mm_wallet_2, wallet_1_name, wallet_1_pass).await;
+    assert_eq!(status, StatusCode::OK, "Body: {}", body);
+
+    // Verify the wallet is deleted
+    let get_wallet_names_3 = get_wallet_names(&mm_wallet_2).await;
+    assert_eq!(get_wallet_names_3.wallet_names, vec![wallet_2_name]);
+    assert_eq!(get_wallet_names_3.activated_wallet.as_deref(), Some(wallet_2_name));
+
     mm_wallet_2
         .stop_and_wait_for_ctx_is_dropped(STOP_TIMEOUT_MS)
         .await

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -2985,6 +2985,20 @@ pub async fn get_wallet_names(mm: &MarketMakerIt) -> GetWalletNamesResult {
     res.result
 }
 
+pub async fn delete_wallet(mm: &MarketMakerIt, wallet_name: &str, password: &str) -> (StatusCode, String, HeaderMap) {
+    mm.rpc(&json!({
+        "userpass": mm.userpass,
+        "method": "delete_wallet",
+        "mmrpc": "2.0",
+        "params": {
+            "wallet_name": wallet_name,
+            "password": password,
+        }
+    }))
+        .await
+        .unwrap()
+}
+
 pub async fn max_maker_vol(mm: &MarketMakerIt, coin: &str) -> RpcResponse {
     let rc = mm
         .rpc(&json!({


### PR DESCRIPTION
This PR introduces the `delete_wallet` RPC endpoint, allowing for the secure deletion of wallets with password confirmation.

### To Test:
- Create two wallets, for example, `wallet-to-delete` (password: pass1) and `active-wallet` (password: pass2).
- Log into `active-wallet` to make it the active session.
- Verify wallets exist by calling `get_wallet_names`.

#### Attempt to delete the active wallet (should fail):
```json
{
  "userpass": "your_rpc_password",
  "method": "delete_wallet",
  "mmrpc": "2.0",
  "params": {
    "wallet_name": "active-wallet",
    "password": "pass2"
  }
}
```
**Expected Error:** Cannot delete wallet 'active-wallet' as it is currently active.

#### Attempt to delete with an incorrect password (should fail):
```json
{
  "userpass": "your_rpc_password",
  "method": "delete_wallet",
  "mmrpc": "2.0",
  "params": {
    "wallet_name": "wallet-to-delete",
    "password": "wrong_password"
  }
}
```
**Expected Error:** Invalid password

#### Attempt to delete a non-existent wallet (should fail):
```json
{
  "userpass": "your_rpc_password",
  "method": "delete_wallet",
  "mmrpc": "2.0",
  "params": {
    "wallet_name": "non-existent-wallet",
    "password": "any_password"
  }
}
```
**Expected Error:** Wallet 'non-existent-wallet' not found.

#### Successfully delete an inactive wallet
```json
{
  "userpass": "your_rpc_password",
  "method": "delete_wallet",
  "mmrpc": "2.0",
  "params": {
    "wallet_name": "wallet-to-delete",
    "password": "pass1"
  }
}
```
**Expected Response:** A successful result `({"result":null})`.

#### Verify deletion:
Call `get_wallet_names` again. The response should now only list active-wallet.

