### PR TITLE
fix(eth): correctly implement EVM max withdrawal logic

### DIFF
--- a/mm2src/coins/eth/eth_withdraw.rs
+++ b/mm2src/coins/eth/eth_withdraw.rs
@@ -259,7 +259,7 @@ where
             data.clone().into(),
             my_address,
             call_addr,
-            false,
+            req.max,
         )
         .await
         .map_mm_err()?;

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -3295,6 +3295,7 @@ impl From<EthGasDetailsErr> for WithdrawError {
     fn from(e: EthGasDetailsErr) -> Self {
         match e {
             EthGasDetailsErr::InvalidFeePolicy(e) => WithdrawError::InvalidFeePolicy(e),
+            EthGasDetailsErr::AmountTooLow { amount, threshold } => WithdrawError::AmountTooLow { amount, threshold },
             EthGasDetailsErr::Internal(e) => WithdrawError::InternalError(e),
             EthGasDetailsErr::Transport(e) => WithdrawError::Transport(e),
             EthGasDetailsErr::NftProtocolNotSupported => WithdrawError::NftProtocolNotSupported,


### PR DESCRIPTION
EVM max withdrawals (`max: true`) were fundamentally broken. The `max` flag was hardcoded to `false` when calling the gas estimation helper, meaning the special logic for calculating a max-amount transaction was never triggered.

This commit corrects the primary bug by passing the proper `req.max` value.

Fixing this initial issue revealed two subsequent failure modes when a user's balance was insufficient to cover gas fees, which this fix also resolves:

1.  **Panic on Low Balance:** If the balance was less than the hardcoded fee estimate, the code would panic due to arithmetic underflow. This is now prevented by using `checked_sub().unwrap_or_default()`.

2.  **Cryptic RPC Errors:** If the balance was slightly higher but still too low for gas, the `eth_estimateGas` RPC call would fail with an unhelpful error like "gas required exceeds allowance". This is now gracefully handled by catching known "insufficient funds" error strings and mapping them to a user-friendly `WithdrawError::AmountTooLow`.