### PR TITLE
fix(walletconnect): centralize connection and retry logic

### DIFF
--- a/mm2src/kdf_walletconnect/src/connection_handler.rs
+++ b/mm2src/kdf_walletconnect/src/connection_handler.rs
@@ -1,9 +1,5 @@
-use crate::WalletConnectCtxImpl;
-
-use common::executor::Timer;
-use common::log::{debug, error, info};
-use futures::channel::mpsc::{UnboundedReceiver, UnboundedSender};
-use futures::StreamExt;
+use common::log::{debug, error};
+use futures::channel::mpsc::UnboundedSender;
 use relay_client::error::ClientError;
 use relay_client::websocket::{CloseFrame, ConnectionHandler, PublishedMessage};
 
@@ -64,35 +60,6 @@ impl ConnectionHandler for Handler {
         debug!("[{}] outbound error: {error}", self.name);
         if let Err(e) = self.conn_live_sender.unbounded_send(Some(error.to_string())) {
             error!("[{}] failed to send to the receiver: {e}", self.name);
-        }
-    }
-}
-
-/// Handles unexpected disconnections from WalletConnect relay server.
-/// Implements exponential backoff retry mechanism for reconnection attempts.
-/// After successful reconnection, resubscribes to previous topics to restore full functionality.
-pub(crate) async fn handle_disconnections(
-    this: &WalletConnectCtxImpl,
-    mut connection_live_rx: UnboundedReceiver<Option<String>>,
-) {
-    let mut backoff = 1;
-
-    while let Some(msg) = connection_live_rx.next().await {
-        info!("WalletConnect disconnected with message: {msg:?}. Attempting to reconnect...");
-        loop {
-            match this.reconnect_and_subscribe().await {
-                Ok(_) => {
-                    info!("Reconnection process complete.");
-                    backoff = 1;
-                    break;
-                },
-                Err(e) => {
-                    error!("Reconnection attempt failed: {:?}. Retrying in {:?}...", e, backoff);
-                    Timer::sleep(backoff as f64).await;
-                    // Exponentially increase backoff, but cap it at MAX_BACKOFF
-                    backoff = std::cmp::min(backoff * 2, MAX_BACKOFF);
-                },
-            }
         }
     }
 }

