### PR TITLE
fix(HD-Wallet): store & load correct HD Accounts

### DIFF
--- a/mm2src/coins/Cargo.toml
+++ b/mm2src/coins/Cargo.toml
@@ -12,7 +12,7 @@ enable-sia = [
 ]
 default = []
 run-docker-tests = []
-for-tests = ["dep:mocktopus"]
+for-tests = ["dep:mocktopus", "crypto/for-tests"]
 new-db-arch = ["mm2_core/new-db-arch"]
 
 # Temporary feature for implementing IBC wrap/unwrap mechanism and will be removed

--- a/mm2src/coins/eth/eth_withdraw.rs
+++ b/mm2src/coins/eth/eth_withdraw.rs
@@ -94,12 +94,12 @@ where
     #[allow(clippy::result_large_err)]
     fn get_from_derivation_path(&self, from: &HDAddressSelector) -> Result<DerivationPath, MmError<WithdrawError>> {
         let coin = self.coin();
-        let path_to_coin = &coin
+        let path_to_coin = coin
             .deref()
             .derivation_method
             .hd_wallet_or_err()
             .map_mm_err()?
-            .derivation_path;
+            .derivation_path();
         let path_to_address = from
             .to_address_path(path_to_coin.coin_type())
             .mm_err(|err| WithdrawError::UnexpectedFromAddress(err.to_string()))

--- a/mm2src/coins/eth/v2_activation.rs
+++ b/mm2src/coins/eth/v2_activation.rs
@@ -771,9 +771,7 @@ pub(crate) async fn build_address_and_priv_key_policy(
             let accounts = load_hd_accounts_from_storage(&hd_wallet_storage).await.map_mm_err()?;
             let gap_limit = gap_limit.unwrap_or(DEFAULT_GAP_LIMIT);
             let hd_wallet = EthHDWallet {
-                hd_wallet_rmd160,
                 hd_wallet_storage,
-                derivation_path: path_to_coin.clone(),
                 accounts: HDAccountsMutex::new(accounts),
                 enabled_address: *path_to_address,
                 gap_limit,
@@ -801,15 +799,9 @@ pub(crate) async fn build_address_and_priv_key_policy(
                 .mm_err(EthActivationV2Error::from)?;
             let accounts = load_hd_accounts_from_storage(&hd_wallet_storage).await.map_mm_err()?;
             let gap_limit = gap_limit.unwrap_or(DEFAULT_GAP_LIMIT);
-            let crypto_ctx = CryptoCtx::from_ctx(ctx).map_mm_err()?;
-            let hw_ctx = crypto_ctx
-                .hw_ctx()
-                .or_mm_err(|| EthActivationV2Error::HwContextNotInitialized)?;
-            let hd_wallet_rmd160 = hw_ctx.rmd160();
+
             let hd_wallet = EthHDWallet {
-                hd_wallet_rmd160,
                 hd_wallet_storage,
-                derivation_path: path_to_coin.clone(),
                 accounts: HDAccountsMutex::new(accounts),
                 enabled_address: *path_to_address,
                 gap_limit,

--- a/mm2src/coins/eth/v2_activation.rs
+++ b/mm2src/coins/eth/v2_activation.rs
@@ -768,9 +768,7 @@ pub(crate) async fn build_address_and_priv_key_policy(
                 HDWalletCoinStorage::init_with_rmd160(ctx, ticker.to_string(), path_to_coin.clone(), hd_wallet_rmd160)
                     .await
                     .mm_err(EthActivationV2Error::from)?;
-            let accounts = load_hd_accounts_from_storage(&hd_wallet_storage, &path_to_coin)
-                .await
-                .map_mm_err()?;
+            let accounts = load_hd_accounts_from_storage(&hd_wallet_storage).await.map_mm_err()?;
             let gap_limit = gap_limit.unwrap_or(DEFAULT_GAP_LIMIT);
             let hd_wallet = EthHDWallet {
                 hd_wallet_rmd160,
@@ -801,9 +799,7 @@ pub(crate) async fn build_address_and_priv_key_policy(
             let hd_wallet_storage = HDWalletCoinStorage::init_with_hw(ctx, ticker.to_string(), path_to_coin.clone())
                 .await
                 .mm_err(EthActivationV2Error::from)?;
-            let accounts = load_hd_accounts_from_storage(&hd_wallet_storage, &path_to_coin)
-                .await
-                .map_mm_err()?;
+            let accounts = load_hd_accounts_from_storage(&hd_wallet_storage).await.map_mm_err()?;
             let gap_limit = gap_limit.unwrap_or(DEFAULT_GAP_LIMIT);
             let crypto_ctx = CryptoCtx::from_ctx(ctx).map_mm_err()?;
             let hw_ctx = crypto_ctx

--- a/mm2src/coins/hd_wallet/mod.rs
+++ b/mm2src/coins/hd_wallet/mod.rs
@@ -4,7 +4,6 @@ use crypto::{Bip32DerPathOps, Bip32Error, Bip44Chain, ChildNumber, DerivationPat
              Secp256k1ExtendedPublicKey, StandardHDPath, StandardHDPathError};
 use futures::lock::{MappedMutexGuard as AsyncMappedMutexGuard, Mutex as AsyncMutex, MutexGuard as AsyncMutexGuard};
 use mm2_err_handle::prelude::*;
-use primitives::hash::H160;
 use serde::Serialize;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Display;
@@ -277,18 +276,9 @@ pub struct HDWallet<HDAccount>
 where
     HDAccount: HDAccountOps + Clone + Send + Sync,
 {
-    /// A unique identifier for the HD wallet derived from the master public key.
-    /// Specifically, it's the RIPEMD160 hash of the SHA256 hash of the master pubkey.
-    /// This property aids in storing database items uniquely for each HD wallet.
-    pub hd_wallet_rmd160: H160,
     /// Provides a means to access database operations for a specific user, HD wallet, and coin.
     /// The storage wrapper associates with the `coin` and `hd_wallet_rmd160` to provide unique storage access.
     pub hd_wallet_storage: HDWalletCoinStorage,
-    /// Derivation path of the coin.
-    /// This derivation path consists of `purpose` and `coin_type` only
-    /// where the full `BIP44` address has the following structure:
-    /// `m/purpose'/coin_type'/account'/change/address_index`.
-    pub derivation_path: HDPathToCoin,
     /// Contains information about the accounts enabled for this HD wallet.
     pub accounts: HDAccountsMutex<HDAccount>,
     // Todo: This should be removed in the future to enable simultaneous swaps from multiple addresses
@@ -307,9 +297,9 @@ where
 {
     type HDAccount = HDAccount;
 
-    fn coin_type(&self) -> u32 { self.derivation_path.coin_type() }
+    fn coin_type(&self) -> u32 { self.derivation_path().coin_type() }
 
-    fn derivation_path(&self) -> &HDPathToCoin { &self.derivation_path }
+    fn derivation_path(&self) -> &HDPathToCoin { self.hd_wallet_storage.path_to_coin() }
 
     fn gap_limit(&self) -> u32 { self.gap_limit }
 

--- a/mm2src/coins/hd_wallet/mod.rs
+++ b/mm2src/coins/hd_wallet/mod.rs
@@ -244,7 +244,6 @@ where
 
 pub async fn load_hd_accounts_from_storage<HDAddress, ExtendedPublicKey>(
     hd_wallet_storage: &HDWalletCoinStorage,
-    derivation_path: &HDPathToCoin,
 ) -> HDWalletStorageResult<HDAccountsMap<HDAccount<HDAddress, ExtendedPublicKey>>>
 where
     HDAddress: HDAddressOps + Send,
@@ -255,7 +254,7 @@ where
     let res: HDWalletStorageResult<HDAccountsMap<HDAccount<HDAddress, ExtendedPublicKey>>> = accounts
         .iter()
         .map(|account_info| {
-            let account = HDAccount::try_from_storage_item(derivation_path, account_info)?;
+            let account = HDAccount::try_from_storage_item(hd_wallet_storage.path_to_coin(), account_info)?;
             Ok((account.account_id, account))
         })
         .collect();

--- a/mm2src/coins/hd_wallet/storage/mod.rs
+++ b/mm2src/coins/hd_wallet/storage/mod.rs
@@ -227,7 +227,7 @@ impl Default for HDWalletCoinStorage {
     fn default() -> Self {
         HDWalletCoinStorage {
             coin: String::default(),
-            path_to_coin: HDPathToCoin::default_for_test(),
+            path_to_coin: HDPathToCoin::default_for_test(0),
             hd_wallet_rmd160: H160::default(),
             inner: Box::new(HDWalletMockStorage),
         }
@@ -360,17 +360,18 @@ mod tests {
         let device0_rmd160 = H160::from("0000000000000000000000000000000000000020");
         let device1_rmd160 = H160::from("0000000000000000000000000000000000000030");
 
-        let dummy_path_to_coin = HDPathToCoin::default_for_test();
+        let rick_path_to_coin = HDPathToCoin::default_for_test(0);
         let rick_device0_db =
-            HDWalletCoinStorage::init_with_rmd160(&ctx, "RICK".to_owned(), dummy_path_to_coin.clone(), device0_rmd160)
+            HDWalletCoinStorage::init_with_rmd160(&ctx, "RICK".to_owned(), rick_path_to_coin.clone(), device0_rmd160)
                 .await
                 .expect("!HDWalletCoinStorage::new");
         let rick_device1_db =
-            HDWalletCoinStorage::init_with_rmd160(&ctx, "RICK".to_owned(), dummy_path_to_coin.clone(), device1_rmd160)
+            HDWalletCoinStorage::init_with_rmd160(&ctx, "RICK".to_owned(), rick_path_to_coin, device1_rmd160)
                 .await
                 .expect("!HDWalletCoinStorage::new");
+        let morty_path_to_coin = HDPathToCoin::default_for_test(1);
         let morty_device0_db =
-            HDWalletCoinStorage::init_with_rmd160(&ctx, "MORTY".to_owned(), dummy_path_to_coin, device0_rmd160)
+            HDWalletCoinStorage::init_with_rmd160(&ctx, "MORTY".to_owned(), morty_path_to_coin, device0_rmd160)
                 .await
                 .expect("!HDWalletCoinStorage::new");
 
@@ -456,7 +457,7 @@ mod tests {
         let device1_rmd160 = H160::from("0000000000000000000000000000000000000020");
         let device2_rmd160 = H160::from("0000000000000000000000000000000000000030");
 
-        let dummy_path_to_coin = HDPathToCoin::default_for_test();
+        let dummy_path_to_coin = HDPathToCoin::default_for_test(0);
         let wallet0_db =
             HDWalletCoinStorage::init_with_rmd160(&ctx, "RICK".to_owned(), dummy_path_to_coin.clone(), device0_rmd160)
                 .await
@@ -519,7 +520,7 @@ mod tests {
         let ctx = mm_ctx_with_custom_db();
         let device_rmd160 = H160::from("0000000000000000000000000000000000000010");
 
-        let dummy_path_to_coin = HDPathToCoin::default_for_test();
+        let dummy_path_to_coin = HDPathToCoin::default_for_test(0);
         let db = HDWalletCoinStorage::init_with_rmd160(&ctx, "RICK".to_owned(), dummy_path_to_coin, device_rmd160)
             .await
             .expect("!HDWalletCoinStorage::new");

--- a/mm2src/coins/hd_wallet/storage/mod.rs
+++ b/mm2src/coins/hd_wallet/storage/mod.rs
@@ -262,6 +262,8 @@ impl HDWalletCoinStorage {
         })
     }
 
+    pub fn path_to_coin(&self) -> &HDPathToCoin { &self.path_to_coin }
+
     pub fn wallet_id(&self) -> HDWalletId {
         HDWalletId::new(self.coin.clone(), self.path_to_coin.clone(), &self.hd_wallet_rmd160)
     }

--- a/mm2src/coins/hd_wallet/storage/sqlite_storage.rs
+++ b/mm2src/coins/hd_wallet/storage/sqlite_storage.rs
@@ -39,20 +39,20 @@ const MIGRATION_1: &str = "
 ";
 
 const INSERT_ACCOUNT: &str = "INSERT INTO hd_account
-    (coin, hd_wallet_rmd160, account_id, account_xpub, external_addresses_number, internal_addresses_number)
-    VALUES (:coin, :hd_wallet_rmd160, :account_id, :account_xpub, :external_addresses_number, :internal_addresses_number);";
+    (coin, hd_wallet_rmd160, purpose, coin_type, account_id, account_xpub, external_addresses_number, internal_addresses_number)
+    VALUES (:coin, :hd_wallet_rmd160, :purpose, :coin_type, :account_id, :account_xpub, :external_addresses_number, :internal_addresses_number);";
 
 const DELETE_ACCOUNTS_BY_WALLET_ID: &str =
-    "DELETE FROM hd_account WHERE coin=:coin AND hd_wallet_rmd160=:hd_wallet_rmd160;";
+    "DELETE FROM hd_account WHERE hd_wallet_rmd160=:hd_wallet_rmd160 AND purpose=:purpose AND coin_type=:coin_type;";
 
 const SELECT_ACCOUNT: &str = "SELECT account_id, account_xpub, external_addresses_number, internal_addresses_number
     FROM hd_account
-    WHERE coin=:coin AND hd_wallet_rmd160=:hd_wallet_rmd160 AND account_id=:account_id;";
+    WHERE hd_wallet_rmd160=:hd_wallet_rmd160 AND purpose=:purpose AND coin_type=:coin_type AND account_id=:account_id;";
 
 const SELECT_ACCOUNTS_BY_WALLET_ID: &str =
     "SELECT account_id, account_xpub, external_addresses_number, internal_addresses_number
     FROM hd_account
-    WHERE coin=:coin AND hd_wallet_rmd160=:hd_wallet_rmd160;";
+    WHERE hd_wallet_rmd160=:hd_wallet_rmd160 AND purpose=:purpose AND coin_type=:coin_type;";
 
 impl From<SqlError> for HDWalletStorageError {
     fn from(e: SqlError) -> Self {
@@ -101,6 +101,8 @@ impl HDWalletId {
         owned_named_params! {
             ":coin": self.coin.clone(),
             ":hd_wallet_rmd160": self.hd_wallet_rmd160.clone(),
+            ":purpose": self.path_to_coin.purpose() as u32,
+            ":coin_type": self.path_to_coin.coin_type(),
         }
     }
 }
@@ -324,7 +326,7 @@ impl HDWalletSqliteStorage {
         new_addresses_number: u32,
     ) -> HDWalletStorageResult<()> {
         let sql = format!(
-            "UPDATE hd_account SET {updating_property}=:new_value WHERE coin=:coin AND hd_wallet_rmd160=:hd_wallet_rmd160 AND account_id=:account_id;",
+            "UPDATE hd_account SET {updating_property}=:new_value WHERE hd_wallet_rmd160=:hd_wallet_rmd160 AND purpose=:purpose AND coin_type=:coin_type AND account_id=:account_id;",
         );
 
         let selfi = self.clone();

--- a/mm2src/coins/hd_wallet/storage/wasm_storage.rs
+++ b/mm2src/coins/hd_wallet/storage/wasm_storage.rs
@@ -12,13 +12,11 @@ use mm2_err_handle::prelude::*;
 
 const DB_VERSION: u32 = 2;
 /// An index of the `HDAccountTable` table that consists of the following properties:
-/// * coin - coin ticker
 /// * purpose - the purpose of the HD account
 /// * coin_type - the coin type of the HD account
 /// * hd_wallet_rmd160 - RIPEMD160(SHA256(x)) where x is a pubkey extracted from a Hardware Wallet device or passphrase.
 const WALLET_ID_INDEX: &str = "wallet_id";
 /// A **unique** index of the `HDAccountTable` table that consists of the following properties:
-/// * coin - coin ticker
 /// * purpose - the purpose of the HD account
 /// * coin_type - the coin type of the HD account
 /// * hd_wallet_rmd160 - RIPEMD160(SHA256(x)) where x is a pubkey extracted from a Hardware Wallet device or passphrase.
@@ -213,9 +211,11 @@ impl HDWalletStorageInternalOps for HDWalletIndexedDbStorage {
         let table = transaction.table::<HDAccountTable>().await.map_mm_err()?;
 
         let index_keys = MultiIndex::new(WALLET_ID_INDEX)
-            .with_value(wallet_id.coin)
-            .map_mm_err()?
             .with_value(wallet_id.hd_wallet_rmd160)
+            .map_mm_err()?
+            .with_value(wallet_id.path_to_coin.purpose() as u32)
+            .map_mm_err()?
+            .with_value(wallet_id.path_to_coin.coin_type())
             .map_mm_err()?;
         Ok(table
             .get_items_by_multi_index(index_keys)
@@ -295,9 +295,11 @@ impl HDWalletStorageInternalOps for HDWalletIndexedDbStorage {
         let table = transaction.table::<HDAccountTable>().await.map_mm_err()?;
 
         let index_keys = MultiIndex::new(WALLET_ID_INDEX)
-            .with_value(wallet_id.coin)
-            .map_mm_err()?
             .with_value(wallet_id.hd_wallet_rmd160)
+            .map_mm_err()?
+            .with_value(wallet_id.path_to_coin.purpose() as u32)
+            .map_mm_err()?
+            .with_value(wallet_id.path_to_coin.coin_type())
             .map_mm_err()?;
         table.delete_items_by_multi_index(index_keys).await.map_mm_err()?;
         Ok(())
@@ -321,9 +323,11 @@ impl HDWalletIndexedDbStorage {
         account_id: u32,
     ) -> HDWalletStorageResult<Option<(ItemId, HDAccountTable)>> {
         let index_keys = MultiIndex::new(WALLET_ACCOUNT_ID_INDEX)
-            .with_value(wallet_id.coin)
-            .map_mm_err()?
             .with_value(wallet_id.hd_wallet_rmd160)
+            .map_mm_err()?
+            .with_value(wallet_id.path_to_coin.purpose() as u32)
+            .map_mm_err()?
+            .with_value(wallet_id.path_to_coin.coin_type())
             .map_mm_err()?
             .with_value(account_id)
             .map_mm_err()?;

--- a/mm2src/coins/utxo/utxo_builder/utxo_coin_builder.rs
+++ b/mm2src/coins/utxo/utxo_builder/utxo_coin_builder.rs
@@ -326,6 +326,7 @@ pub trait UtxoFieldsWithHardwareWalletBuilder: UtxoCoinBuilderCommonOps {
         let gap_limit = self.gap_limit();
         let hd_wallet = UtxoHDWallet {
             inner: HDWallet {
+                // FIXME: this field is also already stored in `hd_wallet_storage`, so don't duplicate it please.
                 hd_wallet_rmd160,
                 hd_wallet_storage,
                 // FIXME: hd_wallet_storage already store the path to coin. Don't duplicate stuff please.

--- a/mm2src/coins/utxo/utxo_builder/utxo_coin_builder.rs
+++ b/mm2src/coins/utxo/utxo_builder/utxo_coin_builder.rs
@@ -205,10 +205,14 @@ pub trait UtxoFieldsWithGlobalHDBuilder: UtxoCoinBuilderCommonOps {
 
         let address_format = self.address_format()?;
         let hd_wallet_rmd160 = *self.ctx().rmd160();
-        let hd_wallet_storage =
-            HDWalletCoinStorage::init_with_rmd160(self.ctx(), self.ticker().to_owned(), hd_wallet_rmd160)
-                .await
-                .map_mm_err()?;
+        let hd_wallet_storage = HDWalletCoinStorage::init_with_rmd160(
+            self.ctx(),
+            self.ticker().to_owned(),
+            path_to_coin.clone(),
+            hd_wallet_rmd160,
+        )
+        .await
+        .map_mm_err()?;
         let accounts = load_hd_accounts_from_storage(&hd_wallet_storage, path_to_coin)
             .await
             .mm_err(UtxoCoinBuildError::from)?;
@@ -312,7 +316,9 @@ pub trait UtxoFieldsWithHardwareWalletBuilder: UtxoCoinBuilderCommonOps {
             .or_mm_err(|| UtxoConfError::DerivationPathIsNotSet)
             .map_mm_err()?;
 
-        let hd_wallet_storage = HDWalletCoinStorage::init(self.ctx(), ticker).await.map_mm_err()?;
+        let hd_wallet_storage = HDWalletCoinStorage::init_with_hw(self.ctx(), ticker, path_to_coin.clone())
+            .await
+            .map_mm_err()?;
 
         let accounts = load_hd_accounts_from_storage(&hd_wallet_storage, &path_to_coin)
             .await

--- a/mm2src/coins/utxo/utxo_builder/utxo_coin_builder.rs
+++ b/mm2src/coins/utxo/utxo_builder/utxo_coin_builder.rs
@@ -213,7 +213,7 @@ pub trait UtxoFieldsWithGlobalHDBuilder: UtxoCoinBuilderCommonOps {
         )
         .await
         .map_mm_err()?;
-        let accounts = load_hd_accounts_from_storage(&hd_wallet_storage, path_to_coin)
+        let accounts = load_hd_accounts_from_storage(&hd_wallet_storage)
             .await
             .mm_err(UtxoCoinBuildError::from)?;
         let gap_limit = self.gap_limit();
@@ -320,7 +320,7 @@ pub trait UtxoFieldsWithHardwareWalletBuilder: UtxoCoinBuilderCommonOps {
             .await
             .map_mm_err()?;
 
-        let accounts = load_hd_accounts_from_storage(&hd_wallet_storage, &path_to_coin)
+        let accounts = load_hd_accounts_from_storage(&hd_wallet_storage)
             .await
             .mm_err(UtxoCoinBuildError::from)?;
         let gap_limit = self.gap_limit();
@@ -328,6 +328,7 @@ pub trait UtxoFieldsWithHardwareWalletBuilder: UtxoCoinBuilderCommonOps {
             inner: HDWallet {
                 hd_wallet_rmd160,
                 hd_wallet_storage,
+                // FIXME: hd_wallet_storage already store the path to coin. Don't duplicate stuff please.
                 derivation_path: path_to_coin,
                 accounts: HDAccountsMutex::new(accounts),
                 enabled_address: self.activation_params().path_to_address,

--- a/mm2src/coins/utxo/utxo_common_tests.rs
+++ b/mm2src/coins/utxo/utxo_common_tests.rs
@@ -274,9 +274,7 @@ pub(super) async fn test_hd_utxo_tx_history_impl(rpc_client: ElectrumClient) {
     fields.conf.ticker = "DOC".to_string();
     fields.derivation_method = DerivationMethod::HDWallet(UtxoHDWallet {
         inner: HDWallet {
-            hd_wallet_rmd160: "6d9d2b554d768232320587df75c4338ecc8bf37d".into(),
             hd_wallet_storage: HDWalletCoinStorage::default(),
-            derivation_path: HDPathToCoin::from_str("m/44'/141'").unwrap(),
             accounts: HDAccountsMutex::new(hd_accounts),
             enabled_address: HDPathAccountToAddressId::default(),
             gap_limit: 20,

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -4306,9 +4306,7 @@ fn test_account_balance_rpc() {
     });
     fields.derivation_method = DerivationMethod::HDWallet(UtxoHDWallet {
         inner: HDWallet {
-            hd_wallet_rmd160: "21605444b36ec72780bdf52a5ffbc18288893664".into(),
             hd_wallet_storage: HDWalletCoinStorage::default(),
-            derivation_path: HDPathToCoin::from_str("m/44'/141'").unwrap(),
             accounts: HDAccountsMutex::new(hd_accounts),
             enabled_address: HDPathAccountToAddressId::default(),
             gap_limit: 3,
@@ -4638,9 +4636,7 @@ fn test_scan_for_new_addresses() {
     });
     fields.derivation_method = DerivationMethod::HDWallet(UtxoHDWallet {
         inner: HDWallet {
-            hd_wallet_rmd160: "21605444b36ec72780bdf52a5ffbc18288893664".into(),
             hd_wallet_storage: HDWalletCoinStorage::default(),
-            derivation_path: HDPathToCoin::from_str("m/44'/141'").unwrap(),
             accounts: HDAccountsMutex::new(hd_accounts),
             enabled_address: HDPathAccountToAddressId::default(),
             gap_limit: 3,
@@ -4778,9 +4774,7 @@ fn test_get_new_address() {
 
     fields.derivation_method = DerivationMethod::HDWallet(UtxoHDWallet {
         inner: HDWallet {
-            hd_wallet_rmd160: "21605444b36ec72780bdf52a5ffbc18288893664".into(),
             hd_wallet_storage: HDWalletCoinStorage::default(),
-            derivation_path: HDPathToCoin::from_str("m/44'/141'").unwrap(),
             accounts: HDAccountsMutex::new(hd_accounts),
             enabled_address: HDPathAccountToAddressId::default(),
             gap_limit: 2,

--- a/mm2src/crypto/Cargo.toml
+++ b/mm2src/crypto/Cargo.toml
@@ -61,3 +61,4 @@ tokio.workspace = true
 
 [features]
 trezor-udp = ["trezor/trezor-udp"]
+for-tests = []

--- a/mm2src/crypto/src/standard_hd_path.rs
+++ b/mm2src/crypto/src/standard_hd_path.rs
@@ -64,6 +64,19 @@ impl HDPathToCoin {
     pub fn purpose(&self) -> Bip43Purpose { self.value() }
 
     pub fn coin_type(&self) -> u32 { self.child().value() }
+
+    #[cfg(any(target_arch = "wasm32", feature = "for-tests"))]
+    pub fn default_for_test() -> HDPathToCoin {
+        HDPathToCoin {
+            value: Bip32PurposeValue {
+                purpose: Bip43Purpose::Bip84,
+            },
+            child: Bip32Child {
+                value: HardenedValue::from_bip32_number(ChildNumber::new(0, true).unwrap(), 0).unwrap(),
+                child: Bip44Tail,
+            },
+        }
+    }
 }
 
 impl HDPathToAccount {

--- a/mm2src/crypto/src/standard_hd_path.rs
+++ b/mm2src/crypto/src/standard_hd_path.rs
@@ -66,13 +66,13 @@ impl HDPathToCoin {
     pub fn coin_type(&self) -> u32 { self.child().value() }
 
     #[cfg(any(target_arch = "wasm32", feature = "for-tests"))]
-    pub fn default_for_test() -> HDPathToCoin {
+    pub fn default_for_test(coin_type: u32) -> HDPathToCoin {
         HDPathToCoin {
             value: Bip32PurposeValue {
                 purpose: Bip43Purpose::Bip84,
             },
             child: Bip32Child {
-                value: HardenedValue::from_bip32_number(ChildNumber::new(0, true).unwrap(), 0).unwrap(),
+                value: HardenedValue::from_bip32_number(ChildNumber::new(coin_type, true).unwrap(), 0).unwrap(),
                 child: Bip44Tail,
             },
         }

--- a/mm2src/mm2_db/src/indexed_db/drivers/upgrader.rs
+++ b/mm2src/mm2_db/src/indexed_db/drivers/upgrader.rs
@@ -31,6 +31,8 @@ pub enum OnUpgradeError {
     },
     #[display(fmt = "Error occurred due to deleting the '{}' index: {}", index, description)]
     ErrorDeletingIndex { index: String, description: String },
+    #[display(fmt = "Error occurred due to clearing the '{}' table: {}", table, description)]
+    ErrorClearingTable { table: String, description: String },
 }
 
 pub struct DbUpgrader {
@@ -121,6 +123,18 @@ impl TableUpgrader {
             .map(|_| ())
             .map_to_mm(|e| OnUpgradeError::ErrorDeletingIndex {
                 index: index.to_owned(),
+                description: stringify_js_error(&e),
+            })
+    }
+
+    /// Clears the object store.
+    /// https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/clear
+    pub fn clear(&self) -> OnUpgradeResult<()> {
+        self.object_store
+            .clear()
+            .map(|_| ())
+            .map_to_mm(|e| OnUpgradeError::ErrorCreatingTable {
+                table: self.object_store.name(),
                 description: stringify_js_error(&e),
             })
     }


### PR DESCRIPTION
This PR makes it so that `HDPathToCoin` is a fieled of `HDWalletCoinStorage` and integrates it inside the databases.
`HDWalletCoinStorage` used to represent a selective set of the DB rows that match the same `hd_wallet_rmd160` and `coin` (ticker).
This has changed to `hd_wallet_rmd160` and `purpose` and `coin_type` (since `purpose` + `coin_type` define the coin uniquely*).
`coin` field is still stored in the DB but is not used. This is more for convenience.

This PR at the current state will purge your HD Wallet DB via a migration when run, so take a backup of it before running this code.
Will discuss a mitigation (easy for native, a little harder/tedious for wasm) for this side-effect in the review.

*: This isn't entirely true. There is one case where two coins share `purpose/coin_type` derivation path, namely, `BTC-testnet` & `LTC-testnet`. I didn't want to involve the `coin` field as a selector just for this as this feels very redundant. The downside for that though, is that `BTC-testnet` and `LTC-testnet` are co-mingled among each other in the DB.
Just in case you are looking, no, we don't have `LTC-testnet` in coins file.

supersedes #2482
closes #2470