### PR TITLE
improvement(walletconnect): return the `pairing_topic` in `new_connection` response

### DIFF
--- a/mm2src/kdf_walletconnect/src/lib.rs
+++ b/mm2src/kdf_walletconnect/src/lib.rs
@@ -281,7 +281,7 @@ impl WalletConnectCtxImpl {
         &self,
         required_namespaces: serde_json::Value,
         optional_namespaces: Option<serde_json::Value>,
-    ) -> MmResult<String, WalletConnectError> {
+    ) -> MmResult<(String, Topic), WalletConnectError> {
         self.await_connection().await?;
 
         let required_namespaces = serde_json::from_value(required_namespaces)?;
@@ -304,7 +304,7 @@ impl WalletConnectCtxImpl {
 
         send_proposal_request(self, &topic, required_namespaces, optional_namespaces).await?;
 
-        Ok(url)
+        Ok((url, topic))
     }
 
     /// Get symmetric key associated with a for `topic`.

--- a/mm2src/kdf_walletconnect/src/session/mod.rs
+++ b/mm2src/kdf_walletconnect/src/session/mod.rs
@@ -264,7 +264,7 @@ impl SessionManager {
     /// Retrieves a cloned session associated with a given topic.
     pub fn get_session(&self, topic: &Topic) -> Option<Session> { self.read().get(topic).cloned() }
 
-    /// Retrieves a cloned session associated with a given sessionn or pairing topic.
+    /// Retrieves a cloned session associated with a given session or pairing topic.
     pub fn get_session_with_any_topic(&self, topic: &Topic, with_pairing_topic: bool) -> Option<Session> {
         if with_pairing_topic {
             return self.read().values().find(|s| &s.pairing_topic == topic).cloned();

--- a/mm2src/mm2_main/src/rpc/wc_commands/new_connection.rs
+++ b/mm2src/mm2_main/src/rpc/wc_commands/new_connection.rs
@@ -1,4 +1,4 @@
-use kdf_walletconnect::WalletConnectCtx;
+use kdf_walletconnect::{NewConnection, WalletConnectCtx};
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -24,13 +24,10 @@ pub async fn new_connection(
 ) -> MmResult<CreateConnectionResponse, WalletConnectRpcError> {
     let wc_ctx =
         WalletConnectCtx::from_ctx(&ctx).mm_err(|err| WalletConnectRpcError::InitializationError(err.to_string()))?;
-    let (url, topic) = wc_ctx
+    let NewConnection { url, pairing_topic } = wc_ctx
         .new_connection(req.required_namespaces, req.optional_namespaces)
         .await
         .mm_err(|err| WalletConnectRpcError::SessionRequestError(err.to_string()))?;
 
-    Ok(CreateConnectionResponse {
-        url,
-        pairing_topic: topic.to_string(),
-    })
+    Ok(CreateConnectionResponse { url, pairing_topic })
 }

--- a/mm2src/mm2_main/src/rpc/wc_commands/new_connection.rs
+++ b/mm2src/mm2_main/src/rpc/wc_commands/new_connection.rs
@@ -8,6 +8,7 @@ use super::WalletConnectRpcError;
 #[derive(Debug, PartialEq, Serialize)]
 pub struct CreateConnectionResponse {
     pub url: String,
+    pub pairing_topic: String,
 }
 
 #[derive(Deserialize)]
@@ -23,10 +24,13 @@ pub async fn new_connection(
 ) -> MmResult<CreateConnectionResponse, WalletConnectRpcError> {
     let wc_ctx =
         WalletConnectCtx::from_ctx(&ctx).mm_err(|err| WalletConnectRpcError::InitializationError(err.to_string()))?;
-    let url = wc_ctx
+    let (url, topic) = wc_ctx
         .new_connection(req.required_namespaces, req.optional_namespaces)
         .await
         .mm_err(|err| WalletConnectRpcError::SessionRequestError(err.to_string()))?;
 
-    Ok(CreateConnectionResponse { url })
+    Ok(CreateConnectionResponse {
+        url,
+        pairing_topic: topic.to_string(),
+    })
 }


### PR DESCRIPTION
Currently when creating a new WalletConnect connection, you get back only the pairing url. It's now made so it returns also the pairing topic along.

The flow from the GUI would be like this:
- hit `new_connection` -> receive `{ "url": "wc:40923091...", "pairing_topic": "40923091..." }`
- keep hitting `get_session` till the user has established the session:
   - request `{ "topic": "40923091...", "with_pairing_topic": true }`
   - keep requesting till getting a non `null` response. Only then, the session has been established.
- any subsequent requests to `get_session` should use the `session_topic` instead of `pairing_topic` (the `pairing_topic` should be discarded really at this point). And `"with_pairing_topic"` should be set to `false` (or left out to default to `false`) for performance reasons.

I initially thought that there was actually no way for somebody who initialized 2 connections simultaneously to know which connection is which because they never knew an identifier for the connection. But this turns out to not be true, since the `"url"` field returned from `new_connection` encodes the `pairing_topic` inside it.
This PR just makes the pairing topic more accessible by having it in a different field in the response.

cc @KomodoPlatform/qa 