### PR TITLE
fix(WASM and Debian): fix build failures

### DIFF
--- a/.docker/Dockerfile.ci-container
+++ b/.docker/Dockerfile.ci-container
@@ -1,4 +1,4 @@
-FROM docker.io/debian:buster-slim
+FROM docker.io/debian:bullseye-slim
 
 MAINTAINER Onur Özkan <onur@komodoplatform.com>
 

--- a/mm2src/coins/z_coin/storage/blockdb/blockdb_idb_storage.rs
+++ b/mm2src/coins/z_coin/storage/blockdb/blockdb_idb_storage.rs
@@ -9,6 +9,7 @@ use mm2_core::mm_ctx::MmArc;
 use mm2_db::indexed_db::{BeBigUint, ConstructibleDb, DbIdentifier, DbInstance, DbLocked, DbUpgrader, IndexedDb,
                          IndexedDbBuilder, InitDbResult, MultiIndex, OnUpgradeResult, TableSignature};
 use mm2_err_handle::prelude::*;
+use mm2_event_stream::DeriveStreamerId;
 use protobuf::Message;
 use zcash_client_backend::proto::compact_formats::CompactBlock;
 use zcash_extras::WalletRead;


### PR DESCRIPTION
I missed the WASM problem while reviewing https://github.com/KomodoPlatform/komodo-defi-framework/pull/2489 (CI is not being properly run on external PRs :/).

Also, `komodoofficial/ci-container` image has been updated to use Debian 11 as LTS support for Debian 10 has ended and it is no longer working in the CI environment.

