### PR TITLE
fix: remove nested result field in offline key export response

### DIFF
--- a/mm2src/coins/rpc_command/offline_keys.rs
+++ b/mm2src/coins/rpc_command/offline_keys.rs
@@ -69,19 +69,10 @@ pub struct HdAddressInfo {
 #[derive(Debug, Serialize)]
 #[serde(untagged)]
 pub enum GetPrivateKeysResponse {
-    Iguana(IguanaKeysResponse),
-    Hd(HdKeysResponse),
+    Iguana(Vec<CoinKeyInfo>),
+    Hd(Vec<HdCoinKeyInfo>),
 }
 
-#[derive(Debug, Serialize)]
-pub struct IguanaKeysResponse {
-    pub result: Vec<CoinKeyInfo>,
-}
-
-#[derive(Debug, Serialize)]
-pub struct HdKeysResponse {
-    pub result: Vec<HdCoinKeyInfo>,
-}
 
 #[derive(Debug, Display, Serialize, SerializeErrorType)]
 #[serde(tag = "error_type", content = "error_data")]
@@ -233,7 +224,7 @@ async fn offline_hd_keys_export_internal(
     start_index: u32,
     end_index: u32,
     account_index: u32,
-) -> Result<HdKeysResponse, MmError<OfflineKeysError>> {
+) -> Result<Vec<HdCoinKeyInfo>, MmError<OfflineKeysError>> {
     if start_index > end_index {
         return MmError::err(OfflineKeysError::InvalidHdRange { start_index, end_index });
     }
@@ -448,13 +439,13 @@ async fn offline_hd_keys_export_internal(
         });
     }
 
-    Ok(HdKeysResponse { result })
+    Ok(result)
 }
 
 async fn offline_iguana_keys_export_internal(
     ctx: MmArc,
     req: OfflineKeysRequest,
-) -> Result<IguanaKeysResponse, MmError<OfflineKeysError>> {
+) -> Result<Vec<CoinKeyInfo>, MmError<OfflineKeysError>> {
     let mut result = Vec::with_capacity(req.coins.len());
 
     for ticker in &req.coins {
@@ -578,7 +569,7 @@ async fn offline_iguana_keys_export_internal(
         });
     }
 