--- a/mm2src/kdf_walletconnect/src/lib.rs
+++ b/mm2src/kdf_walletconnect/src/lib.rs
@@ -632,8 +632,6 @@ impl WalletConnectCtxImpl {
     where
         R: DeserializeOwned,
     {
-        self.await_connection().await?;
-
         let session_topic = session_topic.into();
         self.session_manager.validate_session_exists(&session_topic)?;
 
@@ -662,7 +660,6 @@ impl WalletConnectCtxImpl {
 
     // Destroy WC session.
     pub async fn drop_session(&self, topic: &Topic) -> MmResult<(), WalletConnectError> {
-        self.await_connection().await?;
         send_session_delete_request(self, topic).await
     }
 }

--- a/mm2src/kdf_walletconnect/src/lib.rs
+++ b/mm2src/kdf_walletconnect/src/lib.rs
@@ -51,7 +51,6 @@ const CONNECTION_TIMEOUT_S: f64 = 30.;
 /// Broadcast by the lifecycle task so every RPC can cheaply await connectivity.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ConnectionState {
-    Connecting,
     Connected,
     Disconnected,
 }
@@ -194,9 +193,6 @@ impl WalletConnectCtxImpl {
         }
 
         loop {
-            let _ = connection_state_tx.send(ConnectionState::Connecting);
-            info!("WalletConnect: connecting…");
-
             let mut backoff = 1;
             while let Err(e) = self.connect_and_subscribe().await {
                 error!("Connection attempt failed: {e:?}; retrying in {backoff}s");

--- a/mm2src/kdf_walletconnect/src/lib.rs
+++ b/mm2src/kdf_walletconnect/src/lib.rs
@@ -212,6 +212,7 @@ impl WalletConnectCtxImpl {
                 connection_state_tx.send(ConnectionState::Disconnected).error_log();
             } else {
                 connection_state_tx.send(ConnectionState::Disconnected).error_log();
+                self.abortable_system.abort_all().error_log();
                 break;
             }
         }

--- a/mm2src/kdf_walletconnect/src/lib.rs
+++ b/mm2src/kdf_walletconnect/src/lib.rs
@@ -7,15 +7,13 @@ mod metadata;
 pub mod session;
 mod storage;
 
-use crate::connection_handler::{handle_disconnections, MAX_BACKOFF};
+use crate::connection_handler::{Handler, MAX_BACKOFF};
 use crate::session::rpc::propose::send_proposal_request;
 use chain::{WcChainId, WcRequestMethods, SUPPORTED_PROTOCOL};
 use common::custom_futures::timeout::FutureTimerExt;
 use common::executor::abortable_queue::AbortableQueue;
-use common::executor::{AbortableSystem, Timer};
-use common::log::{debug, info, LogOnError};
-use common::{executor::SpawnFuture, log::error};
-use connection_handler::Handler;
+use common::executor::{AbortableSystem, SpawnFuture, Timer};
+use common::log::{debug, error, info, LogOnError};
 use error::WalletConnectError;
 use futures::channel::mpsc::{unbounded, UnboundedReceiver};
 use futures::StreamExt;
@@ -39,16 +37,24 @@ use session::{key::SymKeyPair, SessionManager};
 use session::{EncodingAlgo, Session, SessionProperties, FIVE_MINUTES};
 use std::collections::BTreeSet;
 use std::ops::Deref;
-use std::{sync::{Arc, Mutex},
-          time::Duration};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use storage::SessionStorageDb;
 use storage::WalletConnectStorageOps;
 use timed_map::TimedMap;
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, watch};
 use wc_common::{decode_and_decrypt_type0, encrypt_and_encode, EnvelopeType, SymKey};
 
 const PUBLISH_TIMEOUT_SECS: f64 = 6.;
-const MAX_RETRIES: usize = 5;
+const CONNECTION_TIMEOUT_S: f64 = 30.;
+
+/// Broadcast by the lifecycle task so every RPC can cheaply await connectivity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConnectionState {
+    Connecting,
+    Connected,
+    Disconnected,
+}
 
 #[async_trait::async_trait]
 pub trait WalletConnectOps {
@@ -92,6 +98,7 @@ pub struct WalletConnectCtxImpl {
     message_id_generator: MessageIdGenerator,
     pending_requests: Mutex<TimedMap<MessageId, oneshot::Sender<SessionMessageType>>>,
     abortable_system: AbortableQueue,
+    connection_state_rx: watch::Receiver<ConnectionState>,
 }
 
 /// A newtype wrapper around a thread-safe reference to `WalletConnectCtxImpl`.
@@ -117,6 +124,7 @@ impl WalletConnectCtx {
         };
         let (inbound_message_tx, inbound_message_rx) = unbounded();
         let (conn_live_sender, conn_live_receiver) = unbounded();
+        let (connection_state_tx, connection_state_rx) = watch::channel(ConnectionState::Disconnected);
         let (client, _) = Client::new_with_callback(
             Handler::new("KDF", inbound_message_tx, conn_live_sender),
             |receiver, handler| {
@@ -137,13 +145,15 @@ impl WalletConnectCtx {
             pending_requests: Default::default(),
             message_id_generator,
             abortable_system,
+            connection_state_rx,
         });
 
-        // Connect to relayer client and spawn a watcher loop for disconnection.
-        context
-            .abortable_system
-            .weak_spawner()
-            .spawn(context.clone().spawn_connection_initialization_fut(conn_live_receiver));
+        // Spawn the relayer connection lifecycle task.
+        context.abortable_system.weak_spawner().spawn(
+            context
+                .clone()
+                .connection_lifecycle_task(conn_live_receiver, connection_state_tx),
+        );
 
         // spawn message handler event loop
         context
@@ -163,42 +173,68 @@ impl WalletConnectCtx {
 }
 
 impl WalletConnectCtxImpl {
-    /// Establishes initial connection to WalletConnect relay server with linear retry mechanism.
-    /// Uses increasing delay between retry attempts starting from 1sec and increase exponentially.
-    /// After successful connection, attempts to restore previous session state from storage.
-    pub(crate) async fn spawn_connection_initialization_fut(
+    /// Centralised task owning **all** connection logic (connect → monitor → reconnect).
+    async fn connection_lifecycle_task(
         self: Arc<Self>,
-        connection_live_rx: UnboundedReceiver<Option<String>>,
+        mut conn_status_rx: UnboundedReceiver<Option<String>>,
+        connection_state_tx: watch::Sender<ConnectionState>,
     ) {
-        info!("Initializing WalletConnect connection");
-        let mut retry_count = 0;
-        let mut retry_secs = 1;
-
-        // Connect to WalletConnect relay client(retry until successful) before proceeeding with other initializations.
-        while let Err(err) = self.connect_client().await {
-            retry_count += 1;
-            error!(
-                "Error during initial connection attempt {}: {:?}. Retrying in {retry_secs} seconds...",
-                retry_count, err
-            );
-            Timer::sleep(retry_secs as f64).await;
-            retry_secs = std::cmp::min(retry_secs * 2, MAX_BACKOFF);
-        }
-
-        // Initialize storage
         if let Err(err) = self.session_manager.storage().init().await {
             error!("Failed to initialize WalletConnect storage, shutting down: {err:?}");
+            let _ = connection_state_tx.send(ConnectionState::Disconnected);
             self.abortable_system.abort_all().error_log();
-        };
+            return;
+        }
 
-        // load session from storage
-        if let Err(err) = self.load_session_from_storage().await {
+        if let Err(err) = self.load_sessions_from_storage().await {
             error!("Failed to load sessions from storage, shutting down: {err:?}");
+            let _ = connection_state_tx.send(ConnectionState::Disconnected);
             self.abortable_system.abort_all().error_log();
-        };
+            return;
+        }
 
-        // Spawn session disconnection watcher.
-        handle_disconnections(&self, connection_live_rx).await;
+        loop {
+            let _ = connection_state_tx.send(ConnectionState::Connecting);
+            info!("WalletConnect: connecting…");
+
+            let mut backoff = 1;
+            while let Err(e) = self.connect_and_subscribe().await {
+                error!("Connection attempt failed: {e:?}; retrying in {backoff}s");
+                Timer::sleep(backoff as f64).await;
+                backoff = std::cmp::min(backoff * 2, MAX_BACKOFF);
+            }
+
+            let _ = connection_state_tx.send(ConnectionState::Connected);
+            info!("WalletConnect: online.");
+
+            if let Some(msg) = conn_status_rx.next().await {
+                info!("WalletConnect: disconnected with message: {msg:?}, will reconnect.");
+            } else {
+                // This handles the case where the channel is closed (equivalent to the original .is_none() check)
+                let _ = connection_state_tx.send(ConnectionState::Disconnected);
+                break;
+            }
+        }
+    }
+
+    /// Synchronously fetches the current state or waits until `Connected`.
+    async fn await_connection(&self) -> MmResult<(), WalletConnectError> {
+        if *self.connection_state_rx.borrow() == ConnectionState::Connected {
+            return Ok(());
+        }
+
+        let mut rx = self.connection_state_rx.clone();
+        Box::pin(rx.changed())
+            .timeout_secs(CONNECTION_TIMEOUT_S)
+            .await
+            .map_to_mm(|_| WalletConnectError::TimeoutError)?
+            .map_to_mm(|e| WalletConnectError::InternalError(format!("Connection task dropped: {e}")))?;
+
+        if *rx.borrow() == ConnectionState::Connected {
+            Ok(())
+        } else {
+            MmError::err(WalletConnectError::ClientError("failed to connect".to_owned()))
+        }
     }
 
     /// Attempt to connect to a wallet connection relay server.
@@ -217,8 +253,8 @@ impl WalletConnectCtxImpl {
         Ok(())
     }
 
-    /// Re-connect to WalletConnect relayer and re-subscribes to previously active session topics after reconnection.
-    pub(crate) async fn reconnect_and_subscribe(&self) -> MmResult<(), WalletConnectError> {
+    /// Connects to WalletConnect relayer and re-subscribes to previously active session topics if it's a reconnection.
+    pub(crate) async fn connect_and_subscribe(&self) -> MmResult<(), WalletConnectError> {
         self.connect_client().await?;
         let sessions = self
             .session_manager
@@ -239,6 +275,8 @@ impl WalletConnectCtxImpl {
         required_namespaces: serde_json::Value,
         optional_namespaces: Option<serde_json::Value>,
     ) -> MmResult<String, WalletConnectError> {
+        self.await_connection().await?;
+
         let required_namespaces = serde_json::from_value(required_namespaces)?;
         let optional_namespaces = match optional_namespaces {
             Some(value) => serde_json::from_value(value)?,
@@ -248,26 +286,18 @@ impl WalletConnectCtxImpl {
 
         info!("[{topic}] Subscribing to topic");
 
-        for attempt in 0..MAX_RETRIES {
-            match self
-                .client
-                .subscribe(topic.clone())
-                .timeout_secs(PUBLISH_TIMEOUT_SECS)
-                .await
-            {
-                Ok(res) => {
-                    res.map_to_mm(|err| err.into())?;
-                    info!("[{topic}] Subscribed to topic");
-                    send_proposal_request(self, &topic, required_namespaces, optional_namespaces).await?;
-                    return Ok(url);
-                },
-                Err(_) => self.wait_until_client_is_online_loop(attempt).await,
-            }
-        }
+        self.client
+            .subscribe(topic.clone())
+            .timeout_secs(PUBLISH_TIMEOUT_SECS)
+            .await
+            .map_to_mm(|_| WalletConnectError::TimeoutError)?
+            .map_to_mm(|e| e)?;
 
-        MmError::err(WalletConnectError::InternalError(
-            "client connection timeout".to_string(),
-        ))
+        info!("[{topic}] Subscribed to topic");
+
+        send_proposal_request(self, &topic, required_namespaces, optional_namespaces).await?;
+
+        Ok(url)
     }
 
     /// Get symmetric key associated with a for `topic`.
@@ -312,7 +342,7 @@ impl WalletConnectCtxImpl {
     }
 
     /// Loads sessions from storage, activates valid ones, and deletes expired.
-    async fn load_session_from_storage(&self) -> MmResult<(), WalletConnectError> {
+    async fn load_sessions_from_storage(&self) -> MmResult<(), WalletConnectError> {
         info!("Loading WalletConnect session from storage");
         let now = chrono::Utc::now().timestamp() as u64;
         let sessions = self
@@ -321,8 +351,6 @@ impl WalletConnectCtxImpl {
             .get_all_sessions()
             .await
             .mm_err(|err| WalletConnectError::StorageError(err.to_string()))?;
-        let mut valid_topics = Vec::with_capacity(sessions.len());
-        let mut pairing_topics = Vec::with_capacity(sessions.len());
 
         // bring most recent active session to the back.
         for session in sessions.into_iter().rev() {
@@ -337,19 +365,8 @@ impl WalletConnectCtxImpl {
                 continue;
             };
 
-            let topic = session.topic.clone();
-            let pairing_topic = session.pairing_topic.clone();
-            debug!("[{topic}] Session found! activating");
+            debug!("[{}] Session found! activating", session.topic);
             self.session_manager.add_session(session);
-
-            valid_topics.push(topic);
-            pairing_topics.push(pairing_topic);
-        }
-
-        let all_topics = valid_topics.into_iter().chain(pairing_topics).collect::<Vec<_>>();
-
-        if !all_topics.is_empty() {
-            self.client.batch_subscribe(all_topics).await?;
         }
 
         info!("Loaded WalletConnect session from storage");
@@ -429,6 +446,8 @@ impl WalletConnectCtxImpl {
         irn_metadata: IrnMetadata,
         payload: Payload,
     ) -> MmResult<(), WalletConnectError> {
+        self.await_connection().await?;
+
         info!("[{topic}] Publishing message={payload:?}");
         let message = {
             let sym_key = self.sym_key(topic)?;
@@ -436,52 +455,22 @@ impl WalletConnectCtxImpl {
             encrypt_and_encode(EnvelopeType::Type0, payload, &sym_key)?
         };
 
-        for attempt in 0..MAX_RETRIES {
-            match self
-                .client
-                .publish(
-                    topic.clone(),
-                    &*message,
-                    None,
-                    irn_metadata.tag,
-                    Duration::from_secs(irn_metadata.ttl),
-                    irn_metadata.prompt,
-                )
-                .timeout_secs(PUBLISH_TIMEOUT_SECS)
-                .await
-            {
-                Ok(Ok(_)) => {
-                    info!("[{topic}] Message published successfully");
-                    return Ok(());
-                },
-                Ok(Err(err)) => return MmError::err(err.into()),
-                Err(_) => self.wait_until_client_is_online_loop(attempt).await,
-            }
-        }
+        self.client
+            .publish(
+                topic.clone(),
+                &*message,
+                None,
+                irn_metadata.tag,
+                Duration::from_secs(irn_metadata.ttl),
+                irn_metadata.prompt,
+            )
+            .timeout_secs(PUBLISH_TIMEOUT_SECS)
+            .await
+            .map_to_mm(|_| WalletConnectError::TimeoutError)?
+            .map_to_mm(|e| e)?;
 
-        MmError::err(WalletConnectError::InternalError(
-            "[{topic}] client connection timeout".to_string(),
-        ))
-    }
-
-    /// Persistent reconnection and retry strategy keeps the WebSocket connection active,
-    /// allowing the client to automatically resume operations after network interruptions or disconnections.
-    /// Since TCP handles connection timeouts (which can be lengthy and it's determined by the OS), we're using a shorter timeout here
-    /// to detect issues quickly and reconnect as needed.
-    async fn wait_until_client_is_online_loop(&self, attempt: usize) {
-        debug!("Attempt {} failed due to timeout. Reconnecting...", attempt + 1);
-        loop {
-            match self.reconnect_and_subscribe().await {
-                Ok(_) => {
-                    info!("Reconnected and subscribed successfully.");
-                    break;
-                },
-                Err(reconnect_err) => {
-                    error!("Reconnection attempt failed: {reconnect_err:?}. Retrying...");
-                    Timer::sleep(1.5).await;
-                },
-            }
-        }
+        info!("[{topic}] Message published successfully");
+        Ok(())
     }
 
     /// Checks if the current session is connected to a Ledger device.
@@ -638,6 +627,8 @@ impl WalletConnectCtxImpl {
     where
         R: DeserializeOwned,
     {
+        self.await_connection().await?;
+
         let session_topic = session_topic.into();
         self.session_manager.validate_session_exists(&session_topic)?;
 
@@ -666,6 +657,7 @@ impl WalletConnectCtxImpl {
 
     // Destroy WC session.
     pub async fn drop_session(&self, topic: &Topic) -> MmResult<(), WalletConnectError> {
+        self.await_connection().await?;
         send_session_delete_request(self, topic).await
     }
 }


### PR DESCRIPTION
This PR fixes a critical race condition in the WalletConnect module that causes `Client(WebsocketClient(NotConnected))` errors during initialization, particularly for the `wc_new_connection` RPC call.

### The Problem
As reported in https://github.com/KomodoPlatform/komodo-defi-framework/issues/2505, network operations could be attempted before the WebSocket connection was fully established or immediately after it was dropped. This resulted in an immediate failure with the following error, instead of returning a valid session URL:
```json
{
    "error": "Subscription Error: Client(WebsocketClient(NotConnected))",
    "error_type": "SessionRequestError"
}
```
This was a regression traced back to recent changes in https://github.com/KomodoPlatform/komodo-defi-framework/pull/2485 that decoupled WalletConnect initialization from KDF initialization.

### The Solution
This PR resolves the issue by refactoring the connection management logic into a robust, centralized state machine. The scattered, per-function retry loops have been removed in favor of a more reliable architecture.

The key changes are:

1. Centralized `connection_lifecycle_task`: A single background task now owns the entire connection lifecycle. It is the single source of truth for the connection status and handles initial connection, monitoring for disconnects, and reconnection with exponential backoff.

2. State Broadcast via watch Channel: The lifecycle task broadcasts the current connection status (Connecting, Connected, Disconnected) to the rest of the application using a `tokio::sync::watch` channel.

3. `await_connection` Gatekeeper: All network-dependent functions (like `publish_payload`, `new_connection`, etc.) now first call the `await_connection` helper. This function acts as a gatekeeper, pausing execution until it receives a Connected signal from the lifecycle task.

This new architecture completely eliminates the race condition by ensuring that no network operation can be attempted unless the connection is confirmed to be active. This makes the connection handling more resilient and easier to maintain.

Fixes https://github.com/KomodoPlatform/komodo-defi-framework/issues/2505