### PR TITLE
Adds `derive_priv_key` v2 RPC for HD wallets

### DIFF
--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -211,6 +211,7 @@ use coin_balance::{AddressBalanceStatus, HDAddressBalance, HDWalletBalanceOps};
 
 pub mod lp_price;
 pub mod watcher_common;
+pub mod priv_key;
 
 pub mod coin_errors;
 use coin_errors::{AddressFromPubkeyError, MyAddressError, ValidatePaymentError, ValidatePaymentFut,
@@ -2153,6 +2154,11 @@ pub trait MarketCoinOps {
     /// Should burn part of dex fee coin
     fn should_burn_dex_fee(&self) -> bool;
 
+    /// Returns the WIF prefix for the coin.
+    fn wif_prefix(&self) -> Option<u8> { None }
+
+    fn is_utxo(&self) -> bool { true }
+    
     fn is_trezor(&self) -> bool;
 }
 

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -2157,8 +2157,8 @@ pub trait MarketCoinOps {
     /// Returns the WIF prefix for the coin.
     fn wif_prefix(&self) -> Option<u8> { None }
 
-    fn is_utxo(&self) -> bool { true }
-    
+    fn is_utxo(&self) -> bool { false }
+
     fn is_trezor(&self) -> bool;
 }
 

--- a/mm2src/coins/priv_key.rs
+++ b/mm2src/coins/priv_key.rs
@@ -1,0 +1,140 @@
+use crate::hd_wallet::{HDAccountOps, HDWalletOps};
+use crate::{
+    CoinWithDerivationMethod, CoinWithPrivKeyPolicy, DerivationMethod, MarketCoinOps, MmCoin,
+    PrivKeyPolicy,
+};
+use async_trait::async_trait;
+use bip32::ChildNumber;
+use common::HttpStatusCode;
+use crypto::Bip44Chain;
+use derive_more::Display;
+use http::StatusCode;
+use keys::{KeyPair, Private};
+use mm2_err_handle::prelude::*;
+use serde::{Deserialize, Serialize};
+use std::convert::TryInto;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct DerivedPrivKey {
+    pub coin: String,
+    pub address: String,
+    pub derivation_path: String,
+    pub priv_key: String,
+    pub pub_key: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DerivePrivKeyReq {
+    pub account_id: u32,
+    pub chain: Option<Bip44Chain>,
+    pub address_id: u32,
+}
+
+#[derive(Debug, Display, Serialize, SerializeErrorType)]
+#[serde(tag = "error_type", content = "error_data")]
+pub enum DerivePrivKeyError {
+    #[display(fmt = "No such coin: {}", _0)]
+    NoSuchCoin(String),
+    #[display(fmt = "Coin {} doesn't support HD wallet derivation", _0)]
+    CoinDoesntSupportDerivation(String),
+    #[display(fmt = "Hardware/remote wallet doesn't allow exporting private keys")]
+    HwWalletNotAllowed,
+    #[display(fmt = "Internal error: {}", _0)]
+    Internal(String),
+}
+
+impl HttpStatusCode for DerivePrivKeyError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            DerivePrivKeyError::NoSuchCoin(_) => StatusCode::NOT_FOUND,
+            DerivePrivKeyError::CoinDoesntSupportDerivation(_) => StatusCode::BAD_REQUEST,
+            DerivePrivKeyError::HwWalletNotAllowed => StatusCode::FORBIDDEN,
+            DerivePrivKeyError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+#[async_trait]
+pub trait DerivePrivKeyV2: MmCoin + CoinWithPrivKeyPolicy + CoinWithDerivationMethod + Sized {
+    async fn derive_priv_key(&self, req: &DerivePrivKeyReq) -> Result<DerivedPrivKey, MmError<DerivePrivKeyError>>;
+}
+
+#[async_trait]
+impl<Coin> DerivePrivKeyV2 for Coin
+where
+    Coin: MmCoin + CoinWithPrivKeyPolicy + CoinWithDerivationMethod + MarketCoinOps + Sync,
+{
+    async fn derive_priv_key(&self, req: &DerivePrivKeyReq) -> Result<DerivedPrivKey, MmError<DerivePrivKeyError>> {
+        match self.priv_key_policy() {
+            PrivKeyPolicy::Iguana(_) => MmError::err(DerivePrivKeyError::CoinDoesntSupportDerivation(
+                self.ticker().to_string(),
+            )),
+            PrivKeyPolicy::Trezor | PrivKeyPolicy::WalletConnect { .. } => {
+                MmError::err(DerivePrivKeyError::HwWalletNotAllowed)
+            },
+            PrivKeyPolicy::HDWallet { .. } => {
+                let hd_wallet = match self.derivation_method() {
+                    DerivationMethod::HDWallet(hd_wallet) => hd_wallet,
+                    _ => {
+                        return MmError::err(DerivePrivKeyError::CoinDoesntSupportDerivation(
+                            self.ticker().to_string(),
+                        ))
+                    },
+                };
+
+                let account = hd_wallet
+                    .get_account(req.account_id)
+                    .await
+                    .ok_or_else(|| DerivePrivKeyError::Internal(format!("Account {} not found", req.account_id)))?;
+
+                let mut path_to_address = account.account_derivation_path();
+                path_to_address.push(req.chain.unwrap_or(Bip44Chain::External).to_child_number());
+                path_to_address.push(ChildNumber::new(req.address_id, false).expect("non-hardened"));
+
+                let secret_key = self
+                    .priv_key_policy()
+                    .hd_wallet_derived_priv_key_or_err(&path_to_address)
+                    .map_err(|e| DerivePrivKeyError::Internal(format!("Error deriving secret key: {}", e)))?;
+
+                let private = Private {
+                    prefix: self.wif_prefix().unwrap_or(0),
+                    secret: secret_key.into(),
+                    compressed: true,
+                    checksum_type: Default::default(),
+                };
+
+                let key_pair = KeyPair::from_private(private)
+                    .map_err(|e| DerivePrivKeyError::Internal(format!("Error creating key pair from secret: {}", e)))?;
+
+                let pubkey_slice = key_pair.public_slice();
+                let pubkey: [u8; 33] = pubkey_slice.try_into().map_err(|_| {
+                    DerivePrivKeyError::Internal("Error converting pubkey slice to array".to_string())
+                })?;
+
+                let address = self
+                    .address_from_pubkey(&pubkey.into())
+                    .map_err(|e| {
+                        DerivePrivKeyError::Internal(format!("Error getting address from pubkey: {}", e))
+                    })?;
+
+                let priv_key_wif = key_pair.private().to_string();
+                let priv_key_hex = format!("0x{}", hex::encode(key_pair.private_bytes()));
+
+                let priv_key = if self.is_utxo() {
+                    priv_key_wif
+                } else {
+                    priv_key_hex
+                };
+
+                let response = DerivedPrivKey {
+                    coin: self.ticker().to_string(),
+                    address,
+                    derivation_path: path_to_address.to_string(),
+                    priv_key,
+                    pub_key: hex::encode(key_pair.public_slice()),
+                };
+                Ok(response)
+            },
+        }
+    }
+}

--- a/mm2src/coins/utxo/utxo_standard.rs
+++ b/mm2src/coins/utxo/utxo_standard.rs
@@ -923,6 +923,10 @@ impl MarketCoinOps for UtxoStandardCoin {
 
     fn should_burn_dex_fee(&self) -> bool { utxo_common::should_burn_dex_fee() }
 
+    fn wif_prefix(&self) -> Option<u8> { Some(self.as_ref().conf.wif_prefix) }
+
+    fn is_utxo(&self) -> bool { true }
+
     fn is_trezor(&self) -> bool { self.as_ref().priv_key_policy.is_trezor() }
 }
 

--- a/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
+++ b/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
@@ -20,12 +20,12 @@ use crate::rpc::lp_commands::one_inch::rpcs::{one_inch_v6_0_classic_swap_contrac
                                               one_inch_v6_0_classic_swap_liquidity_sources_rpc,
                                               one_inch_v6_0_classic_swap_quote_rpc,
                                               one_inch_v6_0_classic_swap_tokens_rpc};
+use crate::rpc::lp_commands::priv_key::derive_priv_key;
 use crate::rpc::lp_commands::pubkey::*;
 use crate::rpc::lp_commands::tokens::get_token_info;
 use crate::rpc::lp_commands::tokens::{approve_token_rpc, get_token_allowance_rpc};
 use crate::rpc::lp_commands::trezor::trezor_connection_status;
 use crate::rpc::rate_limiter::{process_rate_limit, RateLimitContext};
-use crate::rpc::lp_commands::priv_key::derive_priv_key;
 use crate::rpc::wc_commands::{new_connection, ping_session};
 
 use coins::eth::fee_estimation::rpc::get_eth_estimated_fee_per_gas;

--- a/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
+++ b/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
@@ -25,6 +25,7 @@ use crate::rpc::lp_commands::tokens::get_token_info;
 use crate::rpc::lp_commands::tokens::{approve_token_rpc, get_token_allowance_rpc};
 use crate::rpc::lp_commands::trezor::trezor_connection_status;
 use crate::rpc::rate_limiter::{process_rate_limit, RateLimitContext};
+use crate::rpc::lp_commands::priv_key::derive_priv_key;
 use crate::rpc::wc_commands::{new_connection, ping_session};
 
 use coins::eth::fee_estimation::rpc::get_eth_estimated_fee_per_gas;
@@ -220,6 +221,7 @@ async fn dispatcher_v2(request: MmRpcRequest, ctx: MmArc) -> DispatcherResult<Re
         "enable_tendermint_token" => handle_mmrpc(ctx, request, enable_token::<TendermintToken>).await,
         "get_current_mtp" => handle_mmrpc(ctx, request, get_current_mtp_rpc).await,
         "get_enabled_coins" => handle_mmrpc(ctx, request, get_enabled_coins_rpc).await,
+        "derive_priv_key" => handle_mmrpc(ctx, request, derive_priv_key).await,
         "get_locked_amount" => handle_mmrpc(ctx, request, get_locked_amount_rpc).await,
         "get_mnemonic" => handle_mmrpc(ctx, request, get_mnemonic_rpc).await,
         "get_my_address" => handle_mmrpc(ctx, request, get_my_address).await,

--- a/mm2src/mm2_main/src/rpc/lp_commands/mod.rs
+++ b/mm2src/mm2_main/src/rpc/lp_commands/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod db_id;
 pub mod legacy;
 pub(crate) mod lr_swap;
 pub(crate) mod one_inch;
+pub mod priv_key;
 pub(crate) mod pubkey;
 pub(crate) mod tokens;
 pub(crate) mod trezor;

--- a/mm2src/mm2_main/src/rpc/lp_commands/priv_key.rs
+++ b/mm2src/mm2_main/src/rpc/lp_commands/priv_key.rs
@@ -1,0 +1,44 @@
+use coins::lp_coinfind_any;
+use coins::priv_key::{DerivePrivKeyError, DerivePrivKeyReq, DerivePrivKeyV2, DerivedPrivKey};
+use coins::MmCoinEnum;
+use crypto::Bip44Chain;
+use mm2_core::mm_ctx::MmArc;
+use mm2_err_handle::prelude::*;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct DerivePrivKeyRequest {
+    pub coin: String,
+    pub account_id: u32,
+    pub address_id: u32,
+    #[serde(default)]
+    pub chain: Option<Bip44Chain>,
+}
+
+pub async fn derive_priv_key(
+    ctx: MmArc,
+    req: DerivePrivKeyRequest,
+) -> MmResult<DerivedPrivKey, DerivePrivKeyError> {
+    let coin_ticker = req.coin.clone();
+    let coin = lp_coinfind_any(&ctx, &req.coin)
+        .await
+        .map_err(|e| DerivePrivKeyError::Internal(e.to_string()))?
+        .ok_or_else(|| DerivePrivKeyError::NoSuchCoin(req.coin.clone()))?
+        .inner;
+
+    let req = DerivePrivKeyReq {
+        account_id: req.account_id,
+        chain: req.chain,
+        address_id: req.address_id,
+    };
+
+    match coin {
+        MmCoinEnum::UtxoCoin(c) => c.derive_priv_key(&req).await,
+        MmCoinEnum::Bch(c) => c.derive_priv_key(&req).await,
+        MmCoinEnum::QtumCoin(c) => c.derive_priv_key(&req).await,
+        MmCoinEnum::EthCoin(c) => c.derive_priv_key(&req).await,
+        _ => MmError::err(DerivePrivKeyError::CoinDoesntSupportDerivation(
+            coin_ticker,
+        )),
+    }
+}

--- a/mm2src/mm2_main/src/rpc/lp_commands/priv_key.rs
+++ b/mm2src/mm2_main/src/rpc/lp_commands/priv_key.rs
@@ -15,10 +15,7 @@ pub struct DerivePrivKeyRequest {
     pub chain: Option<Bip44Chain>,
 }
 
-pub async fn derive_priv_key(
-    ctx: MmArc,
-    req: DerivePrivKeyRequest,
-) -> MmResult<DerivedPrivKey, DerivePrivKeyError> {
+pub async fn derive_priv_key(ctx: MmArc, req: DerivePrivKeyRequest) -> MmResult<DerivedPrivKey, DerivePrivKeyError> {
     let coin_ticker = req.coin.clone();
     let coin = lp_coinfind_any(&ctx, &req.coin)
         .await
@@ -37,8 +34,6 @@ pub async fn derive_priv_key(
         MmCoinEnum::Bch(c) => c.derive_priv_key(&req).await,
         MmCoinEnum::QtumCoin(c) => c.derive_priv_key(&req).await,
         MmCoinEnum::EthCoin(c) => c.derive_priv_key(&req).await,
-        _ => MmError::err(DerivePrivKeyError::CoinDoesntSupportDerivation(
-            coin_ticker,
-        )),
+        _ => MmError::err(DerivePrivKeyError::CoinDoesntSupportDerivation(coin_ticker)),
     }
 }


### PR DESCRIPTION
The legacy `show_priv_key` method did not take input for account/address id, and would only return the zero index WIF for HD wallets, so I've added a v2 `derive_priv_key` method which accepts these inputs.

Request:
```json
{
    "userpass": "{{userpass}}",
    "mmrpc": "2.0",
    "method": "derive_priv_key",
    "params": {
        "coin": "MATIC",
        "account_id": 0,
        "address_id": 3
    }
}
```

Response:
```json
{
    "mmrpc": "2.0",
    "result": {
        "coin": "MATIC",
        "address": "0x1e8B4aA6a8B8a376E0357504cF2ebC11Bc02288b",
        "derivation_path": "m/44'/60'/0'/0/3",
        "priv_key": "0x932ec93805200317394d6f63216791cf6052e6bb7412153f799c0b0660086e24",
        "pub_key": "0x036b521bb1f9e845301f8bcb1f025151784ac2ea54b95fa50b9c491aced4a34c04"
    },
    "id": null
}
```

To test:
- Use [the seed](https://github.com/KomodoPlatform/komodo-defi-framework/blob/3619acd1a58ebb15da3552d689e60ae6d7addb02/mm2src/mm2_main/tests/mm2_tests/mm2_tests_inner.rs#L2011) in the test function to launch in HD mode
- Activate some coins, and create some addresses, then query these coins and addresses via `derive_priv_key`.
- Confirm the responses match the values returned at https://iancoleman.io/bip39/ with the same seed and selected coin. 
