### PR TITLE
fix(evm): support EIP55 (mixed case) & uncompressed pubkey exports

### DIFF
--- a/mm2src/coins/rpc_command/offline_keys.rs
+++ b/mm2src/coins/rpc_command/offline_keys.rs
@@ -1,7 +1,7 @@
+use crate::eth::{addr_from_pubkey_str, checksum_address};
 use crate::tendermint;
 use crate::z_coin::{ZcoinConsensusParams, ZcoinProtocolInfo};
 use crate::CoinProtocol;
-use crate::eth::{addr_from_pubkey_str, checksum_address};
 use bitcoin_hashes::hex::ToHex;
 use bitcrypto::ChecksumType;
 use common::HttpStatusCode;
@@ -9,7 +9,7 @@ use crypto::privkey::{key_pair_from_secret, key_pair_from_seed};
 use crypto::{Bip32DerPathOps, CryptoCtx, HDPathToCoin, KeyPairPolicy, StandardHDPath};
 use derive_more::Display;
 use http::StatusCode;
-use keys::{AddressBuilder, AddressFormat, AddressPrefix, NetworkAddressPrefixes, Private};
+use keys::{AddressBuilder, AddressFormat, AddressPrefix, KeyPair, NetworkAddressPrefixes, Private};
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -217,6 +217,43 @@ fn coin_conf_with_protocol(ctx: &MmArc, ticker: &str, conf_override: Option<Json
     Ok((conf, protocol))
 }
 
+/// Gets the appropriate public key format for the given protocol.
+/// ETH protocols require uncompressed public keys, while others use compressed.
+fn get_pubkey_for_protocol(key_pair: &KeyPair, protocol: &CoinProtocol) -> Result<String, String> {
+    match protocol {
+        CoinProtocol::ETH { .. } | CoinProtocol::ERC20 { .. } | CoinProtocol::NFT { .. } => {
+            // For ETH protocols, we need uncompressed public keys (keep 04 prefix for internal processing)
+            let secp_pubkey = key_pair
+                .public()
+                .to_secp256k1_pubkey()
+                .map_err(|e| format!("Failed to convert to secp256k1 pubkey: {}", e))?;
+            let uncompressed = secp_pubkey.serialize_uncompressed();
+            // Keep full uncompressed format for internal compatibility
+            Ok(hex::encode(uncompressed))
+        },
+        _ => {
+            // For other protocols, use compressed public keys
+            Ok(key_pair.public().to_vec().to_hex().to_string())
+        },
+    }
+}
+
+/// Formats the public key for display based on protocol.
+/// ETH protocols get 0x prefix (without 04 prefix), others remain as-is.
+fn format_pubkey_for_display(pubkey: &str, protocol: &CoinProtocol) -> String {
+    match protocol {
+        CoinProtocol::ETH { .. } | CoinProtocol::ERC20 { .. } | CoinProtocol::NFT { .. } => {
+            // For ETH, strip the 04 prefix and add 0x prefix
+            if pubkey.starts_with("04") {
+                format!("0x{}", &pubkey[2..])
+            } else {
+                format!("0x{}", pubkey)
+            }
+        },
+        _ => pubkey.to_string(),
+    }
+}
+
 async fn offline_hd_keys_export_internal(
     ctx: MmArc,
     coins: Vec<String>,
@@ -293,7 +330,18 @@ async fn offline_hd_keys_export_internal(
                 })?
             };
 
