### PR TITLE
fix(DOC): improve docker tests start doc

### DIFF
--- a/docs/DEV_ENVIRONMENT.md
+++ b/docs/DEV_ENVIRONMENT.md
@@ -38,10 +38,13 @@
        ```
 9. Try `cargo test --all --features run-docker-tests -- --test-threads=16`.
 
-   Note for MacOS users:
-    - The UTXO 'testblockchain' docker container may fail to start due to TCP port conflict with MacOS AirPlay Receiver (using the same 7000 port). Disabling AirPlay Receiver resolves this problem.
+   Warning:
 
-    - The 'nucleusd' test docker container (and the dependent 'ibc-relayer' container) may fail to start on MacOS. The MacOS docker "Enable host networking" option may help with this issue.
+   Running the tests will start several Docker containers. If any container fails to start, check for potential port conflicts with existing services on your system. For example, on MacOS, the testblockchain container (used for UTXO testing) may not start because it uses port 7000, which is also used by the MacOS AirPlay Receiver. To resolve this issue, disable AirPlay Receiver in your system settings.
+
+   Note for MacOS users:
+
+   The nucleusd container (and its dependent ibc-relayer container) requires host network access. However, on MacOS, Docker does not support host networking by default. To ensure the nucleusd container runs correctly, make sure to turn on the "Enable host networking" option in your Docker settings.
 
 ## Running WASM tests
 


### PR DESCRIPTION
Improve the docker test start failure note on @onur-ozkan review 
(gpt was used to fix it)