### PR TITLE
fix(ci): adds nodejs 20 to ci-container

### DIFF
--- a/.docker/Dockerfile.ci-container
+++ b/.docker/Dockerfile.ci-container
@@ -1,6 +1,6 @@
 FROM docker.io/debian:bullseye-slim
 
-MAINTAINER Onur Özkan <onur@komodoplatform.com>
+LABEL maintainer="Onur Özkan <onur@komodoplatform.com>"
 
 RUN apt-get update -y
 
@@ -56,6 +56,10 @@ RUN apt-get install -y 	  \
 	docker-ce-cli 		  \
 	containerd.io 		  \
 	docker-buildx-plugin
+
+# --- Added: Install Node.js (needed by JavaScript GitHub Actions such as Swatinem/rust-cache) ---
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 


### PR DESCRIPTION
While working on updates to the notary seed node repo, I noticed https://hub.docker.com/r/komodoofficial/komodo-defi-framework/tags did not appear to be updating with the most recent releases.

The cause of this was found to be [failing GHA runs](https://github.com/KomodoPlatform/komodo-defi-framework/actions/workflows/release-build.yml) due to a lack of nodejs. To resolve this, I added an install step into the ci-container and [pushed an update to dockerhub](https://hub.docker.com/r/komodoofficial/ci-container/tags) as I couldn't see an automated pipeline for that in this repo. 

Once this was done, previously failing builds in `release-build.yml` were successful.