-            let pubkey = key_pair.public().to_vec().to_hex().to_string();
+            let protocol: CoinProtocol = serde_json::from_value(coin_conf["protocol"].clone()).map_err(|e| {
+                OfflineKeysError::ProtocolParseError {
+                    ticker: ticker.to_string(),
+                    error: e.to_string(),
+                }
+            })?;
+
+            let pubkey =
+                get_pubkey_for_protocol(&key_pair, &protocol).map_err(|e| OfflineKeysError::KeyDerivationFailed {
+                    ticker: ticker.clone(),
+                    error: format!("Failed to get pubkey: {}", e),
+                })?;
 
             let (address, priv_key, viewing_key_from_derivation) = match &prefix_values {
                 Some(PrefixValues::Utxo {
@@ -333,14 +381,6 @@ async fn offline_hd_keys_export_internal(
                     (address.to_string(), private.to_string(), None)
                 },
                 None => {
-                    let protocol: CoinProtocol =
-                        serde_json::from_value(coin_conf["protocol"].clone()).map_err(|e| {
-                            OfflineKeysError::ProtocolParseError {
-                                ticker: ticker.to_string(),
-                                error: e.to_string(),
-                            }
-                        })?;
-
                     let address = match protocol {
                         CoinProtocol::ETH { .. } | CoinProtocol::ERC20 { .. } | CoinProtocol::NFT { .. } => {
                             let raw_address = addr_from_pubkey_str(&pubkey).map_err(OfflineKeysError::Internal)?;
@@ -425,7 +465,7 @@ async fn offline_hd_keys_export_internal(
 
             addresses.push(HdAddressInfo {
                 derivation_path,
-                pubkey,
+                pubkey: format_pubkey_for_display(&pubkey, &protocol),
                 address,
                 priv_key,
                 viewing_key: viewing_key_from_derivation,
@@ -467,7 +507,18 @@ async fn offline_iguana_keys_export_internal(
             }
         };
 
-        let pubkey = key_pair.public().to_vec().to_hex().to_string();
+        let protocol: CoinProtocol = serde_json::from_value(coin_conf["protocol"].clone()).map_err(|e| {
+            OfflineKeysError::ProtocolParseError {
+                ticker: ticker.to_string(),
+                error: e.to_string(),
+            }
+        })?;
+
+        let pubkey =
+            get_pubkey_for_protocol(&key_pair, &protocol).map_err(|e| OfflineKeysError::KeyDerivationFailed {
+                ticker: ticker.clone(),
+                error: format!("Failed to get pubkey: {}", e),
+            })?;
 
         let (address, priv_key) = match prefix_values {
             Some(PrefixValues::Utxo {
@@ -496,13 +547,6 @@ async fn offline_iguana_keys_export_internal(
                 (address.to_string(), private.to_string())
             },
             None => {
-                let protocol: CoinProtocol = serde_json::from_value(coin_conf["protocol"].clone()).map_err(|e| {
-                    OfflineKeysError::ProtocolParseError {
-                        ticker: ticker.to_string(),
-                        error: e.to_string(),
-                    }
-                })?;
-
                 let address = match protocol {
                     CoinProtocol::ETH { .. } | CoinProtocol::ERC20 { .. } | CoinProtocol::NFT { .. } => {
                         let raw_address = addr_from_pubkey_str(&pubkey).map_err(OfflineKeysError::Internal)?;
@@ -562,7 +606,7 @@ async fn offline_iguana_keys_export_internal(
 
         result.push(CoinKeyInfo {
             coin: ticker.clone(),
-            pubkey,
+            pubkey: format_pubkey_for_display(&pubkey, &protocol),
             address,
             priv_key,
         });
@@ -779,10 +823,10 @@ mod tests {
             "0x012F492f2d254e204dD8da3a4f0d6071C345b9D1",
             "0xa713617C963b82429909B09B9181a22884f1eb8f",
         ];
-        let _expected_pubkeys = [
-            "02a2b68c3126ba160e5ffb7c0d5c5c5c56e724f57e5ec0ace40d6db990e688ed4a",
-            "02d7efb9086100311021166c11b2dc7ca941ccbe242b51206555721efe93737678",
-            "03353b68f1b2c0891edf78395480bc67e128fb967c5722a6b41d784da295986d4d",
+        let expected_pubkeys = [
+            "0xa2b68c3126ba160e5ffb7c0d5c5c5c56e724f57e5ec0ace40d6db990e688ed4a98256f5b30ea495e91602b165c4e58372ec3f6032768de49925f8754bb0df7f8",
+            "0xd7efb9086100311021166c11b2dc7ca941ccbe242b51206555721efe93737678e02073766420f2bc3bdb313d648b780bd71cacfc1b9b66b8f2559c7231be9006",
+            "0x353b68f1b2c0891edf78395480bc67e128fb967c5722a6b41d784da295986d4d2d6cedd92e84beb57332b8f5e2e4c623c72d992f83c5baa9324e3e3410c8d1f9",
         ];
         let expected_privkeys = [
             "0x646431107ae37e826aaa5108fe2c2611ef15615e78b4175919b85fd6366f19a3",
@@ -801,15 +845,22 @@ mod tests {
 
                 for (i, addr_info) in eth_result.addresses.iter().enumerate() {
                     // Verify addresses are returned in EIP-55 checksum format
-                    assert_eq!(addr_info.address, expected_addresses[i], 
-                        "Address {} should be in EIP-55 checksum format", i);
-                    
+                    assert_eq!(
+                        addr_info.address, expected_addresses[i],
+                        "Address {} should be in EIP-55 checksum format",
+                        i
+                    );
+
                     // Verify that the address is valid checksum format
-                    assert_eq!(addr_info.address, checksum_address(&addr_info.address.to_lowercase()),
-                        "Address {} should match EIP-55 checksum of its lowercase version", i);
-                    
+                    assert_eq!(
+                        addr_info.address,
+                        checksum_address(&addr_info.address.to_lowercase()),
+                        "Address {} should match EIP-55 checksum of its lowercase version",
+                        i
+                    );
+
                     // Original assertions
-                    assert_eq!(addr_info.pubkey, _expected_pubkeys[i]);
+                    assert_eq!(addr_info.pubkey, expected_pubkeys[i]);
                     assert_eq!(addr_info.priv_key, expected_privkeys[i]);
                     assert_eq!(addr_info.derivation_path, format!("m/44'/60'/0/0/{}", i));
                 }
@@ -1075,7 +1126,7 @@ mod tests {
         assert!(expected_first_viewing_key.len() > 100);
     }
 
-    #[tokio::test]  
+    #[tokio::test]
     async fn test_eth_iguana_eip55_formatting() {
         use mm2_test_helpers::for_tests::eth_dev_conf;
 
@@ -1093,7 +1144,7 @@ mod tests {
             coins: vec!["ETH".to_string()],
             mode: Some(KeyExportMode::Iguana),
             start_index: None,
-            end_index: None,  
+            end_index: None,
             account_index: None,
         };
 
@@ -1109,25 +1160,37 @@ mod tests {
                 let address = &eth_result.address;
                 assert!(address.starts_with("0x"), "Address should start with 0x");
                 assert_eq!(address.len(), 42, "Address should be 42 characters long");
-                
+
                 // Verify that the address is properly checksummed
                 let lowercase_addr = address.to_lowercase();
                 let checksummed_addr = checksum_address(&lowercase_addr);
-                assert_eq!(address, &checksummed_addr, 
-                    "Address should be in proper EIP-55 checksum format");
-                
+                assert_eq!(
+                    address, &checksummed_addr,
+                    "Address should be in proper EIP-55 checksum format"
+                );
+
                 // Verify mixed case (some letters should be uppercase if properly checksummed)
                 let has_uppercase = address.chars().any(|c| c.is_uppercase() && c.is_alphabetic());
                 let has_lowercase = address.chars().any(|c| c.is_lowercase() && c.is_alphabetic());
-                
+
                 // For a proper checksum, we expect a mix of cases (unless it's an edge case)
                 if address.chars().any(|c| c.is_alphabetic()) {
-                    assert!(has_uppercase || has_lowercase, "Address should have mixed case for EIP-55");
+                    assert!(
+                        has_uppercase || has_lowercase,
+                        "Address should have mixed case for EIP-55"
+                    );
                 }
 
                 // Verify private key format
-                assert!(eth_result.priv_key.starts_with("0x"), "Private key should start with 0x");
-                assert_eq!(eth_result.priv_key.len(), 66, "Private key should be 66 characters long");
+                assert!(
+                    eth_result.priv_key.starts_with("0x"),
+                    "Private key should start with 0x"
+                );
+                assert_eq!(
+                    eth_result.priv_key.len(),
+                    66,
+                    "Private key should be 66 characters long"
+                );
             },
             _ => panic!("Expected Iguana response for ETH key derivation test"),
         }

--- a/mm2src/coins/rpc_command/offline_keys.rs
+++ b/mm2src/coins/rpc_command/offline_keys.rs
@@ -1,6 +1,7 @@
 use crate::tendermint;
 use crate::z_coin::{ZcoinConsensusParams, ZcoinProtocolInfo};
 use crate::CoinProtocol;
+use crate::eth::{addr_from_pubkey_str, checksum_address};
 use bitcoin_hashes::hex::ToHex;
 use bitcrypto::ChecksumType;
 use common::HttpStatusCode;
@@ -342,8 +343,8 @@ async fn offline_hd_keys_export_internal(
 
                     let address = match protocol {
                         CoinProtocol::ETH { .. } | CoinProtocol::ERC20 { .. } | CoinProtocol::NFT { .. } => {
-                            let raw_address = crate::eth::addr_from_pubkey_str(&pubkey).map_err(OfflineKeysError::Internal)?;
-                            crate::eth::checksum_address(&raw_address)
+                            let raw_address = addr_from_pubkey_str(&pubkey).map_err(OfflineKeysError::Internal)?;
+                            checksum_address(&raw_address)
                         },
                         _ => {
                             return MmError::err(OfflineKeysError::Internal(format!(
@@ -504,8 +505,8 @@ async fn offline_iguana_keys_export_internal(
 
                 let address = match protocol {
                     CoinProtocol::ETH { .. } | CoinProtocol::ERC20 { .. } | CoinProtocol::NFT { .. } => {
-                        let raw_address = crate::eth::addr_from_pubkey_str(&pubkey).map_err(OfflineKeysError::Internal)?;
-                        crate::eth::checksum_address(&raw_address)
+                        let raw_address = addr_from_pubkey_str(&pubkey).map_err(OfflineKeysError::Internal)?;
+                        checksum_address(&raw_address)
                     },
                     _ => {
                         return MmError::err(OfflineKeysError::Internal(format!(
@@ -804,7 +805,7 @@ mod tests {
                         "Address {} should be in EIP-55 checksum format", i);
                     
                     // Verify that the address is valid checksum format
-                    assert_eq!(addr_info.address, crate::eth::checksum_address(&addr_info.address.to_lowercase()),
+                    assert_eq!(addr_info.address, checksum_address(&addr_info.address.to_lowercase()),
                         "Address {} should match EIP-55 checksum of its lowercase version", i);
                     
                     // Original assertions
@@ -1111,7 +1112,7 @@ mod tests {
                 
                 // Verify that the address is properly checksummed
                 let lowercase_addr = address.to_lowercase();
-                let checksummed_addr = crate::eth::checksum_address(&lowercase_addr);
+                let checksummed_addr = checksum_address(&lowercase_addr);
                 assert_eq!(address, &checksummed_addr, 
                     "Address should be in proper EIP-55 checksum format");
                 

--- a/mm2src/coins/rpc_command/offline_keys.rs
+++ b/mm2src/coins/rpc_command/offline_keys.rs
@@ -233,7 +233,7 @@ fn get_pubkey_for_protocol(key_pair: &KeyPair, protocol: &CoinProtocol) -> Resul
         },
         _ => {
             // For other protocols, use compressed public keys
-            Ok(key_pair.public().to_vec().to_hex().to_string())
+            Ok(key_pair.public().to_vec().to_hex())
         },
     }
 }
@@ -244,8 +244,8 @@ fn format_pubkey_for_display(pubkey: &str, protocol: &CoinProtocol) -> String {
     match protocol {
         CoinProtocol::ETH { .. } | CoinProtocol::ERC20 { .. } | CoinProtocol::NFT { .. } => {
             // For ETH, strip the 04 prefix and add 0x prefix
-            if pubkey.starts_with("04") {
-                format!("0x{}", &pubkey[2..])
+            if let Some(stripped_pubkey) = pubkey.strip_prefix("04") {
+                format!("0x{}", stripped_pubkey)
             } else {
                 format!("0x{}", pubkey)
             }

--- a/mm2src/mm2_bin_lib/Cargo.toml
+++ b/mm2src/mm2_bin_lib/Cargo.toml
@@ -6,7 +6,7 @@
 [package]
 name = "mm2_bin_lib"
 version = "2.5.1-beta"
-authors = ["James Lee", "Artem Pikulin", "Artem Grinblat", "Omar S.", "Onur Ozkan", "Alina Sharon", "Caglar Kaya", "Cipi", "Sergey Boiko", "Samuel Onoja", "Roman Sztergbaum", "Kadan Stadelmann <ca333@komodoplatform.com>", "Dimxy", "Omer Yacine", "DeckerSU", "Devin (AI Contributor)"]
+authors = ["James Lee", "Artem Pikulin", "Artem Grinblat", "Omar S.", "Onur Ozkan", "Alina Sharon", "Caglar Kaya", "Cipi", "Sergey Boiko", "Samuel Onoja", "Roman Sztergbaum", "Kadan Stadelmann <ca333@komodoplatform.com>", "Dimxy", "Omer Yacine", "DeckerSU", "Devin AI"]
 edition = "2018"
 default-run = "kdf"
 


### PR DESCRIPTION
## EIP55 (Mixed case ETH addresses), and uncompressed pubkeys:

Before:
```json
                    {
                        "derivation_path": "m/44'/60'/0/0/1",
                        "pubkey": "03de36fe6b0b1eaea7447e4bb3a56c8755fd5cf5d3fd9885a0582c99777229052e",
                        "address": "0x49f4a1c47579d9603100fc50e227079794335f20",
                        "priv_key": "0xe6a0f10b28192d2823433ec7121633c5d85239799b50e1e93280d000ad6a1341"
                    }
```

After
```json

                {
                    "derivation_path": "m/44'/60'/0/0/1",
                    "pubkey": "0xde36fe6b0b1eaea7447e4bb3a56c8755fd5cf5d3fd9885a0582c99777229052e1b7019075669c5d65d4878b3db06e0b534159b0ba762714737677711b3375a3f",
                    "address": "0x49F4A1c47579d9603100Fc50e227079794335f20",
                    "priv_key": "0xe6a0f10b28192d2823433ec7121633c5d85239799b50e1e93280d000ad6a1341"
                }
```

`0x49f4a1c47579d9603100fc50e227079794335f20` -> 0x49**F**4**A**1c47579d9603100**F**c50e227079794335f20

Output was validated against web3.py using the script below:

```py
from eth_keys import keys
from eth_utils import keccak

priv = bytes.fromhex("e6a0f10b28192d2823433ec7121633c5d85239799b50e1e93280d000ad6a1341")
pk = keys.PrivateKey(priv)

print("Public Key:", pk.public_key.to_hex())
print("Address:", pk.public_key.to_checksum_address())

```
Note: the priv key's `0x` prefix needs to be dropped for web3.py

Output:
```bash
Public Key: 0xde36fe6b0b1eaea7447e4bb3a56c8755fd5cf5d3fd9885a0582c99777229052e1b7019075669c5d65d4878b3db06e0b534159b0ba762714737677711b3375a3f
Address: 0x49F4A1c47579d9603100Fc50e227079794335f20
```