### PR TITLE
refactor(EVM): rename fn, fix timeouts, add activation req validation

### DIFF
--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -2506,7 +2506,7 @@ impl MarketCoinOps for EthCoin {
         Box::new(fut)
     }
 
-    fn base_coin_balance(&self) -> BalanceFut<BigDecimal> {
+    fn platform_coin_balance(&self) -> BalanceFut<BigDecimal> {
         Box::new(
             self.eth_balance()
                 .and_then(move |result| u256_to_big_decimal(result, ETH_DECIMALS).map_mm_err()),

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -26,7 +26,6 @@ use super::watcher_common::{validate_watcher_reward, REWARD_GAS_AMOUNT};
 use super::*;
 use crate::coin_balance::{EnableCoinBalanceError, EnabledCoinBalanceParams, HDAccountBalance, HDAddressBalance,
                           HDWalletBalance, HDWalletBalanceOps};
-use crate::eth::eth_rpc::ETH_RPC_REQUEST_TIMEOUT;
 use crate::eth::web3_transport::websocket_transport::{WebsocketTransport, WebsocketTransportNode};
 use crate::hd_wallet::{DisplayAddress, HDAccountOps, HDCoinAddress, HDCoinWithdrawOps, HDConfirmAddress,
                        HDPathAccountToAddressId, HDWalletCoinOps, HDXPubExtractor};
@@ -66,6 +65,7 @@ use crypto::{Bip44Chain, CryptoCtx, CryptoCtxError, GlobalHDAccountArc, KeyPairP
 use derive_more::Display;
 use enum_derives::EnumFromStringify;
 
+use compatible_time::Duration;
 use compatible_time::Instant;
 use ethabi::{Contract, Function, Token};
 use ethcore_transaction::tx_builders::TxBuilderError;
@@ -98,7 +98,6 @@ use std::str::from_utf8;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 use web3::types::{Action as TraceAction, BlockId, BlockNumber, Bytes, CallRequest, FilterBuilder, Log, Trace,
                   TraceFilterBuilder, Transaction as Web3Transaction, TransactionId, U64};
 use web3::{self, Web3};
@@ -171,6 +170,9 @@ use eth_swap_v2::{extract_id_from_tx_data, EthPaymentType, PaymentMethod, SpendT
 
 pub mod eth_utils;
 pub mod tron;
+
+pub(crate) const ETH_RPC_REQUEST_TIMEOUT_S: Duration = Duration::from_secs(30);
+pub(crate) const WEB3_REQUEST_TIMEOUT_S: Duration = Duration::from_secs(30);
 
 pub const ETH_PROTOCOL_TYPE: &str = "ETH";
 pub const ERC20_PROTOCOL_TYPE: &str = "ERC20";
@@ -1197,7 +1199,7 @@ pub async fn withdraw_erc1155(ctx: MmArc, withdraw_type: WithdrawErc1155) -> Wit
         .clone()
         .get_addr_nonce(my_address)
         .compat()
-        .timeout_secs(30.)
+        .timeout(ETH_RPC_REQUEST_TIMEOUT_S)
         .await?
         .map_to_mm(WithdrawError::Transport)?;
 
@@ -1301,7 +1303,7 @@ pub async fn withdraw_erc721(ctx: MmArc, withdraw_type: WithdrawErc721) -> Withd
         .clone()
         .get_addr_nonce(my_address)
         .compat()
-        .timeout_secs(30.)
+        .timeout(ETH_RPC_REQUEST_TIMEOUT_S)
         .await?
         .map_to_mm(WithdrawError::Transport)?;
 
@@ -2621,6 +2623,7 @@ impl MarketCoinOps for EthCoin {
                 }
 
                 // Make sure that there was no chain reorganization that led to transaction confirmation block to be changed
+                // TODO: maybe we should use the eth_syncing call here (or elsewhere) to ensure the eth node is not out of sync
                 match selfi
                     .transaction_confirmed_at(tx_hash, input.wait_until, check_every)
                     .compat()
@@ -3030,7 +3033,7 @@ impl RpcCommonOps for EthCoin {
                 .as_ref()
                 .web3()
                 .client_version()
-                .timeout(ETH_RPC_REQUEST_TIMEOUT)
+                .timeout(ETH_RPC_REQUEST_TIMEOUT_S)
                 .await
             {
                 Ok(Ok(_)) => {

--- a/mm2src/coins/eth/eth_rpc.rs
+++ b/mm2src/coins/eth/eth_rpc.rs
@@ -3,16 +3,13 @@
 //! rotates through all transports in case of failures.
 
 use super::web3_transport::FeeHistoryResult;
-use super::{web3_transport::Web3Transport, EthCoin};
+use super::{web3_transport::Web3Transport, EthCoin, ETH_RPC_REQUEST_TIMEOUT_S};
 use common::{custom_futures::timeout::FutureTimerExt, log::debug};
-use compatible_time::Duration;
 use serde_json::Value;
 use web3::types::{Address, Block, BlockId, BlockNumber, Bytes, CallRequest, FeeHistory, Filter, Log, Proof, SyncState,
                   Trace, TraceFilter, Transaction, TransactionId, TransactionReceipt, TransactionRequest, Work, H256,
                   H520, H64, U256, U64};
 use web3::{helpers, Transport};
-
-pub(crate) const ETH_RPC_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 impl EthCoin {
     async fn try_rpc_send(&self, method: &str, params: Vec<jsonrpc_core::Value>) -> Result<Value, web3::Error> {
@@ -30,7 +27,7 @@ impl EthCoin {
                 Web3Transport::Metamask(metamask) => metamask.execute(method, params.clone()),
             };
 
-            match execute_fut.timeout(ETH_RPC_REQUEST_TIMEOUT).await {
+            match execute_fut.timeout(ETH_RPC_REQUEST_TIMEOUT_S).await {
                 Ok(Ok(r)) => {
                     // Bring the live client to the front of rpc_clients
                     clients.rotate_left(i);

--- a/mm2src/coins/eth/eth_withdraw.rs
+++ b/mm2src/coins/eth/eth_withdraw.rs
@@ -3,7 +3,7 @@ use super::{checksum_address, u256_to_big_decimal, wei_from_big_decimal, ChainSp
 use crate::eth::wallet_connect::WcEthTxParams;
 use crate::eth::{calc_total_fee, get_eth_gas_details_from_withdraw_fee, tx_builder_with_pay_for_gas_option,
                  tx_type_from_pay_for_gas_option, Action, Address, EthTxFeeDetails, KeyPair, PayForGasOption,
-                 SignedEthTx, TransactionWrapper, UnSignedEthTxBuilder};
+                 SignedEthTx, TransactionWrapper, UnSignedEthTxBuilder, ETH_RPC_REQUEST_TIMEOUT_S};
 use crate::hd_wallet::{HDAddressSelector, HDCoinWithdrawOps, HDWalletOps, WithdrawSenderAddress};
 use crate::rpc_command::init_withdraw::{WithdrawInProgressStatus, WithdrawTaskHandleShared};
 use crate::{BytesJson, CoinWithDerivationMethod, EthCoin, GetWithdrawSenderAddress, PrivKeyPolicy, TransactionData,
@@ -287,7 +287,7 @@ where
                     .clone()
                     .get_addr_nonce(my_address)
                     .compat()
-                    .timeout_secs(30.)
+                    .timeout(ETH_RPC_REQUEST_TIMEOUT_S)
                     .await?
                     .map_to_mm(WithdrawError::Transport)?;
 
@@ -336,7 +336,7 @@ where
                     .clone()
                     .get_addr_nonce(my_address)
                     .compat()
-                    .timeout_secs(30.)
+                    .timeout(ETH_RPC_REQUEST_TIMEOUT_S)
                     .await?
                     .map_to_mm(WithdrawError::Transport)?;
                 let params = WcEthTxParams {

--- a/mm2src/coins/eth/v2_activation.rs
+++ b/mm2src/coins/eth/v2_activation.rs
@@ -78,6 +78,7 @@ pub enum EthActivationV2Error {
     // TODO: Map WalletConnectError to distinct error categories (transport, invalid payload) after refactoring.
     #[from_stringify("WalletConnectError")]
     WalletConnectError(String),
+    InvalidTokenProtocol,
 }
 
 impl From<MyAddressError> for EthActivationV2Error {
@@ -110,6 +111,7 @@ impl From<EthTokenActivationError> for EthActivationV2Error {
             },
             EthTokenActivationError::PrivKeyPolicyNotAllowed(e) => EthActivationV2Error::PrivKeyPolicyNotAllowed(e),
             EthTokenActivationError::CustomTokenError(e) => EthActivationV2Error::CustomTokenError(e),
+            EthTokenActivationError::InvalidTokenProtocol => EthActivationV2Error::InvalidTokenProtocol,
         }
     }
 }
@@ -233,6 +235,7 @@ pub enum EthTokenActivationError {
     UnexpectedDerivationMethod(UnexpectedDerivationMethod),
     PrivKeyPolicyNotAllowed(PrivKeyPolicyNotAllowed),
     CustomTokenError(CustomTokenError),
+    InvalidTokenProtocol,
 }
 
 impl From<AbortedError> for EthTokenActivationError {

--- a/mm2src/coins/eth/web3_transport/http_transport.rs
+++ b/mm2src/coins/eth/web3_transport/http_transport.rs
@@ -1,5 +1,5 @@
-use crate::eth::{web3_transport::Web3SendOut, RpcTransportEventHandler, RpcTransportEventHandlerShared, Web3RpcError,
-                 WEB3_REQUEST_TIMEOUT_S};
+use crate::eth::{web3_transport::Web3SendOut, RpcTransportEventHandler, RpcTransportEventHandlerShared, Web3RpcError};
+#[cfg(not(target_arch = "wasm32"))] use crate::eth::WEB3_REQUEST_TIMEOUT_S;
 use common::APPLICATION_JSON;
 use common::X_AUTH_PAYLOAD;
 use http::header::CONTENT_TYPE;

--- a/mm2src/coins/eth/web3_transport/websocket_transport.rs
+++ b/mm2src/coins/eth/web3_transport/websocket_transport.rs
@@ -6,8 +6,8 @@
 //! for each request.
 
 use super::http_transport::de_rpc_response;
-use crate::eth::eth_rpc::ETH_RPC_REQUEST_TIMEOUT;
 use crate::eth::web3_transport::Web3SendOut;
+use crate::eth::WEB3_REQUEST_TIMEOUT_S;
 use crate::eth::{EthCoin, RpcTransportEventHandlerShared};
 use crate::{MmCoin, RpcTransportEventHandler};
 use common::executor::{AbortSettings, SpawnAbortable, Timer};
@@ -148,7 +148,7 @@ impl WebsocketTransport {
                     request_id,
                     response_notifier,
                     // Since request will be cancelled when timeout occurs, we are free to drop its state.
-                    ETH_RPC_REQUEST_TIMEOUT,
+                    WEB3_REQUEST_TIMEOUT_S,
                 );
 
                 let mut should_continue = Default::default();

--- a/mm2src/coins/lightning.rs
+++ b/mm2src/coins/lightning.rs
@@ -1008,7 +1008,7 @@ impl MarketCoinOps for LightningCoin {
         Box::new(fut.boxed().compat())
     }
 
-    fn base_coin_balance(&self) -> BalanceFut<BigDecimal> { Box::new(self.my_balance().map(|res| res.spendable)) }
+    fn platform_coin_balance(&self) -> BalanceFut<BigDecimal> { Box::new(self.my_balance().map(|res| res.spendable)) }
 
     fn platform_ticker(&self) -> &str { self.platform_coin().ticker() }
 

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -2108,8 +2108,8 @@ pub trait MarketCoinOps {
         Box::new(self.my_balance().map(|CoinBalance { spendable, .. }| spendable))
     }
 
-    /// Base coin balance for tokens, e.g. ETH balance in ERC20 case
-    fn base_coin_balance(&self) -> BalanceFut<BigDecimal>;
+    /// Platform coin balance for tokens, e.g. ETH balance in ERC20 case
+    fn platform_coin_balance(&self) -> BalanceFut<BigDecimal>;
 
     fn platform_ticker(&self) -> &str;
 

--- a/mm2src/coins/qrc20.rs
+++ b/mm2src/coins/qrc20.rs
@@ -1084,7 +1084,7 @@ impl MarketCoinOps for Qrc20Coin {
         };
         Box::new(fut.boxed().compat())
     }
-    fn base_coin_balance(&self) -> BalanceFut<BigDecimal> {
+    fn platform_coin_balance(&self) -> BalanceFut<BigDecimal> {
         // use standard UTXO my_balance implementation that returns Qtum balance instead of QRC20
         Box::new(utxo_common::my_balance(self.clone()).map(|CoinBalance { spendable, .. }| spendable))
     }

--- a/mm2src/coins/siacoin.rs
+++ b/mm2src/coins/siacoin.rs
@@ -369,7 +369,7 @@ impl MarketCoinOps for SiaCoin {
         Box::new(fut.boxed().compat())
     }
 
-    fn base_coin_balance(&self) -> BalanceFut<BigDecimal> { unimplemented!() }
+    fn platform_coin_balance(&self) -> BalanceFut<BigDecimal> { unimplemented!() }
 
     fn platform_ticker(&self) -> &str { "FOO" } // TODO Alright
 

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -3723,7 +3723,7 @@ impl MarketCoinOps for TendermintCoin {
         Box::new(fut.boxed().compat())
     }
 
-    fn base_coin_balance(&self) -> BalanceFut<BigDecimal> {
+    fn platform_coin_balance(&self) -> BalanceFut<BigDecimal> {
         Box::new(self.my_balance().map(|coin_balance| coin_balance.spendable))
     }
 

--- a/mm2src/coins/tendermint/tendermint_token.rs
+++ b/mm2src/coins/tendermint/tendermint_token.rs
@@ -302,7 +302,7 @@ impl MarketCoinOps for TendermintToken {
         Box::new(fut.boxed().compat())
     }
 
-    fn base_coin_balance(&self) -> BalanceFut<BigDecimal> { self.platform_coin.my_spendable_balance() }
+    fn platform_coin_balance(&self) -> BalanceFut<BigDecimal> { self.platform_coin.my_spendable_balance() }
 
     fn platform_ticker(&self) -> &str { self.platform_coin.ticker() }
 

--- a/mm2src/coins/test_coin.rs
+++ b/mm2src/coins/test_coin.rs
@@ -81,7 +81,7 @@ impl MarketCoinOps for TestCoin {
 
     fn my_balance(&self) -> BalanceFut<CoinBalance> { unimplemented!() }
 
-    fn base_coin_balance(&self) -> BalanceFut<BigDecimal> { unimplemented!() }
+    fn platform_coin_balance(&self) -> BalanceFut<BigDecimal> { unimplemented!() }
 
     fn platform_ticker(&self) -> &str { &self.ticker }
 

--- a/mm2src/coins/utxo/bch.rs
+++ b/mm2src/coins/utxo/bch.rs
@@ -1173,7 +1173,7 @@ impl MarketCoinOps for BchCoin {
         Box::new(fut.boxed().compat())
     }
 
-    fn base_coin_balance(&self) -> BalanceFut<BigDecimal> { utxo_common::base_coin_balance(self) }
+    fn platform_coin_balance(&self) -> BalanceFut<BigDecimal> { utxo_common::platform_coin_balance(self) }
 
     fn platform_ticker(&self) -> &str { self.ticker() }
 

--- a/mm2src/coins/utxo/qtum.rs
+++ b/mm2src/coins/utxo/qtum.rs
@@ -788,7 +788,7 @@ impl MarketCoinOps for QtumCoin {
 
     fn my_balance(&self) -> BalanceFut<CoinBalance> { utxo_common::my_balance(self.clone()) }
 
-    fn base_coin_balance(&self) -> BalanceFut<BigDecimal> { utxo_common::base_coin_balance(self) }
+    fn platform_coin_balance(&self) -> BalanceFut<BigDecimal> { utxo_common::platform_coin_balance(self) }
 
     fn platform_ticker(&self) -> &str { self.ticker() }
 

--- a/mm2src/coins/utxo/slp.rs
+++ b/mm2src/coins/utxo/slp.rs
@@ -72,6 +72,7 @@ pub enum EnableSlpError {
     GetBalanceError(UtxoRpcError),
     UnexpectedDerivationMethod(String),
     Internal(String),
+    InvalidTokenProtocol,
 }
 
 impl From<MyAddressError> for EnableSlpError {

--- a/mm2src/coins/utxo/slp.rs
+++ b/mm2src/coins/utxo/slp.rs
@@ -1164,7 +1164,7 @@ impl MarketCoinOps for SlpToken {
         Box::new(fut.boxed().compat())
     }
 
-    fn base_coin_balance(&self) -> BalanceFut<BigDecimal> {
+    fn platform_coin_balance(&self) -> BalanceFut<BigDecimal> {
         Box::new(self.platform_coin.my_balance().map(|res| res.spendable))
     }
 

--- a/mm2src/coins/utxo/utxo_common.rs
+++ b/mm2src/coins/utxo/utxo_common.rs
@@ -355,7 +355,7 @@ pub fn denominate_satoshis(coin: &UtxoCoinFields, satoshi: i64) -> f64 {
     satoshi as f64 / 10f64.powf(coin.decimals as f64)
 }
 
-pub fn base_coin_balance<T>(coin: &T) -> BalanceFut<BigDecimal>
+pub fn platform_coin_balance<T>(coin: &T) -> BalanceFut<BigDecimal>
 where
     T: MarketCoinOps,
 {

--- a/mm2src/coins/utxo/utxo_standard.rs
+++ b/mm2src/coins/utxo/utxo_standard.rs
@@ -870,7 +870,7 @@ impl MarketCoinOps for UtxoStandardCoin {
 
     fn my_balance(&self) -> BalanceFut<CoinBalance> { utxo_common::my_balance(self.clone()) }
 
-    fn base_coin_balance(&self) -> BalanceFut<BigDecimal> { utxo_common::base_coin_balance(self) }
+    fn platform_coin_balance(&self) -> BalanceFut<BigDecimal> { utxo_common::platform_coin_balance(self) }
 
     fn platform_ticker(&self) -> &str { self.ticker() }
 

--- a/mm2src/coins/z_coin.rs
+++ b/mm2src/coins/z_coin.rs
@@ -1266,7 +1266,7 @@ impl MarketCoinOps for ZCoin {
         Box::new(fut.boxed().compat())
     }
 
-    fn base_coin_balance(&self) -> BalanceFut<BigDecimal> { utxo_common::base_coin_balance(self) }
+    fn platform_coin_balance(&self) -> BalanceFut<BigDecimal> { utxo_common::platform_coin_balance(self) }
 
     fn platform_ticker(&self) -> &str { self.ticker() }
 

--- a/mm2src/coins_activation/src/erc20_token_activation.rs
+++ b/mm2src/coins_activation/src/erc20_token_activation.rs
@@ -45,6 +45,7 @@ impl From<EthTokenActivationError> for EnableTokenError {
             EthTokenActivationError::UnexpectedDerivationMethod(e) => EnableTokenError::UnexpectedDerivationMethod(e),
             EthTokenActivationError::PrivKeyPolicyNotAllowed(e) => EnableTokenError::PrivKeyPolicyNotAllowed(e),
             EthTokenActivationError::CustomTokenError(e) => EnableTokenError::CustomTokenError(e),
+            EthTokenActivationError::InvalidTokenProtocol => EnableTokenError::InvalidTokenProtocol,
         }
     }
 }

--- a/mm2src/coins_activation/src/eth_with_token_activation.rs
+++ b/mm2src/coins_activation/src/eth_with_token_activation.rs
@@ -91,6 +91,7 @@ impl From<EthActivationV2Error> for EnablePlatformCoinWithTokensError {
                 "Hardware wallet must be used within rpc task manager".to_string(),
             ),
             EthActivationV2Error::CustomTokenError(e) => EnablePlatformCoinWithTokensError::CustomTokenError(e),
+            EthActivationV2Error::InvalidTokenProtocol => EnablePlatformCoinWithTokensError::InvalidTokenProtocol,
         }
     }
 }
@@ -126,6 +127,7 @@ impl From<EthTokenActivationError> for InitTokensAsMmCoinsError {
             },
             EthTokenActivationError::PrivKeyPolicyNotAllowed(e) => InitTokensAsMmCoinsError::Internal(e.to_string()),
             EthTokenActivationError::CustomTokenError(e) => InitTokensAsMmCoinsError::CustomTokenError(e),
+            EthTokenActivationError::InvalidTokenProtocol => InitTokensAsMmCoinsError::InvalidTokenProtocol,
         }
     }
 }
@@ -166,6 +168,19 @@ impl TokenInitializer for Erc20Initializer {
     }
 
     fn platform_coin(&self) -> &EthCoin { &self.platform_coin }
+
+    fn validate_token_params(
+        &self,
+        params: &[TokenActivationParams<Self::TokenActivationRequest, Self::TokenProtocol>],
+    ) -> MmResult<(), Self::InitTokensError> {
+        for token_param in params {
+            match &token_param.protocol {
+                Erc20Protocol { platform, .. } if platform == self.platform_coin().ticker() => {},
+                _ => return MmError::err(EthTokenActivationError::InvalidTokenProtocol),
+            }
+        }
+        Ok(())
+    }
 }
 
 #[derive(Clone, Deserialize)]

--- a/mm2src/coins_activation/src/init_erc20_token_activation.rs
+++ b/mm2src/coins_activation/src/init_erc20_token_activation.rs
@@ -28,11 +28,18 @@ pub enum InitErc20Error {
     #[display(fmt = "{}", _0)]
     HwError(HwRpcError),
     #[display(fmt = "Initialization task has timed out {:?}", duration)]
-    TaskTimedOut { duration: Duration },
+    TaskTimedOut {
+        duration: Duration,
+    },
     #[display(fmt = "Token {} is activated already", ticker)]
-    TokenIsAlreadyActivated { ticker: String },
+    TokenIsAlreadyActivated {
+        ticker: String,
+    },
     #[display(fmt = "Error on  token {} creation: {}", ticker, error)]
-    TokenCreationError { ticker: String, error: String },
+    TokenCreationError {
+        ticker: String,
+        error: String,
+    },
     #[display(fmt = "Could not fetch balance: {}", _0)]
     CouldNotFetchBalance(String),
     #[display(fmt = "Transport error: {}", _0)]
@@ -41,6 +48,7 @@ pub enum InitErc20Error {
     Internal(String),
     #[display(fmt = "Custom token error: {}", _0)]
     CustomTokenError(CustomTokenError),
+    InvalidTokenProtocol,
 }
 
 impl From<InitErc20Error> for InitTokenError {
@@ -58,6 +66,7 @@ impl From<InitErc20Error> for InitTokenError {
             InitErc20Error::Transport(transport) => InitTokenError::Transport(transport),
             InitErc20Error::Internal(internal) => InitTokenError::Internal(internal),
             InitErc20Error::CustomTokenError(error) => InitTokenError::CustomTokenError(error),
+            InitErc20Error::InvalidTokenProtocol => InitTokenError::InvalidTokenProtocol,
         }
     }
 }
@@ -73,6 +82,7 @@ impl From<EthTokenActivationError> for InitErc20Error {
             | EthTokenActivationError::InvalidPayload(_)
             | EthTokenActivationError::Transport(_) => InitErc20Error::Transport(e.to_string()),
             EthTokenActivationError::CustomTokenError(e) => InitErc20Error::CustomTokenError(e),
+            EthTokenActivationError::InvalidTokenProtocol => InitErc20Error::InvalidTokenProtocol,
         }
     }
 }

--- a/mm2src/coins_activation/src/init_token.rs
+++ b/mm2src/coins_activation/src/init_token.rs
@@ -296,17 +296,30 @@ pub enum InitTokenError {
     #[display(fmt = "No such task '{}'", _0)]
     NoSuchTask(TaskId),
     #[display(fmt = "Initialization task has timed out {:?}", duration)]
-    TaskTimedOut { duration: Duration },
+    TaskTimedOut {
+        duration: Duration,
+    },
     #[display(fmt = "Token {} is activated already", ticker)]
-    TokenIsAlreadyActivated { ticker: String },
+    TokenIsAlreadyActivated {
+        ticker: String,
+    },
     #[display(fmt = "Token {} config is not found", _0)]
     TokenConfigIsNotFound(String),
     #[display(fmt = "Token {} protocol parsing failed: {}", ticker, error)]
-    TokenProtocolParseError { ticker: String, error: String },
+    TokenProtocolParseError {
+        ticker: String,
+        error: String,
+    },
     #[display(fmt = "Unexpected platform protocol {} for {}", protocol, ticker)]
-    UnexpectedTokenProtocol { ticker: String, protocol: Json },
+    UnexpectedTokenProtocol {
+        ticker: String,
+        protocol: Json,
+    },
     #[display(fmt = "Error on platform coin {} creation: {}", ticker, error)]
-    TokenCreationError { ticker: String, error: String },
+    TokenCreationError {
+        ticker: String,
+        error: String,
+    },
     #[display(fmt = "Could not fetch balance: {}", _0)]
     CouldNotFetchBalance(String),
     #[display(fmt = "Platform coin {} is not activated", _0)]
@@ -324,6 +337,7 @@ pub enum InitTokenError {
     Transport(String),
     #[display(fmt = "Internal error: {}", _0)]
     Internal(String),
+    InvalidTokenProtocol,
 }
 
 impl From<CoinConfWithProtocolError> for InitTokenError {
@@ -364,6 +378,7 @@ impl HttpStatusCode for InitTokenError {
             | InitTokenError::UnexpectedTokenProtocol { .. }
             | InitTokenError::TokenCreationError { .. }
             | InitTokenError::PlatformCoinIsNotActivated(_)
+            | InitTokenError::InvalidTokenProtocol
             | InitTokenError::CustomTokenError(_) => StatusCode::BAD_REQUEST,
             InitTokenError::TaskTimedOut { .. } => StatusCode::REQUEST_TIMEOUT,
             InitTokenError::HwError(_) => StatusCode::GONE,

--- a/mm2src/coins_activation/src/platform_coin_with_tokens.rs
+++ b/mm2src/coins_activation/src/platform_coin_with_tokens.rs
@@ -74,6 +74,12 @@ pub trait TokenInitializer {
     ) -> Result<Vec<Self::Token>, MmError<Self::InitTokensError>>;
 
     fn platform_coin(&self) -> &<Self::Token as TokenOf>::PlatformCoin;
+
+    /// Currently ensures platform coin from the token protocol matches the platfrom coin ticker
+    fn validate_token_params(
+        &self,
+        params: &[TokenActivationParams<Self::TokenActivationRequest, Self::TokenProtocol>],
+    ) -> MmResult<(), Self::InitTokensError>;
 }
 
 #[async_trait]
@@ -98,6 +104,7 @@ pub enum InitTokensAsMmCoinsError {
     Transport(String),
     InvalidPayload(String),
     CustomTokenError(CustomTokenError),
+    InvalidTokenProtocol,
 }
 
 impl From<CoinConfWithProtocolError> for InitTokensAsMmCoinsError {
@@ -153,6 +160,7 @@ where
             .collect::<Result<Vec<_>, _>>()
             .map_mm_err()?;
 
+        self.validate_token_params(&token_params).map_mm_err()?;
         let tokens = self.enable_tokens(token_params).await.map_mm_err()?;
         for token in tokens.iter() {
             self.platform_coin().register_token_info(token);
@@ -281,6 +289,7 @@ pub enum EnablePlatformCoinWithTokensError {
     CustomTokenError(CustomTokenError),
     #[display(fmt = "WalletConnect Error: {}", _0)]
     WalletConnectError(String),
+    InvalidTokenProtocol,
 }
 
 impl From<CoinConfWithProtocolError> for EnablePlatformCoinWithTokensError {
@@ -324,6 +333,7 @@ impl From<InitTokensAsMmCoinsError> for EnablePlatformCoinWithTokensError {
                 EnablePlatformCoinWithTokensError::UnexpectedDerivationMethod(e.to_string())
             },
             InitTokensAsMmCoinsError::CustomTokenError(e) => EnablePlatformCoinWithTokensError::CustomTokenError(e),
+            InitTokensAsMmCoinsError::InvalidTokenProtocol => EnablePlatformCoinWithTokensError::InvalidTokenProtocol,
         }
     }
 }
@@ -370,8 +380,9 @@ impl HttpStatusCode for EnablePlatformCoinWithTokensError {
             | EnablePlatformCoinWithTokensError::NoSuchTask(_)
             | EnablePlatformCoinWithTokensError::UnexpectedDeviceActivationPolicy
             | EnablePlatformCoinWithTokensError::FailedSpawningBalanceEvents(_)
-            | EnablePlatformCoinWithTokensError::UnexpectedTokenProtocol { .. }
-            | EnablePlatformCoinWithTokensError::WalletConnectError(_) => StatusCode::BAD_REQUEST,
+            | EnablePlatformCoinWithTokensError::WalletConnectError(_)
+            | EnablePlatformCoinWithTokensError::InvalidTokenProtocol
+            | EnablePlatformCoinWithTokensError::UnexpectedTokenProtocol { .. } => StatusCode::BAD_REQUEST,
             EnablePlatformCoinWithTokensError::Transport(_) => StatusCode::BAD_GATEWAY,
         }
     }

--- a/mm2src/coins_activation/src/slp_token_activation.rs
+++ b/mm2src/coins_activation/src/slp_token_activation.rs
@@ -60,6 +60,7 @@ impl From<EnableSlpError> for EnableTokenError {
             EnableSlpError::UnexpectedDerivationMethod(e) | EnableSlpError::Internal(e) => {
                 EnableTokenError::Internal(e)
             },
+            EnableSlpError::InvalidTokenProtocol => EnableTokenError::InvalidTokenProtocol,
         }
     }
 }

--- a/mm2src/coins_activation/src/tendermint_with_assets_activation.rs
+++ b/mm2src/coins_activation/src/tendermint_with_assets_activation.rs
@@ -158,6 +158,14 @@ impl TokenInitializer for TendermintTokenInitializer {
     }
 
     fn platform_coin(&self) -> &<Self::Token as TokenOf>::PlatformCoin { &self.platform_coin }
+
+    fn validate_token_params(
+        &self,
+        _params: &[TokenActivationParams<Self::TokenActivationRequest, Self::TokenProtocol>],
+    ) -> MmResult<(), Self::InitTokensError> {
+        // there is no platform coin in TendermintTokenProtocolInfo to validate
+        Ok(())
+    }
 }
 
 impl TryFromCoinProtocol for TendermintProtocolInfo {

--- a/mm2src/coins_activation/src/token.rs
+++ b/mm2src/coins_activation/src/token.rs
@@ -69,6 +69,7 @@ pub enum EnableTokenError {
     PrivKeyPolicyNotAllowed(PrivKeyPolicyNotAllowed),
     #[display(fmt = "Custom token error: {}", _0)]
     CustomTokenError(CustomTokenError),
+    InvalidTokenProtocol,
 }
 
 impl From<RegisterCoinError> for EnableTokenError {
@@ -180,6 +181,7 @@ impl HttpStatusCode for EnableTokenError {
             | EnableTokenError::TokenConfigIsNotFound { .. }
             | EnableTokenError::UnexpectedTokenProtocol { .. }
             | EnableTokenError::InvalidPayload(_)
+            | EnableTokenError::InvalidTokenProtocol
             | EnableTokenError::CustomTokenError(_) => StatusCode::BAD_REQUEST,
             EnableTokenError::TokenProtocolParseError { .. }
             | EnableTokenError::UnsupportedPlatformCoin { .. }

--- a/mm2src/mm2_main/src/lp_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap.rs
@@ -137,10 +137,11 @@ pub use swap_watcher::{process_watcher_msg, watcher_topic, TakerSwapWatcherData,
                        MAKER_PAYMENT_SPEND_SENT_LOG, TAKER_PAYMENT_REFUND_SENT_LOG, TAKER_SWAP_ENTRY_TIMEOUT_SEC,
                        WATCHER_PREFIX};
 use taker_swap::TakerSwapEvent;
-pub use taker_swap::{calc_max_taker_vol, check_balance_for_taker_swap, max_taker_vol, max_taker_vol_from_available,
-                     run_taker_swap, taker_swap_trade_preimage, RunTakerSwapInput, TakerSavedSwap, TakerSwap,
-                     TakerSwapData, TakerSwapPreparedParams, TakerTradePreimage, MAKER_PAYMENT_SPENT_BY_WATCHER_LOG,
-                     REFUND_TEST_FAILURE_LOG, WATCHER_MESSAGE_SENT_LOG};
+pub use taker_swap::{calc_max_taker_vol, check_balance_for_taker_swap, create_taker_swap_default_params,
+                     max_taker_vol, max_taker_vol_from_available, run_taker_swap, taker_swap_trade_preimage,
+                     RunTakerSwapInput, TakerSavedSwap, TakerSwap, TakerSwapData, TakerSwapPreparedParams,
+                     TakerTradePreimage, MAKER_PAYMENT_SPENT_BY_WATCHER_LOG, REFUND_TEST_FAILURE_LOG,
+                     WATCHER_MESSAGE_SENT_LOG};
 pub use trade_preimage::trade_preimage_rpc;
 
 pub const SWAP_PREFIX: TopicPrefix = "swap";

--- a/mm2src/mm2_main/src/lp_swap/check_balance.rs
+++ b/mm2src/mm2_main/src/lp_swap/check_balance.rs
@@ -54,7 +54,9 @@ pub async fn check_my_coin_balance_for_swap(
         trade_fee.amount
     } else {
         let platform_coin_balance: MmNumber = coin.platform_coin_balance().compat().await.map_mm_err()?.into();
-        check_platform_coin_balance_for_swap(ctx, &platform_coin_balance, trade_fee, swap_uuid).await.map_mm_err()?;
+        check_platform_coin_balance_for_swap(ctx, &platform_coin_balance, trade_fee, swap_uuid)
+            .await
+            .map_mm_err()?;
         MmNumber::from(0)
     };
 
@@ -132,7 +134,9 @@ pub async fn check_other_coin_balance_for_swap(
         }
     } else {
         let platform_coin_balance: MmNumber = coin.platform_coin_balance().compat().await.map_mm_err()?.into();
-        check_platform_coin_balance_for_swap(ctx, &platform_coin_balance, trade_fee, swap_uuid).await.map_mm_err()?;
+        check_platform_coin_balance_for_swap(ctx, &platform_coin_balance, trade_fee, swap_uuid)
+            .await
+            .map_mm_err()?;
     }
 
     Ok(())

--- a/mm2src/mm2_main/src/lp_swap/maker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap.rs
@@ -1,4 +1,4 @@
-use super::check_balance::{check_base_coin_balance_for_swap, check_my_coin_balance_for_swap, CheckBalanceError,
+use super::check_balance::{check_my_coin_balance_for_swap, check_platform_coin_balance_for_swap, CheckBalanceError,
                            CheckBalanceResult};
 use super::pubkey_banning::ban_pubkey_on_failed_swap;
 use super::swap_lock::{SwapLock, SwapLockOps};
@@ -2419,8 +2419,9 @@ pub async fn calc_max_maker_vol(
         volume = &volume - &trade_fee.amount;
         required_to_pay_fee = trade_fee.amount;
     } else {
-        let base_coin_balance = coin.base_coin_balance().compat().await.map_mm_err()?;
-        check_base_coin_balance_for_swap(ctx, &MmNumber::from(base_coin_balance), trade_fee.clone(), None).await?;
+        let platform_coin_balance = coin.platform_coin_balance().compat().await.map_mm_err()?;
+        check_platform_coin_balance_for_swap(ctx, &MmNumber::from(platform_coin_balance), trade_fee.clone(), None)
+            .await.map_mm_err()?;
     }
     let min_tx_amount = MmNumber::from(coin.min_tx_amount());
     if volume < min_tx_amount {

--- a/mm2src/mm2_main/src/lp_swap/maker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap.rs
@@ -2421,7 +2421,8 @@ pub async fn calc_max_maker_vol(
     } else {
         let platform_coin_balance = coin.platform_coin_balance().compat().await.map_mm_err()?;
         check_platform_coin_balance_for_swap(ctx, &MmNumber::from(platform_coin_balance), trade_fee.clone(), None)
-            .await.map_mm_err()?;
+            .await
+            .map_mm_err()?;
     }
     let min_tx_amount = MmNumber::from(coin.min_tx_amount());
     if volume < min_tx_amount {

--- a/mm2src/mm2_main/src/lp_swap/max_maker_vol_rpc.rs
+++ b/mm2src/mm2_main/src/lp_swap/max_maker_vol_rpc.rs
@@ -26,7 +26,7 @@ pub enum MaxMakerVolRpcError {
         locked_by_swaps: Option<BigDecimal>,
     },
     #[display(
-        fmt = "Not enough base coin {} balance for swap: available {}, required at least {}, locked by swaps {:?}",
+        fmt = "Not enough platform coin {} balance for swap: available {}, required at least {}, locked by swaps {:?}",
         coin,
         available,
         required,

--- a/mm2src/mm2_main/src/lp_swap/trade_preimage.rs
+++ b/mm2src/mm2_main/src/lp_swap/trade_preimage.rs
@@ -198,7 +198,7 @@ pub enum TradePreimageRpcError {
         locked_by_swaps: Option<BigDecimal>,
     },
     #[display(
-        fmt = "Not enough base coin {} balance for swap: available {}, required at least {}, locked by swaps {:?}",
+        fmt = "Not enough platform coin {} balance for swap: available {}, required at least {}, locked by swaps {:?}",
         coin,
         available,
         required,

--- a/mm2src/mm2_main/src/rpc/lp_commands/legacy.rs
+++ b/mm2src/mm2_main/src/rpc/lp_commands/legacy.rs
@@ -138,7 +138,7 @@ pub async fn disable_coin(ctx: MmArc, req: Json) -> Result<Response<Vec<u8>>, St
 pub async fn electrum(ctx: MmArc, req: Json) -> Result<Response<Vec<u8>>, String> {
     let ticker = try_s!(req["coin"].as_str().ok_or("No 'coin' field")).to_owned();
     let coin: MmCoinEnum = try_s!(lp_coininit(&ctx, &ticker, &req).await);
-    let balance = match coin.my_balance().compat().timeout_secs(5.).await {
+    let balance = match coin.my_balance().compat().timeout_secs(20.).await {
         Ok(Ok(balance)) => balance,
         // If the coin was activated successfully but the balance query failed (most probably due to faulty
         // electrum servers), remove the coin as the whole request is a failure now from the POV of the GUI.

--- a/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
+++ b/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
@@ -3743,52 +3743,6 @@ fn test_invalid_token_protocol() {
 }
 
 #[test]
-fn test_invalid_token_protocol() {
-    let coin = erc20_coin_with_random_privkey(swap_contract());
-
-    let priv_key = coin.display_priv_key().unwrap();
-    let mut erc20_conf = erc20_dev_conf(&erc20_contract_checksum());
-    erc20_conf["protocol"]["protocol_data"]["platform"] = "MATIC".into(); // set invalid platform coin
-    let coins = json!([eth_dev_conf(), erc20_conf]);
-
-    let conf = Mm2TestConf::seednode(&priv_key, &coins);
-    let mm = MarketMakerIt::start(conf.conf, conf.rpc_password, None).unwrap();
-
-    let (_dump_log, _dump_dashboard) = mm.mm_dump();
-    log!("log path: {}", mm.log_path.display());
-
-    let swap_contract = format!("0x{}", hex::encode(swap_contract()));
-    let erc20_tokens_requests = vec![json!({ "ticker": "ERC20DEV" })];
-    let nodes = vec![json!({ "url": GETH_RPC_URL })];
-
-    let enable = block_on(mm.rpc(&json!({
-    "userpass": mm.userpass,
-    "method": "enable_eth_with_tokens",
-    "mmrpc": "2.0",
-    "params": {
-            "ticker": "ETH",
-            "erc20_tokens_requests": erc20_tokens_requests,
-            "swap_contract_address": swap_contract,
-            "nodes": nodes,
-            "tx_history": false,
-            "get_balances": false,
-        }
-    })))
-    .unwrap();
-    assert_eq!(
-        enable.0,
-        StatusCode::BAD_REQUEST,
-        "'enable_eth_with_tokens' must fail with InvalidTokenProtocol",
-    );
-    assert_eq!(
-        serde_json::from_str::<serde_json::Value>(&enable.1).unwrap()["error_type"]
-            .as_str()
-            .unwrap(),
-        "InvalidTokenProtocol",
-    );
-}
-
-#[test]
 fn test_enable_eth_coin_with_token_without_balance() {
     let coin = erc20_coin_with_random_privkey(swap_contract());
 

--- a/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
+++ b/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
@@ -3697,6 +3697,52 @@ fn test_enable_eth_coin_with_token_then_disable() {
 }
 
 #[test]
+fn test_invalid_token_protocol() {
+    let coin = erc20_coin_with_random_privkey(swap_contract());
+
+    let priv_key = coin.display_priv_key().unwrap();
+    let mut erc20_conf = erc20_dev_conf(&erc20_contract_checksum());
+    erc20_conf["protocol"]["protocol_data"]["platform"] = "MATIC".into(); // set invalid platform coin
+    let coins = json!([eth_dev_conf(), erc20_conf]);
+
+    let conf = Mm2TestConf::seednode(&priv_key, &coins);
+    let mm = MarketMakerIt::start(conf.conf, conf.rpc_password, None).unwrap();
+
+    let (_dump_log, _dump_dashboard) = mm.mm_dump();
+    log!("log path: {}", mm.log_path.display());
+
+    let swap_contract = format!("0x{}", hex::encode(swap_contract()));
+    let erc20_tokens_requests = vec![json!({ "ticker": "ERC20DEV" })];
+    let nodes = vec![json!({ "url": GETH_RPC_URL })];
+
+    let enable = block_on(mm.rpc(&json!({
+    "userpass": mm.userpass,
+    "method": "enable_eth_with_tokens",
+    "mmrpc": "2.0",
+    "params": {
+            "ticker": "ETH",
+            "erc20_tokens_requests": erc20_tokens_requests,
+            "swap_contract_address": swap_contract,
+            "nodes": nodes,
+            "tx_history": false,
+            "get_balances": false,
+        }
+    })))
+    .unwrap();
+    assert_eq!(
+        enable.0,
+        StatusCode::BAD_REQUEST,
+        "'enable_eth_with_tokens' must fail with InvalidTokenProtocol",
+    );
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&enable.1).unwrap()["error_type"]
+            .as_str()
+            .unwrap(),
+        "InvalidTokenProtocol",
+    );
+}
+
+#[test]
 fn test_enable_eth_coin_with_token_without_balance() {
     let coin = erc20_coin_with_random_privkey(swap_contract());
 

--- a/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
+++ b/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
@@ -3743,6 +3743,52 @@ fn test_invalid_token_protocol() {
 }
 
 #[test]
+fn test_invalid_token_protocol() {
+    let coin = erc20_coin_with_random_privkey(swap_contract());
+
+    let priv_key = coin.display_priv_key().unwrap();
+    let mut erc20_conf = erc20_dev_conf(&erc20_contract_checksum());
+    erc20_conf["protocol"]["protocol_data"]["platform"] = "MATIC".into(); // set invalid platform coin
+    let coins = json!([eth_dev_conf(), erc20_conf]);
+
+    let conf = Mm2TestConf::seednode(&priv_key, &coins);
+    let mm = MarketMakerIt::start(conf.conf, conf.rpc_password, None).unwrap();
+
+    let (_dump_log, _dump_dashboard) = mm.mm_dump();
+    log!("log path: {}", mm.log_path.display());
+
+    let swap_contract = format!("0x{}", hex::encode(swap_contract()));
+    let erc20_tokens_requests = vec![json!({ "ticker": "ERC20DEV" })];
+    let nodes = vec![json!({ "url": GETH_RPC_URL })];
+
+    let enable = block_on(mm.rpc(&json!({
+    "userpass": mm.userpass,
+    "method": "enable_eth_with_tokens",
+    "mmrpc": "2.0",
+    "params": {
+            "ticker": "ETH",
+            "erc20_tokens_requests": erc20_tokens_requests,
+            "swap_contract_address": swap_contract,
+            "nodes": nodes,
+            "tx_history": false,
+            "get_balances": false,
+        }
+    })))
+    .unwrap();
+    assert_eq!(
+        enable.0,
+        StatusCode::BAD_REQUEST,
+        "'enable_eth_with_tokens' must fail with InvalidTokenProtocol",
+    );
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&enable.1).unwrap()["error_type"]
+            .as_str()
+            .unwrap(),
+        "InvalidTokenProtocol",
+    );
+}
+
+#[test]
 fn test_enable_eth_coin_with_token_without_balance() {
     let coin = erc20_coin_with_random_privkey(swap_contract());
 


### PR DESCRIPTION
This is a refactoring PR (preliminary for the upcoming liquidity routing feature):
- rename base_coin_balance to platform_coin_balance fn (to avoid confusion with 'base/rel').
- add const for eth timeouts and increase them.
- increase electrum my_balance timeout
- add check for tokens to match the platform coin in the eth coin activation request.