-    Ok(IguanaKeysResponse { result })
+    Ok(result)
 }
 
 pub async fn get_private_keys(
@@ -685,8 +676,8 @@ mod tests {
 
         match response {
             Ok(hd_response) => {
-                assert_eq!(hd_response.result.len(), 1);
-                let btc_result = &hd_response.result[0];
+                assert_eq!(hd_response.len(), 1);
+                let btc_result = &hd_response[0];
                 assert_eq!(btc_result.coin, "BTC");
                 assert_eq!(btc_result.addresses.len(), 3);
 
@@ -744,8 +735,8 @@ mod tests {
 
         match response {
             Ok(hd_response) => {
-                assert_eq!(hd_response.result.len(), 1);
-                let btc_segwit_result = &hd_response.result[0];
+                assert_eq!(hd_response.len(), 1);
+                let btc_segwit_result = &hd_response[0];
                 assert_eq!(btc_segwit_result.coin, "BTC-segwit");
                 assert_eq!(btc_segwit_result.addresses.len(), 3);
 
@@ -803,8 +794,8 @@ mod tests {
 
         match response {
             Ok(hd_response) => {
-                assert_eq!(hd_response.result.len(), 1);
-                let eth_result = &hd_response.result[0];
+                assert_eq!(hd_response.len(), 1);
+                let eth_result = &hd_response[0];
                 assert_eq!(eth_result.coin, "ETH");
                 assert_eq!(eth_result.addresses.len(), 3);
 
@@ -868,8 +859,8 @@ mod tests {
 
         match response {
             Ok(hd_response) => {
-                assert_eq!(hd_response.result.len(), 1);
-                let atom_result = &hd_response.result[0];
+                assert_eq!(hd_response.len(), 1);
+                let atom_result = &hd_response[0];
                 assert_eq!(atom_result.coin, "ATOM");
                 assert_eq!(atom_result.addresses.len(), 2);
 
@@ -905,8 +896,8 @@ mod tests {
 
         match response {
             Ok(iguana_response) => {
-                assert_eq!(iguana_response.result.len(), 1);
-                let btc_result = &iguana_response.result[0];
+                assert_eq!(iguana_response.len(), 1);
+                let btc_result = &iguana_response[0];
                 assert_eq!(btc_result.coin, "BTC");
                 assert!(!btc_result.pubkey.is_empty());
                 assert!(!btc_result.address.is_empty());
@@ -1037,8 +1028,8 @@ mod tests {
 
         match response {
             GetPrivateKeysResponse::Hd(hd_response) => {
-                assert_eq!(hd_response.result.len(), 1);
-                let arrr_result = &hd_response.result[0];
+                assert_eq!(hd_response.len(), 1);
+                let arrr_result = &hd_response[0];
                 assert_eq!(arrr_result.coin, "ARRR");
                 assert_eq!(arrr_result.addresses.len(), 2);
 


### PR DESCRIPTION
# fix: remove nested result field in offline key export response

## Summary
Fixes the nested "result result" response structure in the offline key export RPC endpoint. The issue was caused by both the response wrapper structs (`IguanaKeysResponse` and `HdKeysResponse`) having their own `result` field, while the RPC framework (`MmRpcBuilder`) automatically wraps all successful responses with an additional `result` field.

**Before:**
```json
{
    "mmrpc": "2.0",
    "result": {
        "result": [...]  // <- nested result
    },
    "id": null
}
```

**After:**
```json
{
    "mmrpc": "2.0",
    "result": [...],  // <- single result as intended
    "id": null
}
```

The fix removes the redundant wrapper structs and updates the response enum to directly contain the data, allowing the RPC framework to provide the correct single-level wrapping.

## Review & Testing Checklist for Human
- [ ] **Test the actual RPC endpoint** with both HD and non-HD key export requests to verify the response format is correct and matches the expected structure
- [ ] **Verify integration scenarios** - run any existing integration tests to ensure no regressions in key derivation or export functionality  
- [ ] **Check client compatibility** - confirm that removing the nested result won't break any existing client applications that depend on this endpoint
- [ ] **Test edge cases** - verify the endpoint handles error cases properly and that the response structure is consistent across different coin types

**Recommended test plan:** Make actual RPC calls to the offline key export endpoint with various coin configurations (both HD and non-HD) and verify the JSON response structure matches the desired format.

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    RPC["RPC Request Handler<br/>(dispatcher.rs)"]:::context
    GetKeys["get_private_keys()<br/>(offline_keys.rs)"]:::minor-edit
    
    HdInternal["offline_hd_keys_export_internal()<br/>(offline_keys.rs)"]:::major-edit
    IguanaInternal["offline_iguana_keys_export_internal()<br/>(offline_keys.rs)"]:::major-edit
    
    ResponseEnum["GetPrivateKeysResponse enum<br/>(offline_keys.rs)"]:::major-edit
    RemovedStructs["❌ IguanaKeysResponse<br/>❌ HdKeysResponse<br/>(offline_keys.rs)"]:::major-edit
    
    Tests["Test functions x6<br/>(offline_keys.rs)"]:::major-edit
    MmRpcBuilder["MmRpcBuilder<br/>(mm_protocol.rs)"]:::context

    RPC --> GetKeys
    GetKeys --> HdInternal
    GetKeys --> IguanaInternal
    HdInternal --> ResponseEnum
    IguanaInternal --> ResponseEnum
    ResponseEnum --> MmRpcBuilder
    Tests --> HdInternal
    Tests --> IguanaInternal
    
    RemovedStructs -.->|"removed to fix<br/>nested result"| ResponseEnum

    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes
- All unit tests pass locally (`cargo test offline_keys` - 8/8 tests successful)
- Build completes successfully without compilation errors
- Changes maintain backward compatibility for the actual key data structure, only fixing the response wrapper
- This addresses the specific issue described in the task requirements

**Link to Devin run:** https://app.devin.ai/sessions/76419a4463834bc58d7f2d23da8ed7e9  
**Requested by:** @ca333