### PR TITLE
feat(coins): implement ARRR ZHTLC offline key export functionality

### DIFF
--- a/mm2src/coins/rpc_command/offline_keys.rs
+++ b/mm2src/coins/rpc_command/offline_keys.rs
@@ -175,14 +175,14 @@ fn extract_prefix_values(
                 })? as u8;
 
             let consensus_params = &coin_conf["protocol"]["protocol_data"]["consensus_params"];
-            
+
             let pub_prefix = consensus_params["b58_pubkey_address_prefix"]
                 .as_array()
                 .ok_or_else(|| OfflineKeysError::MissingPrefixValue {
                     ticker: ticker.to_string(),
                     prefix_type: "b58_pubkey_address_prefix".to_string(),
                 })?;
-            
+
             let script_prefix = consensus_params["b58_script_address_prefix"]
                 .as_array()
                 .ok_or_else(|| OfflineKeysError::MissingPrefixValue {
@@ -299,16 +299,16 @@ async fn offline_hd_keys_export_internal(
 
         let mut addresses = Vec::with_capacity((end_index - start_index + 1) as usize);
 
-        let crypto_ctx = CryptoCtx::from_ctx(&ctx).map_err(|e| OfflineKeysError::Internal(
-            format!("Failed to get crypto context: {}", e),
-        ))?;
+        let crypto_ctx = CryptoCtx::from_ctx(&ctx)
+            .map_err(|e| OfflineKeysError::Internal(format!("Failed to get crypto context: {}", e)))?;
 
         let global_hd_ctx = match crypto_ctx.key_pair_policy() {
             KeyPairPolicy::GlobalHDAccount(hd_ctx) => hd_ctx.clone(),
             KeyPairPolicy::Iguana => {
                 return MmError::err(OfflineKeysError::KeyDerivationFailed {
                     ticker: ticker.clone(),
-                    error: "HD key derivation requires GlobalHDAccount mode. Please initialize with HD wallet.".to_string(),
+                    error: "HD key derivation requires GlobalHDAccount mode. Please initialize with HD wallet."
+                        .to_string(),
                 });
             },
         };
@@ -361,7 +361,8 @@ async fn offline_hd_keys_export_internal(
                         AddressFormat::Standard
                     };
 
-                    let bech32_hrp = coin_conf.get("bech32_hrp")
+                    let bech32_hrp = coin_conf
+                        .get("bech32_hrp")
                         .and_then(|v| v.as_str())
                         .map(|s| s.to_string());
 
@@ -583,7 +584,7 @@ mod tests {
     #[tokio::test]
     async fn test_btc_hd_key_derivation() {
         use mm2_test_helpers::for_tests::btc_with_spv_conf;
-        
+
         let mut btc_conf = btc_with_spv_conf();
         btc_conf["derivation_path"] = json!("m/44'/0'");
         let ctx = MmCtxBuilder::new()
@@ -592,7 +593,7 @@ mod tests {
                 "rpc_password": "test123"
             }))
             .into_mm_arc();
-        
+
         CryptoCtx::init_with_global_hd_account(ctx.clone(), TEST_MNEMONIC).unwrap();
 
         let req = GetPrivateKeysRequest {
@@ -653,7 +654,7 @@ mod tests {
     #[tokio::test]
     async fn test_btc_segwit_hd_key_derivation() {
         use mm2_test_helpers::for_tests::btc_segwit_conf;
-        
+
         let mut btc_segwit_conf = btc_segwit_conf();
         btc_segwit_conf["derivation_path"] = json!("m/84'/0'");
         let ctx = MmCtxBuilder::new()
@@ -662,7 +663,7 @@ mod tests {
                 "rpc_password": "test123"
             }))
             .into_mm_arc();
-        
+
         CryptoCtx::init_with_global_hd_account(ctx.clone(), TEST_MNEMONIC).unwrap();
 
         let req = GetPrivateKeysRequest {
@@ -712,7 +713,7 @@ mod tests {
     #[tokio::test]
     async fn test_eth_hd_key_derivation() {
         use mm2_test_helpers::for_tests::eth_dev_conf;
-        
+
         let mut eth_conf = eth_dev_conf();
         eth_conf["derivation_path"] = json!("m/44'/60'");
         let ctx = MmCtxBuilder::new()
@@ -721,7 +722,7 @@ mod tests {
                 "rpc_password": "test123"
             }))
             .into_mm_arc();
-        
+
         CryptoCtx::init_with_global_hd_account(ctx.clone(), TEST_MNEMONIC).unwrap();
 
         let req = GetPrivateKeysRequest {
@@ -771,7 +772,7 @@ mod tests {
     #[tokio::test]
     async fn test_atom_hd_key_derivation() {
         use mm2_test_helpers::for_tests::atom_testnet_conf;
-        
+
         let mut atom_conf = atom_testnet_conf();
         atom_conf["derivation_path"] = json!("m/44'/118'");
         let ctx = MmCtxBuilder::new()
@@ -780,7 +781,7 @@ mod tests {
                 "rpc_password": "test123"
             }))
             .into_mm_arc();
-        
+
         CryptoCtx::init_with_global_hd_account(ctx.clone(), TEST_MNEMONIC).unwrap();
 
         let req = GetPrivateKeysRequest {
@@ -834,7 +835,7 @@ mod tests {
     #[tokio::test]
     async fn test_iguana_key_derivation() {
         use mm2_test_helpers::for_tests::btc_with_spv_conf;
-        
+
         let mut btc_conf = btc_with_spv_conf();
         btc_conf["derivation_path"] = json!("m/44'/0'");
         let ctx = MmCtxBuilder::new()
@@ -843,7 +844,7 @@ mod tests {
                 "rpc_password": "test123"
             }))
             .into_mm_arc();
-        
+
         CryptoCtx::init_with_iguana_passphrase(ctx.clone(), TEST_MNEMONIC).unwrap();
 
         let req = OfflineKeysRequest {
@@ -868,7 +869,7 @@ mod tests {
     #[tokio::test]
     async fn test_error_cases() {
         use mm2_test_helpers::for_tests::btc_with_spv_conf;
-        
+
         let mut btc_conf = btc_with_spv_conf();
         btc_conf["derivation_path"] = json!("m/44'/0'");
         let ctx = MmCtxBuilder::new()
@@ -877,7 +878,7 @@ mod tests {
                 "rpc_password": "test123"
             }))
             .into_mm_arc();
-        
+
         CryptoCtx::init_with_global_hd_account(ctx.clone(), TEST_MNEMONIC).unwrap();
 
         let invalid_range_req = GetPrivateKeysRequest {
@@ -932,7 +933,7 @@ mod tests {
     #[tokio::test]
     async fn test_arrr_hd_key_derivation() {
         use mm2_test_helpers::for_tests::pirate_conf;
-        
+
         let mut arrr_conf = pirate_conf();
         arrr_conf["wiftype"] = json!(128);
         let ctx = MmCtxBuilder::new()
@@ -941,7 +942,7 @@ mod tests {
                 "rpc_password": "test123"
             }))
             .into_mm_arc();
-        
+
         CryptoCtx::init_with_global_hd_account(ctx.clone(), TEST_MNEMONIC).unwrap();
 
         let response = offline_hd_keys_export_internal(ctx.clone(), vec!["ARRR".to_string()], 0, 2, 0).await;
@@ -967,7 +968,7 @@ mod tests {
     #[tokio::test]
     async fn test_arrr_iguana_key_derivation() {
         use mm2_test_helpers::for_tests::pirate_conf;
-        
+
         let mut arrr_conf = pirate_conf();
         arrr_conf["wiftype"] = json!(128);
         let ctx = MmCtxBuilder::new()
@@ -976,7 +977,7 @@ mod tests {
                 "rpc_password": "test123"
             }))
             .into_mm_arc();
-        
+
         CryptoCtx::init_with_iguana_passphrase(ctx.clone(), TEST_MNEMONIC).unwrap();
 
         let req = OfflineKeysRequest {

--- a/mm2src/coins/rpc_command/offline_keys.rs
+++ b/mm2src/coins/rpc_command/offline_keys.rs
@@ -396,7 +396,7 @@ async fn offline_hd_keys_export_internal(
                     (address, priv_key)
                 },
                 Some(PrefixValues::Tendermint { account_prefix }) => {
-                    let address = tendermint::account_id_from_pubkey_hex(&account_prefix, &pubkey)
+                    let address = tendermint::account_id_from_pubkey_hex(account_prefix, &pubkey)
                         .map_err(|e| OfflineKeysError::Internal(e.to_string()))?
                         .to_string();
 
@@ -591,7 +591,7 @@ mod tests {
 
         CryptoCtx::init_with_global_hd_account(ctx.clone(), TEST_MNEMONIC).unwrap();
 
-        let req = GetPrivateKeysRequest {
+        let _req = GetPrivateKeysRequest {
             coins: vec!["BTC".to_string()],
             mode: Some(KeyExportMode::Hd),
             start_index: Some(0),
@@ -615,7 +615,7 @@ mod tests {
             "L5kmC8cqWodyjm2JUQNfRbmyZeJMJMeYH4WJGUSVcdnD9X6aAs8Z",
         ];
 
-        let btc_conf = json!({
+        let _btc_conf = json!({
             "coin": "BTC",
             "protocol": {
                 "type": "UTXO"
@@ -661,7 +661,7 @@ mod tests {
 
         CryptoCtx::init_with_global_hd_account(ctx.clone(), TEST_MNEMONIC).unwrap();
 
-        let req = GetPrivateKeysRequest {
+        let _req = GetPrivateKeysRequest {
             coins: vec!["BTC-segwit".to_string()],
             mode: Some(KeyExportMode::Hd),
             start_index: Some(0),
@@ -720,7 +720,7 @@ mod tests {
 
         CryptoCtx::init_with_global_hd_account(ctx.clone(), TEST_MNEMONIC).unwrap();
 
-        let req = GetPrivateKeysRequest {
+        let _req = GetPrivateKeysRequest {
             coins: vec!["ETH".to_string()],
             mode: Some(KeyExportMode::Hd),
             start_index: Some(0),
@@ -779,7 +779,7 @@ mod tests {
 
         CryptoCtx::init_with_global_hd_account(ctx.clone(), TEST_MNEMONIC).unwrap();
 
-        let req = GetPrivateKeysRequest {
+        let _req = GetPrivateKeysRequest {
             coins: vec!["ATOM".to_string()],
             mode: Some(KeyExportMode::Hd),
             start_index: Some(0),
@@ -792,12 +792,12 @@ mod tests {
             "cosmos1cecqkvtwn0vyr730yq3hawrl8rztvchz6kadk8",
             "cosmos1c27v3agv745fhnjve8ch754rmzswuc7guglt76",
         ];
-        let expected_pubkeys = [
+        let _expected_pubkeys = [
             "cosmospub1addwnpepq09wmcqe8qvcmyvgre8g07q9z42rz6y7uguz5dxqvhw0tdrqa38csd8wlfa",
             "cosmospub1addwnpepq0uy8zghd8q8p5wjvz84catqgwuwem45s5rpvd9syq44jz2jmyqfvp049kz",
             "cosmospub1add", // Truncated in the original test vectors
         ];
-        let expected_privkeys_base64 = [
+        let _expected_privkeys_base64 = [
             "Nbfdi2ZHb+2W41DNJPaHxAi6oHcJ4lFLtBZkATGAB8M=",
             "8FJrDCXtcLl6OgjqF/l5QQvUYYpjwGn+F3q3pBp3e94=",
         ];

--- a/mm2src/coins/rpc_command/offline_keys.rs
+++ b/mm2src/coins/rpc_command/offline_keys.rs
@@ -167,12 +167,7 @@ fn extract_prefix_values(
             }))
         },
         CoinProtocol::ZHTLC(_protocol_info) => {
-            let wif_type = coin_conf["wiftype"]
-                .as_u64()
-                .ok_or_else(|| OfflineKeysError::MissingPrefixValue {
-                    ticker: ticker.to_string(),
-                    prefix_type: "wiftype".to_string(),
-                })? as u8;
+            let wif_type = coin_conf["wiftype"].as_u64().unwrap_or(128) as u8;
 
             let consensus_params = &coin_conf["protocol"]["protocol_data"]["consensus_params"];
 
@@ -934,8 +929,7 @@ mod tests {
     async fn test_arrr_hd_key_derivation() {
         use mm2_test_helpers::for_tests::pirate_conf;
 
-        let mut arrr_conf = pirate_conf();
-        arrr_conf["wiftype"] = json!(128);
+        let arrr_conf = pirate_conf();
         let ctx = MmCtxBuilder::new()
             .with_conf(json!({
                 "coins": [arrr_conf],
@@ -969,8 +963,7 @@ mod tests {
     async fn test_arrr_iguana_key_derivation() {
         use mm2_test_helpers::for_tests::pirate_conf;
 
-        let mut arrr_conf = pirate_conf();
-        arrr_conf["wiftype"] = json!(128);
+        let arrr_conf = pirate_conf();
         let ctx = MmCtxBuilder::new()
             .with_conf(json!({
                 "coins": [arrr_conf],

--- a/mm2src/coins/rpc_command/offline_keys.rs
+++ b/mm2src/coins/rpc_command/offline_keys.rs
@@ -599,17 +599,17 @@ mod tests {
             account_index: Some(0),
         };
 
-        let expected_addresses = vec![
+        let expected_addresses = [
             "1DWZWURWrdJnuZBqQgv3THfmhbxWgJuFex",
             "17jQZo8xSjJeQLxexLZSZaBA9ks5tWh3fJ",
             "13ZwKLGksE72YgMdKjJC9XZPM6TcpejJrJ",
         ];
-        let expected_pubkeys = vec![
+        let expected_pubkeys = [
             "037e746753316b028859ff20bac70ed4803a3056038e54ef86f71f35e53a6c8625",
             "030bd2b7ab3800a968544bb097a78c1ecfed233af342359e399d72fd970aa35323",
             "034bf56e7072f8f378a8efee382c9a438fa4b4c98c387d4a0db543afc434c4adaf",
         ];
-        let expected_privkeys = vec![
+        let expected_privkeys = [
             "KywJqZF9PrFSwWkocQ4JZSgfTD3eXYbfnM54Q3Ua7UKzGD4WTRbX",
             "KwLRhtqifoX1FuMFJytB85DCZf6YoSjuFSqPXBzPsyi56GXJaVpD",
             "L5kmC8cqWodyjm2JUQNfRbmyZeJMJMeYH4WJGUSVcdnD9X6aAs8Z",
@@ -669,17 +669,17 @@ mod tests {
             account_index: Some(0),
         };
 
-        let expected_addresses = vec![
+        let expected_addresses = [
             "bc1q4cn6qhvuajkdfhk3fzuup07ktrepcukc8hv0c8",
             "bc1qv26wdgw5vqf7fcup92yhjmm234zwd2wrgv5f4f",
             "bc1qvs2pggxxcl40n9cs9v9crkclmrx57hgp5f6579",
         ];
-        let expected_pubkeys = vec![
+        let expected_pubkeys = [
             "024b796b083b51ea5820bbdb80fa4e7f09f5f8c6fe76bc68fa2d8d0452a4ddfa91",
             "0272a14e54bbfa321f7afa8d98b478f7e5bea5440f3e807bd87f5c00f75ef0941f",
             "03e10fed91ec91740c726b945671954c040cd42b3ad9ab5791133f1a33d4c42e5d",
         ];
-        let expected_privkeys = vec![
+        let expected_privkeys = [
             "L2aJGVhekAig5a4Zx81NH9Q99h9gH7umiyqBWXrNX5w8xn2eeU5g",
             "L1susQQK5CaP7eT4MKyAzv8KthN53i5gHJmUGtKksY8r2Hbvvyv6",
             "Kz937rcd2Hack7TUgkcg3YAiSbTGGJciMCzFbu76FkJgZkwb5zES",
@@ -728,17 +728,17 @@ mod tests {
             account_index: Some(0),
         };
 
-        let expected_addresses = vec![
+        let expected_addresses = [
             "0x6B06d67C539B101180aC03b61ba7F7f3158CE54d",
             "0x012F492f2d254e204dD8da3a4f0d6071C345b9D1",
             "0xa713617C963b82429909B09B9181a22884f1eb8f",
         ];
-        let expected_pubkeys = vec![
+        let expected_pubkeys = [
             "02a2b68c3126ba160e5ffb7c0d5c5c5c56e724f57e5ec0ace40d6db990e688ed4a",
             "02d7efb9086100311021166c11b2dc7ca941ccbe242b51206555721efe93737678",
             "03353b68f1b2c0891edf78395480bc67e128fb967c5722a6b41d784da295986d4d",
         ];
-        let expected_privkeys = vec![
+        let expected_privkeys = [
             "0x646431107ae37e826aaa5108fe2c2611ef15615e78b4175919b85fd6366f19a3",
             "0xc11fc3d704820e752bfae8db9f02e489c1e742392b35ac5b4a4e441e7955efa4",
             "0xddb38472a7d7095ad466b4a4e19f85f612f87e04a23c75eac8e7957d31ee22f0",
@@ -787,17 +787,17 @@ mod tests {
             account_index: Some(0),
         };
 
-        let expected_addresses = vec![
+        let expected_addresses = [
             "cosmos1j398pch49fkgx986r4aqm57zp3phuzq4p30dhh",
             "cosmos1cecqkvtwn0vyr730yq3hawrl8rztvchz6kadk8",
             "cosmos1c27v3agv745fhnjve8ch754rmzswuc7guglt76",
         ];
-        let expected_pubkeys = vec![
+        let expected_pubkeys = [
             "cosmospub1addwnpepq09wmcqe8qvcmyvgre8g07q9z42rz6y7uguz5dxqvhw0tdrqa38csd8wlfa",
             "cosmospub1addwnpepq0uy8zghd8q8p5wjvz84catqgwuwem45s5rpvd9syq44jz2jmyqfvp049kz",
             "cosmospub1add", // Truncated in the original test vectors
         ];
-        let expected_privkeys_base64 = vec![
+        let expected_privkeys_base64 = [
             "Nbfdi2ZHb+2W41DNJPaHxAi6oHcJ4lFLtBZkATGAB8M=",
             "8FJrDCXtcLl6OgjqF/l5QQvUYYpjwGn+F3q3pBp3e94=",
         ];


### PR DESCRIPTION
# fix: add default wiftype handling for ZHTLC coins in offline key export

## Summary
This PR implements ARRR coin offline key export functionality and fixes the "Missing prefix value for ARRR: wiftype" error that occurs when using the `get_private_keys` RPC method with ZHTLC coins.

**Key Changes:**
- Added `CoinProtocol::ZHTLC` support to the `extract_prefix_values` function
- Implemented default `wiftype` handling (value: 128) for ZHTLC coins using `unwrap_or(128)` 
- Added comprehensive tests for ARRR offline key export in both HD and Iguana modes
- Extracted address prefixes from ZHTLC protocol configuration (`b58_pubkey_address_prefix` and `b58_script_address_prefix`)

**Background:** ZHTLC coins like ARRR natively use `encode_extended_spending_key` for private key display, but don't include a `wiftype` field in their configuration. The offline key export system expects all coins to have this field for standard WIF encoding compatibility.

## Review & Testing Checklist for Human
- [ ] **[CRITICAL]** Test the original failing RPC call to verify the fix: `curl --url http://127.0.0.1:7783 --data '{"userpass": "ca_is_my_master", "mmrpc": "2.0", "method": "get_private_keys", "params": {"coins": ["ARRR"], "mode": "iguana"}}'`
- [ ] **[HIGH]** Verify that `wiftype: 128` (Bitcoin-compatible WIF encoding) is the appropriate default for ZHTLC coins by checking against other similar coins in the codebase
- [ ] **[MEDIUM]** Test both HD and Iguana modes work correctly for ARRR offline key export
- [ ] **[MEDIUM]** Spot check that other coin types (BTC, ETH, ATOM) still work correctly to ensure no regression in `extract_prefix_values` function

**Recommended Test Plan:**
1. Start MM2 with ARRR configuration
2. Test the `get_private_keys` RPC call that was originally failing
3. Verify generated addresses and private keys are valid for ARRR
4. Test with other ZHTLC coins (e.g., ZOMBIE) to ensure they also work
5. Run existing offline key export tests to ensure no regression

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A["mm2src/coins/rpc_command/<br/>offline_keys.rs"]:::major-edit
    B["extract_prefix_values()<br/>function"]:::major-edit
    C["ZHTLC protocol<br/>handling"]:::major-edit
    D["test_arrr_hd_key_derivation()<br/>test"]:::major-edit
    E["test_arrr_iguana_key_derivation()<br/>test"]:::major-edit
    F["mm2src/coins/z_coin.rs"]:::context
    G["mm2src/mm2_test_helpers/<br/>src/for_tests.rs"]:::context
    
    A --> B
    B --> C
    A --> D
    A --> E
    C -.-> F
    D -.-> G
    E -.-> G
    
    C --> |"adds default wiftype=128"| H["PrefixValues::Utxo"]:::minor-edit
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes
- The choice of `wiftype: 128` follows the pattern used in tests and matches Bitcoin-compatible WIF encoding
- ZHTLC coins natively use `encode_extended_spending_key` but this implementation uses standard WIF for offline key export compatibility
- All existing unit tests pass, including the new ARRR-specific tests
- This change enables offline key export for all ZHTLC coins, not just ARRR

**Session Info:**
- Link to Devin run: https://app.devin.ai/sessions/0a5a5b3229ec47f68ce4ec8e8b11ee7b
- Requested by: @ca333